### PR TITLE
fix: Azure deploy config, disk size, and permissions

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -81,6 +81,24 @@ jobs:
           # Pull latest image
           docker pull ghcr.io/covia-ai/covia:latest
 
+          # Ensure config exists (venues array format)
+          mkdir -p /home/azureuser/covia-data
+          if [ ! -f /home/azureuser/covia-data/config.json ]; then
+            cat > /home/azureuser/covia-data/config.json <<'CONF'
+          {
+            "venues": [
+              {
+                "name": "Covia Venue (Azure)",
+                "hostname": "venue-4.covia.ai",
+                "store": "/data/venue.etch",
+                "mcp": {}
+              }
+            ]
+          }
+          CONF
+          fi
+          sudo chown -R 1001:1001 /home/azureuser/covia-data
+
           # Stop and remove existing container
           docker stop covia-venue 2>/dev/null || true
           docker rm covia-venue 2>/dev/null || true

--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -17,7 +17,7 @@ chmod +x deploy/azure/setup.sh
 ./deploy/azure/setup.sh
 ```
 
-This creates: Resource Group, VNet, NSG (ports 22/80/443), Static IP, VM (Standard_B2ps_v2 Arm64, Ubuntu 24.04), Docker, nginx, and Let's Encrypt TLS.
+This creates: Resource Group, VNet, NSG (ports 22/80/443), Static IP, VM (Standard_B2s_v2 x86, Ubuntu 24.04), Docker, nginx, and Let's Encrypt TLS.
 
 The script will pause before the nginx/TLS step and ask you to configure DNS first.
 
@@ -30,11 +30,19 @@ ssh azureuser@<public-ip>
 
 cat > ~/covia-data/config.json << 'EOF'
 {
-  "name": "Covia Venue (Azure)",
-  "hostname": "venue-4.covia.ai",
-  "store": "/data/venue.etch"
+  "venues": [
+    {
+      "name": "Covia Venue (Azure)",
+      "hostname": "venue-4.covia.ai",
+      "store": "/data/venue.etch",
+      "mcp": {}
+    }
+  ]
 }
 EOF
+
+# Fix permissions for container user (UID 1001)
+sudo chown -R 1001:1001 ~/covia-data
 ```
 
 ## GitHub Secrets Required


### PR DESCRIPTION
## Summary
- Use `venues` array format in config.json (matches `MainVenue` expectation)
- Auto-create config and fix `/data` ownership (UID 1001) on first deploy
- Fix OS disk size 20→30 GB (Ubuntu 24.04 minimum)
- Fix README: x86 not Arm64, add `chown` step

## Test plan
- [x] Verified venue running at `http://20.196.195.234` with corrected config
- [x] Container starts without permission errors after `chown` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)