### PR TITLE
fix: harden JVM opts and health check

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -96,8 +96,13 @@ jobs:
             --log-opt awslogs-stream=docker-covia-venue \
             --log-opt awslogs-create-group=true \
             --restart unless-stopped \
+            --health-cmd='curl -f --max-time 3 http://localhost:8080/' \
+            --health-interval=30s \
+            --health-timeout=5s \
+            --health-start-period=15s \
+            --health-retries=3 \
             ghcr.io/covia-ai/covia:latest \
-            java -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8 -jar covia.jar /data/config.json
+            java -Xmx2g -XX:+UseContainerSupport -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8 -jar covia.jar /data/config.json
 
           # Wait for health check
           sleep 10

--- a/deploy/ec2/docker-compose.yml
+++ b/deploy/ec2/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     volumes:
       - /home/ec2-user/covia-data:/data
     command: >
-      java -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0
-      -XX:+UseG1GC -XX:+UseStringDeduplication
+      java -Xmx2g -XX:+UseContainerSupport -XX:+UseG1GC
+      -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError
       -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8
       -jar covia.jar /data/config.json
     restart: unless-stopped
@@ -20,8 +20,8 @@ services:
         awslogs-stream: docker-covia-venue
         awslogs-create-group: "true"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
+      test: ["CMD", "curl", "-f", "--max-time", "3", "http://localhost:8080/"]
       interval: 30s
-      timeout: 3s
-      start_period: 5s
+      timeout: 5s
+      start_period: 15s
       retries: 3


### PR DESCRIPTION
## Summary
- Replace `-XX:MaxRAMPercentage=75.0` with fixed `-Xmx2g` heap to prevent GC death spirals
- Add `-XX:+ExitOnOutOfMemoryError` so JVM crashes cleanly instead of thrashing
- Add `--max-time 3` to health check curl to prevent zombie process accumulation
- Increase health check `start_period` to 15s and `timeout` to 5s

## Context
The EC2 venue server became unresponsive due to a GC death spiral — the JVM hit 82% memory (3.06/3.75 GB), spent 30+ hours at 195% CPU in GC, and accumulated ~1700 zombie curl health check processes. These changes prevent recurrence.

## Test plan
- [x] Applied directly on EC2 instance and verified healthy operation
- [x] `https://venue-3.covia.ai/api/v1/status` returns 200 OK
- [x] Container health check passes with new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)