### PR TITLE
Strict-allowlist agent tools by default: invert defaultTools (#92)

### DIFF
--- a/venue/docs/AGENT_TEMPLATES.md
+++ b/venue/docs/AGENT_TEMPLATES.md
@@ -78,7 +78,7 @@ A template is any CVM map. The following fields are recognised:
 | `caps` | array | Capability restrictions (array of {with, can} objects) |
 | `context` | array | Context loading entries (asset hashes, workspace paths) |
 | `responseFormat` | object | Structured output schema ({name, schema}) |
-| `defaultTools` | boolean | Whether to include platform default tools (default: true) |
+| `defaultTools` | boolean | Whether to include the platform default tool pack on top of `tools` (default: false — strict allowlist) |
 | `state` | any | Initial state for the agent (optional) |
 
 All fields are optional. Missing fields get platform defaults.
@@ -260,7 +260,7 @@ Template JSON files live in `venue/src/main/resources/agent-templates/`.
 
 ### Default template (Phase 3b — not yet implemented)
 
-Currently when `agent:create` is called with no config, the hardcoded `DEFAULT_TOOL_OPS` list in `LLMAgentAdapter` (19 tools) is merged in. A future change should replace this with the `worker` template as the default, giving a smaller, more focused default tool set and resolving issue #60. This is a breaking change for existing agents that rely on default tools like `agent:create` or `asset:store`, so needs explicit review before rollout.
+As of #92, agents are strict-allowlist by default: an agent is advertised only the tools it declares in `config.tools`, and opts into the `DEFAULT_TOOL_OPS` pack with `defaultTools: true`. An agent created with no config and no `defaultTools` therefore has no tools. A future change may go further and make a focused template (e.g. `worker`) the default starting point for `agent:create` with no config, resolving issue #60.
 
 ---
 

--- a/venue/docs/OPERATIONS.md
+++ b/venue/docs/OPERATIONS.md
@@ -388,7 +388,7 @@ All examples use the same primitives, parameterised by path. Pagination, federat
 
 ### From an agent's perspective
 
-Agents have `covia_list`, `covia_read`, `covia_slice`, `covia_inspect` in their default toolset. **No discovery-specific tools needed.** The agent system prompt includes a one-line hint:
+Agents that declare these tools (or opt into the default pack with `defaultTools: true`) have `covia_list`, `covia_read`, `covia_slice`, `covia_inspect` available for discovery — **no discovery-specific tools needed.** When granted, the agent system prompt includes a one-line hint:
 
 > Operations live in `/v/ops/` (venue defaults) and your own `/o/` (your pins). Adapter info lives in `/v/info/adapters/`. Use `covia:list` to discover, `covia:read` to read details.
 

--- a/venue/src/main/java/covia/adapter/agent/ContextBuilder.java
+++ b/venue/src/main/java/covia/adapter/agent/ContextBuilder.java
@@ -617,7 +617,11 @@ public class ContextBuilder {
 	}
 
 	/**
-	 * Builds tool list from config (defaults + config tools) and extracts caps.
+	 * Builds tool list from config and extracts caps.
+	 *
+	 * <p>By default the agent is advertised only the tools it declares in its
+	 * {@code tools} array (strict allowlist). Setting {@code defaultTools: true}
+	 * in the config opts into the additional {@link #DEFAULT_TOOL_OPS} pack.</p>
 	 *
 	 * <p>The default-tool resolution is cached per Engine via
 	 * {@link #DEFAULT_TOOL_CACHE}: the first call per engine builds the 18
@@ -627,7 +631,12 @@ public class ContextBuilder {
 	 */
 	@SuppressWarnings("unchecked")
 	public ContextBuilder withTools() {
-		boolean useDefaults = config == null || !CVMBool.FALSE.equals(config.get(K_DEFAULT_TOOLS));
+		// Strict allowlist by default (#92): an agent is advertised exactly the
+		// tools it declares, unless it explicitly opts into the default pack
+		// with defaultTools: true. This is fail-safe — a newly-authored agent
+		// does not silently receive 18 extra ops (incl. covia/inspect,
+		// covia/delete, agent/create) it never declared.
+		boolean useDefaults = config != null && CVMBool.TRUE.equals(config.get(K_DEFAULT_TOOLS));
 		configToolMap = new HashMap<>();
 
 		AVector<ACell> baseTools = Vectors.empty();

--- a/venue/src/main/resources/adapters/agent/create.json
+++ b/venue/src/main/resources/adapters/agent/create.json
@@ -16,7 +16,8 @@
 							"properties": {
 								"operation": { "type": "string", "description": "Transition operation for the agent — must be a resolvable lattice path (e.g. 'v/ops/llmagent/chat' for persona chat, 'v/ops/goaltree/chat' for goal-decomposing planners). Bare adapter shorthand like 'llmagent:chat' will NOT resolve. Determines how the agent processes tasks." },
 								"systemPrompt": { "type": "string", "description": "System prompt defining the agent's role and behaviour" },
-								"tools": { "type": "array", "description": "Tool operations the agent can call (e.g. ['covia:read', 'covia:write']). Default tools are included automatically." },
+								"tools": { "type": "array", "description": "Tool operations the agent can call (e.g. ['covia:read', 'covia:write']). This is the agent's exact allowlist — it is advertised only these tools unless defaultTools is true." },
+								"defaultTools": { "type": "boolean", "description": "Opt into the built-in default tool pack (covia read/write/list/etc., asset, grid, schema ops) on top of the declared tools. Defaults to false: the agent sees only its own 'tools' list. Set true for exploratory agents that want the full toolkit without enumerating it." },
 								"model": { "type": "string", "description": "LLM model name (default: gpt-5.4-mini)" },
 								"caps": { "type": "array", "description": "Capability restrictions — array of {with, can} objects limiting what the agent can access" }
 							},

--- a/venue/src/test/java/covia/adapter/AgentWorkspaceTest.java
+++ b/venue/src/test/java/covia/adapter/AgentWorkspaceTest.java
@@ -11,6 +11,7 @@ import convex.core.data.AVector;
 import convex.core.data.Blob;
 import convex.core.data.Maps;
 import convex.core.data.Strings;
+import convex.core.data.Vectors;
 import convex.core.data.prim.CVMBool;
 import convex.core.lang.RT;
 import covia.api.Fields;
@@ -47,12 +48,19 @@ public class AgentWorkspaceTest {
 
 	@Test
 	public void testAgentWorkspaceAcrossRuns() {
-		// Create an LLM agent that uses workspace tools
+		// Create an LLM agent that uses workspace tools. Tools are strict
+		// allowlist (#92): declare exactly the workspace ops the workspacellm
+		// test op calls (covia_write / covia_append / covia_read) so the
+		// tool-name → operation-path mapping resolves.
 		engine.jobs().invokeOperation("v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "workspace-agent",
 				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/ops/llmagent/chat"),
 				AgentState.KEY_STATE, Maps.of("config", Maps.of(
-					"llmOperation", "v/test/ops/workspacellm"))),
+					"llmOperation", "v/test/ops/workspacellm",
+					"tools", Vectors.of(
+						Strings.create("v/ops/covia/write"),
+						Strings.create("v/ops/covia/append"),
+						Strings.create("v/ops/covia/read"))))),
 			ALICE).awaitResult(5000);
 
 		// Run 1: agent writes knowledge, appends to log, reads back

