### PR TITLE
Add OAuth redirect_uri support and dev Dockerfiles

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,45 @@
+################################################
+# Build stage — compile Convex + Covia from source
+FROM maven:3.9-eclipse-temurin-21 AS build
+
+WORKDIR /build
+
+# Copy Convex source and install to local repo
+COPY convex/ /build/convex/
+RUN cd /build/convex && mvn clean install -DskipTests -q
+
+# Copy Covia source
+COPY covia/ /build/covia/
+
+# Build Covia
+RUN cd /build/covia && mvn clean install -DskipTests -q
+
+################################################
+# Run stage
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache curl && rm -rf /var/cache/apk/*
+
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup
+
+COPY --from=build /build/covia/venue/target/covia.jar /app/covia.jar
+
+RUN chown -R appuser:appgroup /app
+
+USER appuser
+
+EXPOSE 8080
+
+ENV JAVA_OPTS="-XX:+UseContainerSupport \
+                -XX:MaxRAMPercentage=75.0 \
+                -XX:+UseG1GC \
+                -Djava.security.egd=file:/dev/./urandom \
+                -Dfile.encoding=UTF-8"
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8080/ || exit 1
+
+CMD ["sh", "-c", "java $JAVA_OPTS -jar covia.jar"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,38 @@
+# Multi-stage build: builds convex + covia from source, then runs venue
+# Usage: docker build -f Dockerfile.local -t covia-local ..
+
+################################################
+# Build stage — Java 21 + Maven
+FROM eclipse-temurin:21-jdk AS builder
+
+RUN apt-get update && apt-get install -y maven && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy both projects
+COPY convex/ /build/convex/
+COPY covia/ /build/covia/
+
+# Build convex with version 0.8.4-SNAPSHOT (covia expects this), then build covia
+RUN cd /build/convex \
+    && mvn versions:set -DnewVersion=0.8.4-SNAPSHOT -q \
+    && mvn clean install -DskipTests -q \
+    && cd /build/covia \
+    && mvn clean install -DskipTests -q
+
+################################################
+# Run stage
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache curl && rm -rf /var/cache/apk/*
+
+COPY --from=builder /build/covia/venue/target/covia.jar /app/covia.jar
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8080/ || exit 1
+
+CMD ["java", "-jar", "covia.jar"]

--- a/venue-config.json
+++ b/venue-config.json
@@ -1,0 +1,25 @@
+{
+  "venues": [
+    {
+      "name": "Local Dev Venue",
+      "hostname": "localhost",
+      "port": 8080,
+      "baseUrl": "http://localhost:8080",
+      "mcp": {},
+      "auth": {
+        "public": { "enabled": true },
+        "tokenExpiry": 86400,
+        "oauth": {
+          "google": {
+            "clientId": "YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com",
+            "clientSecret": "YOUR_GOOGLE_CLIENT_SECRET"
+          },
+          "github": {
+            "clientId": "YOUR_GITHUB_CLIENT_ID",
+            "clientSecret": "YOUR_GITHUB_CLIENT_SECRET"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/venue/src/main/java/covia/venue/auth/LoginProviders.java
+++ b/venue/src/main/java/covia/venue/auth/LoginProviders.java
@@ -8,6 +8,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -114,7 +115,17 @@ public class LoginProviders {
 			ctx.status(400).result("Unsupported or unconfigured provider: " + providerName);
 			return;
 		}
-		ctx.redirect(provider.getAuthUrl());
+
+		String redirectUri = ctx.queryParam("redirect_uri");
+		if (redirectUri != null) {
+			// Encode redirect_uri into OAuth state as base64 JSON
+			String stateJson = "{\"redirect_uri\":\"" + redirectUri.replace("\"", "\\\"") + "\"}";
+			String state = Base64.getUrlEncoder().withoutPadding()
+				.encodeToString(stateJson.getBytes(StandardCharsets.UTF_8));
+			ctx.redirect(provider.getAuthUrl(state));
+		} else {
+			ctx.redirect(provider.getAuthUrl());
+		}
 	}
 
 	@SuppressWarnings("unchecked")
@@ -130,6 +141,23 @@ public class LoginProviders {
 		if (code == null) {
 			ctx.status(400).result("Missing authorisation code");
 			return;
+		}
+
+		// Extract redirect_uri from OAuth state if present
+		String frontendRedirectUri = null;
+		String stateParam = ctx.queryParam("state");
+		if (stateParam != null) {
+			try {
+				String stateJson = new String(
+					Base64.getUrlDecoder().decode(stateParam), StandardCharsets.UTF_8);
+				@SuppressWarnings("unchecked")
+				Map<String, Object> stateMap = (Map<String, Object>) JSON.jvm(stateJson);
+				if (stateMap != null && stateMap.containsKey("redirect_uri")) {
+					frontendRedirectUri = stateMap.get("redirect_uri").toString();
+				}
+			} catch (Exception e) {
+				log.debug("Could not decode OAuth state parameter", e);
+			}
 		}
 
 		try {
@@ -199,12 +227,22 @@ public class LoginProviders {
 			AString venueJwt = JWT.signPublic(claims, engine.getKeyPair());
 
 			// 5. Return JWT to client
-			AMap<AString, ACell> response = Maps.of(
-				"token", venueJwt,
-				"did", userDID
-			);
-			ctx.header("Content-type", "application/json");
-			ctx.result(JSON.toString(response));
+			if (frontendRedirectUri != null) {
+				// Redirect back to frontend with token and DID as query params
+				String sep = frontendRedirectUri.contains("?") ? "&" : "?";
+				String redirectUrl = frontendRedirectUri + sep
+					+ "token=" + URLEncoder.encode(venueJwt.toString(), StandardCharsets.UTF_8)
+					+ "&did=" + URLEncoder.encode(userDID.toString(), StandardCharsets.UTF_8);
+				ctx.redirect(redirectUrl);
+			} else {
+				// Backward compatible: return JSON for API/CLI clients
+				AMap<AString, ACell> response = Maps.of(
+					"token", venueJwt,
+					"did", userDID
+				);
+				ctx.header("Content-type", "application/json");
+				ctx.result(JSON.toString(response));
+			}
 
 		} catch (Exception e) {
 			log.error("OAuth callback error for {}", providerName, e);

--- a/venue/src/main/java/covia/venue/auth/OAuthConfig.java
+++ b/venue/src/main/java/covia/venue/auth/OAuthConfig.java
@@ -72,11 +72,22 @@ public class OAuthConfig {
 	 * Construct the full authorisation redirect URL for this provider.
 	 */
 	public String getAuthUrl() {
-		return authUrl
+		return getAuthUrl(null);
+	}
+
+	/**
+	 * Construct the full authorisation redirect URL with an optional OAuth state parameter.
+	 */
+	public String getAuthUrl(String state) {
+		String url = authUrl
 			+ "?response_type=code"
 			+ "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
 			+ "&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8)
 			+ "&scope=" + URLEncoder.encode(scope, StandardCharsets.UTF_8)
 			+ "&access_type=offline";
+		if (state != null) {
+			url += "&state=" + URLEncoder.encode(state, StandardCharsets.UTF_8);
+		}
+		return url;
 	}
 }


### PR DESCRIPTION
## Summary
- Support frontend OAuth flows by passing `redirect_uri` through the OAuth state parameter (base64-encoded JSON)
- On callback, redirect back to the frontend with `token` and `did` as query params instead of returning JSON
- Backward compatible — API/CLI clients without `redirect_uri` still receive the JSON response
- Add `Dockerfile.dev`, `Dockerfile.local`, and `venue-config.json` for local development

## Test plan
- [ ] Test OAuth login flow from frontend with `redirect_uri` param — verify redirect with token/did
- [ ] Test OAuth login flow without `redirect_uri` — verify JSON response still works
- [ ] Test with invalid/malformed state parameter — verify graceful degradation
- [ ] Verify `Dockerfile.dev` and `Dockerfile.local` build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)