### PR TITLE
fix: harden Azure deploy JVM opts and health check

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -109,8 +109,13 @@ jobs:
             -p 8080:8080 \
             -v /home/azureuser/covia-data:/data \
             --restart unless-stopped \
+            --health-cmd='curl -f --max-time 3 http://localhost:8080/' \
+            --health-interval=30s \
+            --health-timeout=5s \
+            --health-start-period=15s \
+            --health-retries=3 \
             ghcr.io/covia-ai/covia:latest \
-            java -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC -XX:+UseStringDeduplication -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8 -jar covia.jar /data/config.json
+            java -Xmx2g -XX:+UseContainerSupport -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8 -jar covia.jar /data/config.json
 
           # Wait for health check
           sleep 10

--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -72,9 +72,15 @@ docker run -d \
   -p 8080:8080 \
   -v /home/azureuser/covia-data:/data \
   --restart unless-stopped \
+  --health-cmd='curl -f --max-time 3 http://localhost:8080/' \
+  --health-interval=30s \
+  --health-timeout=5s \
+  --health-start-period=15s \
+  --health-retries=3 \
   ghcr.io/covia-ai/covia:latest \
-  java -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC \
-  -XX:+UseStringDeduplication -Djava.security.egd=file:/dev/./urandom \
+  java -Xmx2g -XX:+UseContainerSupport -XX:+UseG1GC \
+  -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError \
+  -Djava.security.egd=file:/dev/./urandom \
   -Dfile.encoding=UTF-8 -jar covia.jar /data/config.json
 ```
 


### PR DESCRIPTION
## Summary
- Same hardening as #107 (EC2), applied to Azure deploy workflow and docs
- Replace `-XX:MaxRAMPercentage=75.0` with `-Xmx2g` and add `-XX:+ExitOnOutOfMemoryError`
- Add `--max-time 3` to health check curl, increase `start_period` to 15s

## Context
Azure venue-4 experienced the same GC death spiral as EC2 (Jun 3-4), which also corrupted the Etch store file. These changes prevent recurrence.

## Test plan
- [x] Applied directly on Azure VM and verified healthy operation
- [x] `https://venue-4.covia.ai/api/v1/status` returns 200 OK
- [x] Container healthy with new flags, 142 MiB memory (1.8%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)