### PR TITLE
Configurable bind address for the venue HTTP connector (#129)

### DIFF
--- a/venue/CLAUDE.md
+++ b/venue/CLAUDE.md
@@ -303,6 +303,18 @@ Venue state (lattice, agents, secrets, DLFS) is persisted via Etch store:
 - `store`: `"temp"` (default, deleted on exit), `"memory"`, or file path
 - `seed`: Ed25519 hex seed for stable venue identity. If omitted with a persistent store, auto-generated and saved to `venue.key` alongside the store file.
 
+### Network binding
+
+```json
+{
+  "port": 8080,
+  "bindAddress": "127.0.0.1"
+}
+```
+
+- `port`: HTTP listen port (default `8080`).
+- `bindAddress`: network interface the HTTP connector binds to. When omitted, the venue binds **all interfaces** (`0.0.0.0`) — reachable from the LAN. Set to `"127.0.0.1"` to restrict the venue to loopback (recommended when embedding the venue as a local subprocess). This is the socket bind address and is distinct from `hostname`, which is the venue's *advertised* public host used to derive `baseUrl`/DID.
+
 ### DLFS WebDAV
 
 ```json

--- a/venue/src/main/java/covia/venue/Config.java
+++ b/venue/src/main/java/covia/venue/Config.java
@@ -59,6 +59,14 @@ public class Config {
 	/** Key for venue port */
 	public static final AString PORT = Strings.intern("port");
 
+	/**
+	 * Key for the HTTP connector's bind address (network interface to listen
+	 * on). Distinct from {@link #HOSTNAME}, which is the venue's advertised
+	 * public host. When unset the connector binds all interfaces (0.0.0.0);
+	 * set to {@code "127.0.0.1"} to restrict to loopback.
+	 */
+	public static final AString BIND_ADDRESS = Strings.intern("bindAddress");
+
 	/** Key for the HTTP connector's accept-queue (backlog) size */
 	public static final AString ACCEPT_QUEUE_SIZE = Strings.intern("acceptQueueSize");
 
@@ -239,6 +247,22 @@ public class Config {
 	public String getHostname() {
 		AString hostname = RT.ensureString(config.get(HOSTNAME));
 		return (hostname != null) ? hostname.toString() : "localhost";
+	}
+
+	/**
+	 * Get the configured bind address (network interface the HTTP connector
+	 * listens on).
+	 *
+	 * <p>Unlike {@link #getHostname()} this is a socket bind address, not the
+	 * advertised public host. When unset, returns {@code null} and the
+	 * connector binds all interfaces (0.0.0.0) — preserving the historical
+	 * default. Set to {@code "127.0.0.1"} to restrict the venue to loopback.</p>
+	 *
+	 * @return bind address string, or {@code null} to bind all interfaces
+	 */
+	public String getBindAddress() {
+		AString bindAddress = RT.ensureString(config.get(BIND_ADDRESS));
+		return (bindAddress != null) ? bindAddress.toString() : null;
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/server/VenueServer.java
+++ b/venue/src/main/java/covia/venue/server/VenueServer.java
@@ -350,10 +350,16 @@ public class VenueServer {
 		if (port==null) port=8080;
 		ServerConnector connector = new ServerConnector(jettyServer);
 		connector.setPort(port);
+		// Restrict the listening interface when a bind address is configured.
+		// When unset, Jetty binds the wildcard address (0.0.0.0 / all
+		// interfaces) — the historical default.
+		String bindAddress = config.getBindAddress();
+		if (bindAddress != null) connector.setHost(bindAddress);
 		// Deeper accept queue than the JDK/Jetty default (50) so bursts of
 		// concurrent connections queue rather than being refused under load.
 		connector.setAcceptQueueSize(config.getAcceptQueueSize());
 		jettyServer.addConnector(connector);
+		log.info("Venue HTTP connector bound to {}:{}", (bindAddress != null) ? bindAddress : "0.0.0.0", port);
 	}
 
 	private Javalin buildApp() {

--- a/venue/src/test/java/covia/venue/VenueServerTest.java
+++ b/venue/src/test/java/covia/venue/VenueServerTest.java
@@ -378,6 +378,19 @@ public class VenueServerTest {
 	}
 
 	@Test
+	public void testBindAddressConfig() {
+		// Unset bindAddress → null, so the connector binds all interfaces
+		// (0.0.0.0). Preserves the historical default (issue #129).
+		assertNull(new Config(Maps.empty()).getBindAddress(),
+			"bindAddress should default to null (wildcard bind)");
+
+		// Explicit bindAddress is returned verbatim for connector.setHost(...)
+		Config loopback = new Config(Maps.of(Config.BIND_ADDRESS, Strings.create("127.0.0.1")));
+		assertEquals("127.0.0.1", loopback.getBindAddress(),
+			"Configured bindAddress should be returned for the connector");
+	}
+
+	@Test
 	public void testAnonymousInvokeGetsPublicDID() throws Exception {
 		// Invoke via HTTP client without auth — should get public DID as caller
 		ACell input = Maps.of("message", "anonymous test");


### PR DESCRIPTION
## Summary

The Jetty `ServerConnector` was constructed with a port but no host, so the venue always bound **all interfaces** (`0.0.0.0`) and was reachable from the LAN with no way to restrict it (#129).

This adds a `bindAddress` venue config key, plumbed through to `connector.setHost(...)`.

- **Unset → binds `0.0.0.0`** (all interfaces) — preserves current behaviour, zero migration impact.
- **`bindAddress: "127.0.0.1"`** restricts the venue to loopback — what embedders (e.g. the GetMine desktop app, which spawns the venue as a local subprocess) want.

`bindAddress` is the *socket bind address* and is intentionally distinct from the existing `hostname` key, which is the venue's *advertised public host* (used to derive `baseUrl`/DID). The resolved bind address is now logged at startup.

## Changes

- `Config.java` — `BIND_ADDRESS` key + `getBindAddress()` (returns `null` when unset → wildcard).
- `VenueServer.setupJettyServer` — `if (bindAddress != null) connector.setHost(bindAddress)`, plus a startup log line.
- `VenueServerTest.testBindAddressConfig` — asserts the unset (null/wildcard) and configured cases.
- `venue/CLAUDE.md` — new **Network binding** config subsection.

## Default-value decision

Defaulting to `0.0.0.0` (preserve current) rather than loopback, per maintainer call — no behaviour change for existing deployments. Embedders opt into loopback explicitly. The GCP fleet behind Caddy is unaffected either way (Caddy dials `:8080` over same-host loopback).

## Follow-up

Unblocks app-side adoption tracked at GetMine-ai/demo#138.

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)