--- a/venue/src/test/java/covia/adapter/agent/ContextBuilderTest.java
+++ b/venue/src/test/java/covia/adapter/agent/ContextBuilderTest.java
@@ -354,14 +354,16 @@ public class ContextBuilderTest {
 	@Test
 	public void testDefaultToolsCached() {
 		// Default tools resolve to the SAME vector across calls — the
-		// per-engine cache returns the cached AVector instance.
+		// per-engine cache returns the cached AVector instance. Default tools
+		// are opt-in (#92), so the config must request them.
+		AMap<AString, ACell> config = Maps.of(Strings.intern("defaultTools"), CVMBool.TRUE);
 		ContextBuilder.ContextResult r1 = new ContextBuilder(engine, ctx)
-			.withConfig(null, null)
+			.withConfig(config, null)
 			.withSystemPrompt()
 			.withTools()
 			.build();
 		ContextBuilder.ContextResult r2 = new ContextBuilder(engine, ctx)
-			.withConfig(null, null)
+			.withConfig(config, null)
 			.withSystemPrompt()
 			.withTools()
 			.build();
@@ -379,8 +381,10 @@ public class ContextBuilderTest {
 
 	@Test
 	public void testDefaultToolsBuilt() {
+		// Default tools are opt-in (#92) — request them via config.
+		AMap<AString, ACell> config = Maps.of(Strings.intern("defaultTools"), CVMBool.TRUE);
 		ContextBuilder.ContextResult result = new ContextBuilder(engine, ctx)
-			.withConfig(null, null)
+			.withConfig(config, null)
 			.withSystemPrompt()
 			.withTools()
 			.build();
@@ -526,8 +530,10 @@ public class ContextBuilderTest {
 	public void testToolDescriptionContainsCatalogPath() {
 		// The LLM-visible description should be prefixed with "Operation: <path>"
 		// so the model sees the lattice address co-located with the tool name.
+		// covia_read lives in the default pack, which is opt-in (#92).
+		AMap<AString, ACell> config = Maps.of(Strings.intern("defaultTools"), CVMBool.TRUE);
 		ContextBuilder.ContextResult result = new ContextBuilder(engine, ctx)
-			.withConfig(null, null)
+			.withConfig(config, null)
 			.withSystemPrompt()
 			.withTools()
 			.build();
@@ -631,8 +637,11 @@ public class ContextBuilderTest {
 	public void testFullBuildShape() {
 		AVector<ACell> inbox = Vectors.of((ACell) Strings.create("Do something"));
 
+		// defaultTools: true so the build carries the default pack (#92) and the
+		// "tools present" assertion below remains meaningful.
+		AMap<AString, ACell> config = Maps.of(Strings.intern("defaultTools"), CVMBool.TRUE);
 		ContextBuilder.ContextResult result = new ContextBuilder(engine, ctx)
-			.withConfig(null, null)
+			.withConfig(config, null)
 			.withSystemPrompt()
 			.withContextEntries(Maps.empty())
 			.withPendingResults(null)


### PR DESCRIPTION
## Summary

`ContextBuilder.withTools()` silently appended the 18-op `DEFAULT_TOOL_OPS` pack — including `covia/inspect`, `covia/delete`, `agent/create` — to **every** agent unless its config set `defaultTools: false`. Strict allowlist was opt-in. This inverts it: **agents are advertised exactly the tools they declare, and opt into the default pack with `defaultTools: true`.** (#92)

This is fail-safe: a newly-authored agent no longer silently receives ops it never declared — the footgun that let a scoped health-data agent reach `covia_inspect` on the lattice root and expose internal venue namespaces to end users.

## Why it's safe

- **Capability enforcement is unaffected.** `caps` come only from the config's explicit `:caps` field (`ContextBuilder` L689), never from the default pack. This change only alters which tool **schemas** are advertised to the LLM.
- **No existing agent changes behaviour.** Every shipped agent config already sets `defaultTools` explicitly — the seven agent templates (six `false`, `full` `true`) and the ap-demo agents (all `false`). Nothing relied on the implicit default.

## Changes

- `ContextBuilder.java` — flip the default (`config != null && TRUE.equals(...)`) + javadoc.
- `agent/create.json` — document `defaultTools` as opt-in; fix the stale "default tools included automatically" note on `tools`.
- `AGENT_TEMPLATES.md` / `OPERATIONS.md` — correct the documented default.
- `ContextBuilderTest` — 4 tests that built with a `null` config now request `defaultTools: true` to still exercise the default-pack machinery.
- `AgentWorkspaceTest` — the `workspacellm` agent now declares the workspace tools it calls (`covia_write/append/read`), since the tool-name → operation-path mapping is no longer supplied by the implicit pack.

## Testing

Full `venue` test suite green locally (incl. ContextBuilder, LLMAgent, GoalTree, AgentAdapter, AgentWorkspace, Covia suites).

## Migration note

Breaking for any **out-of-tree** agent that relied on the implicit 18-pack without declaring tools: add `defaultTools: true` (same effect as before) or enumerate the tools it actually uses. In-tree configs need no change.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)