### PR TITLE
Fix #91: agent run loop executes under the agent owner's identity

### DIFF
--- a/venue/src/main/java/covia/adapter/AgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/AgentAdapter.java
@@ -86,11 +86,11 @@ public class AgentAdapter extends AAdapter {
 	 * atomic "install if absent or done" primitive that serialises launch
 	 * without any lock.
 	 */
-	private final ConcurrentHashMap<AString, CompletableFuture<ACell>> runningLoops
+	private final ConcurrentHashMap<AgentKey, CompletableFuture<ACell>> runningLoops
 		= new ConcurrentHashMap<>();
 
 	/** Active transition job per agent — allows suspend to cancel running transitions */
-	private final ConcurrentHashMap<AString, CompletableFuture<ACell>> activeTransitions = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<AgentKey, CompletableFuture<ACell>> activeTransitions = new ConcurrentHashMap<>();
 
 	/**
 	 * Per-agent deferred task completions written by {@code agent:complete-task}
@@ -99,7 +99,7 @@ public class AgentAdapter extends AAdapter {
 	 * the caller's {@code awaitResult} only returns once the cycle is fully
 	 * persisted. Inner key is the task (== caller Job) ID.
 	 */
-	private final ConcurrentHashMap<AString, ConcurrentHashMap<Blob, AMap<AString, ACell>>> deferredCompletions
+	private final ConcurrentHashMap<AgentKey, ConcurrentHashMap<Blob, AMap<AString, ACell>>> deferredCompletions
 		= new ConcurrentHashMap<>();
 
 	/**
@@ -113,15 +113,24 @@ public class AgentAdapter extends AAdapter {
 	 * act as the truth — no separate CAS required, and a cancelled caller
 	 * Job naturally frees the slot.
 	 */
-	private final ConcurrentHashMap<AString, ConcurrentHashMap<Blob, Job>> activeChats = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<AgentKey, ConcurrentHashMap<Blob, Job>> activeChats = new ConcurrentHashMap<>();
+
+	/**
+	 * Identity of an agent on this venue: its owner's DID plus the local agent
+	 * id. The in-memory run-loop registries above key on this — never the bare
+	 * {@code agentId} — because agents are per-user (stored at
+	 * {@code <ownerDID>/g/<id>}), so two users' agents that share a name must
+	 * not collide on a single venue (see {@code AgentAdapterTest.testUserIsolation}).
+	 */
+	private record AgentKey(AString owner, AString id) {}
 
 	/**
 	 * Test-only: injects a chat reservation so a follow-up {@code agent:chat}
 	 * on the same session hits the busy-slot path deterministically without
 	 * needing a real long-running transition to hold the slot.
 	 */
-	public void reserveChatSlotForTest(AString agentId, Blob sid, Job job) {
-		activeChats.computeIfAbsent(agentId, k -> new ConcurrentHashMap<>())
+	public void reserveChatSlotForTest(AString ownerDID, AString agentId, Blob sid, Job job) {
+		activeChats.computeIfAbsent(new AgentKey(ownerDID, agentId), k -> new ConcurrentHashMap<>())
 			.put(sid, job);
 	}
 
@@ -131,8 +140,8 @@ public class AgentAdapter extends AAdapter {
 	 * is held. Returns null if the previous holder's Job has since finished
 	 * — matches the semantics used by the run loop.
 	 */
-	public Job getActiveChatForTest(AString agentId, Blob sid) {
-		ConcurrentHashMap<Blob, Job> agentChats = activeChats.get(agentId);
+	public Job getActiveChatForTest(AString ownerDID, AString agentId, Blob sid) {
+		ConcurrentHashMap<Blob, Job> agentChats = activeChats.get(new AgentKey(ownerDID, agentId));
 		if (agentChats == null) return null;
 		Job j = agentChats.get(sid);
 		return (j != null && !j.isFinished()) ? j : null;
@@ -293,7 +302,7 @@ public class AgentAdapter extends AAdapter {
 	private ACell doKick(RequestContext ctx, ACell input) {
 		AString agentId = RT.ensureString(RT.getIn(input, Fields.AGENT_ID));
 		if (agentId == null) throw new IllegalArgumentException("agentId is required");
-		wakeAgent(agentId, ctx, parseForce(input));
+		wakeAgent(ctx.getCallerDID(), agentId, parseForce(input));
 		AgentState agent = getAgent(ctx.getCallerDID(), agentId);
 		AString status = (agent != null) ? agent.getStatus() : null;
 		return Maps.of(
@@ -584,7 +593,7 @@ public class AgentAdapter extends AAdapter {
 
 		// Wake agent to process the task — force=true because we just added a task
 		// that may not yet be visible via cursor.get() (lattice write race)
-		wakeAgent(agentId, ctx, true);
+		wakeAgent(ctx.getCallerDID(), agentId, true);
 	}
 
 	private void handleMessage(Job job, ACell input, RequestContext ctx) {
@@ -604,7 +613,7 @@ public class AgentAdapter extends AAdapter {
 			Fields.SESSION_ID, Strings.create(sid.toHexString()),
 			Fields.MESSAGE,    messageContent);
 		agent.appendSessionPending(sid, envelope);
-		wakeAgent(agentId, ctx);
+		wakeAgent(ctx.getCallerDID(), agentId);
 
 		job.setStatus(Status.STARTED);
 		job.completeWith(Maps.of(
@@ -658,7 +667,7 @@ public class AgentAdapter extends AAdapter {
 		// slot. Register a cancel hook so the caller cancelling their own
 		// Job immediately frees the slot for a retry.
 		ConcurrentHashMap<Blob, Job> agentChats = activeChats
-			.computeIfAbsent(agentId, k -> new ConcurrentHashMap<>());
+			.computeIfAbsent(new AgentKey(ctx.getCallerDID(), agentId), k -> new ConcurrentHashMap<>());
 		Job existing = agentChats.get(sid);
 		if (existing != null && !existing.isFinished()) {
 			job.fail("Session " + sidHex + " already has an in-flight chat");
@@ -682,7 +691,7 @@ public class AgentAdapter extends AAdapter {
 
 		// Force the wake — we just reserved a slot and added a message,
 		// either of which may not yet be visible via cursor.get().
-		wakeAgent(agentId, ctx, true);
+		wakeAgent(ctx.getCallerDID(), agentId, true);
 	}
 
 	/**
@@ -726,7 +735,7 @@ public class AgentAdapter extends AAdapter {
 		AString sidHex = (sid != null) ? Strings.create(sid.toHexString()) : null;
 
 		boolean force = parseForce(input);
-		CompletableFuture<ACell> completion = wakeAgent(agentId, ctx, force);
+		CompletableFuture<ACell> completion = wakeAgent(ctx.getCallerDID(), agentId, force);
 		if (completion == null) {
 			// force=true (the default) keeps the historical "must start" contract.
 			if (force) { job.fail("Cannot start agent: " + agentId); return; }
@@ -937,7 +946,7 @@ public class AgentAdapter extends AAdapter {
 		agent.setStatus(AgentState.SUSPENDED);
 
 		// Cancel any active transition so the agent stops promptly
-		CompletableFuture<ACell> activeTransition = activeTransitions.get(agentId);
+		CompletableFuture<ACell> activeTransition = activeTransitions.get(new AgentKey(ctx.getCallerDID(), agentId));
 		if (activeTransition != null) activeTransition.cancel(true);
 
 		job.setStatus(Status.STARTED);
@@ -961,7 +970,7 @@ public class AgentAdapter extends AAdapter {
 			return;
 		}
 
-		if (autoWake) wakeAgent(agentId, ctx, false);
+		if (autoWake) wakeAgent(ctx.getCallerDID(), agentId, false);
 
 		job.setStatus(Status.STARTED);
 		job.completeWith(Maps.of(Fields.AGENT_ID, agentId, Fields.STATUS, AgentState.SLEEPING));
@@ -1059,7 +1068,7 @@ public class AgentAdapter extends AAdapter {
 		}
 
 		ACell result = RT.getIn(input, Fields.RESULT);
-		parkCompletion(agentId, tasks, taskId, Status.COMPLETE, Fields.OUTPUT, result);
+		parkCompletion(ctx.getCallerDID(), agentId, tasks, taskId, Status.COMPLETE, Fields.OUTPUT, result);
 		agent.removeTask(taskId);
 
 		return Maps.of(
@@ -1099,7 +1108,7 @@ public class AgentAdapter extends AAdapter {
 
 		ACell errorCell = RT.getIn(input, Fields.ERROR);
 		AString errorStr = (errorCell == null) ? Strings.create("Task failed") : Strings.create(errorCell.toString());
-		parkCompletion(agentId, tasks, taskId, Status.FAILED, Fields.ERROR, errorStr);
+		parkCompletion(ctx.getCallerDID(), agentId, tasks, taskId, Status.FAILED, Fields.ERROR, errorStr);
 		agent.removeTask(taskId);
 
 		return Maps.of(
@@ -1115,7 +1124,7 @@ public class AgentAdapter extends AAdapter {
 	 * timeline / state writes are visible. Shared by
 	 * {@link #handleCompleteTask} and {@link #handleFailTask}.
 	 */
-	private void parkCompletion(AString agentId, Index<Blob, ACell> tasks, Blob taskId,
+	private void parkCompletion(AString ownerDID, AString agentId, Index<Blob, ACell> tasks, Blob taskId,
 			AString status, AString valueField, ACell value) {
 		AMap<AString, ACell> envelope = Maps.of(
 			Fields.ID,     taskId,
@@ -1124,7 +1133,7 @@ public class AgentAdapter extends AAdapter {
 		ACell sid = extractTaskSessionId(tasks, taskId);
 		if (sid != null) envelope = envelope.assoc(Fields.SESSION_ID, sid);
 		deferredCompletions
-			.computeIfAbsent(agentId, k -> new ConcurrentHashMap<>())
+			.computeIfAbsent(new AgentKey(ownerDID, agentId), k -> new ConcurrentHashMap<>())
 			.put(taskId, envelope);
 	}
 
@@ -1256,7 +1265,7 @@ public class AgentAdapter extends AAdapter {
 	 */
 	AString awaitRunFinished(AString agentId, RequestContext ctx, long timeoutMs)
 			throws TimeoutException {
-		CompletableFuture<ACell> f = runningLoops.get(agentId); // observe only — do NOT wake
+		CompletableFuture<ACell> f = runningLoops.get(new AgentKey(ctx.getCallerDID(), agentId)); // observe only — do NOT wake
 		if (f != null && !f.isDone()) {
 			try {
 				f.get(timeoutMs, TimeUnit.MILLISECONDS);
@@ -1288,20 +1297,30 @@ public class AgentAdapter extends AAdapter {
 	 * across threads. The lattice {@code K_STATUS} mirrors runtime state
 	 * for observability, not concurrency control.</p>
 	 *
+	 * <p>This is a pure mechanism keyed on the agent's address
+	 * ({@code ownerDID} + {@code agentId}): it runs the agent as its owner,
+	 * regardless of who triggered the wake. Authorization (may this caller
+	 * wake this agent?) and provenance (who sent the message) are the
+	 * responsibility of the entry handler, which knows the request and
+	 * records the caller before calling here. The waking caller's identity
+	 * never reaches the run loop. (#91)</p>
+	 *
+	 * @param ownerDID the DID whose namespace the agent lives in — the identity
+	 *              the run loop executes as
 	 * @param force if true, skips the {@code hasWork} gate — used by
 	 *              explicit triggers and scheduler fires that always want
 	 *              to try running
 	 */
-	public CompletableFuture<ACell> wakeAgent(AString agentId, RequestContext ctx, boolean force) {
-		AString callerDID = ctx.getCallerDID();
-
-		AgentState agent = getAgent(callerDID, agentId);
+	public CompletableFuture<ACell> wakeAgent(AString ownerDID, AString agentId, boolean force) {
+		AgentState agent = getAgent(ownerDID, agentId);
 		if (agent == null) return null;
+
+		final AgentKey key = new AgentKey(ownerDID, agentId);
 
 		// Fast path: live loop exists, attach to it. A done future in the
 		// slot is treated as "no live loop" — the exiting loop removes it
 		// in its finally block, but we may observe it briefly.
-		CompletableFuture<ACell> existing = runningLoops.get(agentId);
+		CompletableFuture<ACell> existing = runningLoops.get(key);
 		if (existing != null && !existing.isDone()) return existing;
 
 		// Phantom RUNNING recovery (#64): if lattice shows RUNNING but no
@@ -1323,7 +1342,7 @@ public class AgentAdapter extends AAdapter {
 		// Gate: only start if there's work (or forced).
 		if (!force && !hasWork(agent)) return null;
 
-		AString transitionOp = resolveTransitionOp(callerDID, agentId);
+		AString transitionOp = resolveTransitionOp(ownerDID, agentId);
 		if (transitionOp == null) return null;
 
 		// Atomic CAS: install our completion only if no other loop is live.
@@ -1331,7 +1350,7 @@ public class AgentAdapter extends AAdapter {
 		// check+install is a single operation — no lost-launch race with
 		// concurrent wakeAgent calls.
 		CompletableFuture<ACell> mine = new CompletableFuture<>();
-		CompletableFuture<ACell> installed = runningLoops.compute(agentId, (k, cur) -> {
+		CompletableFuture<ACell> installed = runningLoops.compute(key, (k, cur) -> {
 			if (cur != null && !cur.isDone()) return cur;
 			return mine;
 		});
@@ -1340,17 +1359,24 @@ public class AgentAdapter extends AAdapter {
 			return installed;
 		}
 
+		// The run loop executes under the agent owner's OWN authority — a fresh
+		// context carrying none of the waking caller's proofs, caps, job or
+		// session. Which caller won the launch CAS above must never leak into
+		// the agent's execution: every identity-scoped access during the run
+		// (secrets /s/, workspace w/, job ownership, per-user cursors) must
+		// resolve in the owner's namespace, deterministically. (#91)
+		final RequestContext agentCtx = RequestContext.of(ownerDID);
 		agent.setStatus(AgentState.RUNNING);
 		final AString finalOp = transitionOp;
 		final CompletableFuture<ACell> finalCompletion = mine;
 		Thread.ofVirtual().start(
-			() -> executeRunLoop(agentId, callerDID, finalOp, ctx, finalCompletion));
+			() -> executeRunLoop(agentId, ownerDID, finalOp, agentCtx, finalCompletion));
 		return mine;
 	}
 
 	/** Overload: non-forced wake (used by message delivery / resume auto-wake). */
-	CompletableFuture<ACell> wakeAgent(AString agentId, RequestContext ctx) {
-		return wakeAgent(agentId, ctx, false);
+	CompletableFuture<ACell> wakeAgent(AString ownerDID, AString agentId) {
+		return wakeAgent(ownerDID, agentId, false);
 	}
 
 	private static boolean hasWork(AgentState agent) {
@@ -1394,9 +1420,12 @@ public class AgentAdapter extends AAdapter {
 	 * loop — the CAS in {@code wakeAgent} guarantees at most one survives.</p>
 	 */
 	@SuppressWarnings("unchecked")
-	private void executeRunLoop(AString agentId, AString callerDID,
+	private void executeRunLoop(AString agentId, AString ownerDID,
 			AString transitionOp, RequestContext ctx,
 			CompletableFuture<ACell> completion) {
+		// ctx is the agent's OWN owner-scoped context (see wakeAgent) — never a
+		// waking caller's. ownerDID == ctx.getCallerDID() throughout the run.
+		final AgentKey key = new AgentKey(ownerDID, agentId);
 		ACell lastResult = null;
 		int iteration = 0;
 		AMap<AString, ACell> allTaskResults = Maps.empty();
@@ -1410,7 +1439,7 @@ public class AgentAdapter extends AAdapter {
 					break;
 				}
 
-				AgentState agent = getAgent(callerDID, agentId);
+				AgentState agent = getAgent(ownerDID, agentId);
 				if (agent == null) {
 					completion.completeExceptionally(
 						new RuntimeException("Agent not found: " + agentId));
@@ -1461,7 +1490,7 @@ public class AgentAdapter extends AAdapter {
 				AMap<AString, ACell> pickedSessionRecord = null;
 				long presentedSessionPendingCount = filteredInbox.count();
 				if (pickedSessionBlob != null) {
-					ConcurrentHashMap<Blob, Job> agentChats = activeChats.get(agentId);
+					ConcurrentHashMap<Blob, Job> agentChats = activeChats.get(key);
 					if (agentChats != null) {
 						Job candidate = agentChats.get(pickedSessionBlob);
 						if (candidate != null && !candidate.isFinished()) {
@@ -1512,7 +1541,7 @@ public class AgentAdapter extends AAdapter {
 				// merge path handles it normally.
 				CompletableFuture<ACell> transitionFuture =
 					engine.jobs().invokeInternal(transitionOp, transitionInput, cycleCtx);
-				activeTransitions.put(agentId, transitionFuture);
+				activeTransitions.put(key, transitionFuture);
 
 				ACell transitionResult;
 				try {
@@ -1525,11 +1554,11 @@ public class AgentAdapter extends AAdapter {
 					transitionResult = Maps.of(Fields.ERROR,
 						Strings.create("Transition failed: " + cause.getMessage()));
 				} finally {
-					activeTransitions.remove(agentId, transitionFuture);
+					activeTransitions.remove(key, transitionFuture);
 				}
 
 				IterResult merged = mergeAndPostProcess(
-					agent, agentId, callerDID, transitionOp, transitionResult, pickedTask,
+					agent, agentId, ownerDID, transitionOp, transitionResult, pickedTask,
 					pickedTaskInput, formattedTasks, pickedSession,
 					pickedSessionBlob, pickedChatJob, filteredInbox,
 					presentedSessionPendingCount, tasks, startTs, allTaskResults);
@@ -1541,7 +1570,7 @@ public class AgentAdapter extends AAdapter {
 			// TERMINATED if set externally), complete the completion with
 			// the last cycle's result. Report whatever status we ended up
 			// on so callers of the completion see the true final state.
-			AgentState agent = getAgent(callerDID, agentId);
+			AgentState agent = getAgent(ownerDID, agentId);
 			AString finalStatus = AgentState.SLEEPING;
 			if (agent != null) {
 				agent.sleep();
@@ -1554,19 +1583,19 @@ public class AgentAdapter extends AAdapter {
 				Fields.RESULT, lastResult != null ? RT.getIn(lastResult, Fields.RESULT) : null,
 				Fields.TASK_RESULTS, allTaskResults));
 		} catch (Exception e) {
-			suspendOnError(callerDID, agentId, e);
-			failAllPendingForAgent(callerDID, agentId, e.getMessage());
+			suspendOnError(ownerDID, agentId, e);
+			failAllPendingForAgent(ownerDID, agentId, e.getMessage());
 			completion.completeExceptionally(new RuntimeException(e.getMessage()));
 		} finally {
 			// Release the launcher slot, then re-check for wakes that may
 			// have arrived while this loop was exiting. remove(key, value)
 			// only clears the slot if it still holds OUR completion — a
 			// concurrent wakeAgent that already took over won't be disturbed.
-			runningLoops.remove(agentId, completion);
-			AgentState agent = getAgent(callerDID, agentId);
+			runningLoops.remove(key, completion);
+			AgentState agent = getAgent(ownerDID, agentId);
 			if (agent != null && AgentState.SLEEPING.equals(agent.getStatus())
 					&& hasWork(agent)) {
-				wakeAgent(agentId, ctx, false);
+				wakeAgent(ownerDID, agentId, false);
 			}
 		}
 	}
@@ -1586,6 +1615,7 @@ public class AgentAdapter extends AAdapter {
 			AVector<ACell> filteredInbox, long presentedSessionPendingCount,
 			Index<Blob, ACell> tasks, long startTs,
 			AMap<AString, ACell> allTaskResults) {
+		final AgentKey key = new AgentKey(callerDID, agentId);
 		long endTs = Utils.getCurrentTimestamp();
 		ACell newState = RT.getIn(transitionResult, AgentState.KEY_STATE);
 		ACell leanResponse = RT.getIn(transitionResult, Fields.RESPONSE);
@@ -1604,7 +1634,7 @@ public class AgentAdapter extends AAdapter {
 		// before completeDeferredJobs leaves them visible to the outer
 		// catch sweeper — the slot is only cleared after merge succeeds.
 		ConcurrentHashMap<Blob, AMap<AString, ACell>> deferred =
-			deferredCompletions.get(agentId);
+			deferredCompletions.get(key);
 		AMap<AString, ACell> taskResults = buildTaskResultsFromDeferred(deferred);
 		ACell result = (leanError != null) ? leanError : leanResponse;
 
@@ -1713,12 +1743,12 @@ public class AgentAdapter extends AAdapter {
 		// envelopes (atomic remove) and complete the caller's pending
 		// task Jobs. Doing this AFTER the merge guarantees that an
 		// awaitResult caller sees the completed cycle's writes.
-		completeDeferredJobs(deferredCompletions.remove(agentId));
+		completeDeferredJobs(deferredCompletions.remove(key));
 
 		// Complete any in-flight chat for the picked session. Same
 		// post-merge ordering invariant as task completion.
 		if (pickedChatJob != null && (leanError != null || leanResponse != null)) {
-			ConcurrentHashMap<Blob, Job> agentChats = activeChats.get(agentId);
+			ConcurrentHashMap<Blob, Job> agentChats = activeChats.get(key);
 			if (agentChats != null) agentChats.remove(pickedSessionBlob, pickedChatJob);
 			if (leanError != null) {
 				if (!pickedChatJob.isFinished()) pickedChatJob.fail(leanError.toString());
@@ -1962,11 +1992,12 @@ public class AgentAdapter extends AAdapter {
 	 */
 	@SuppressWarnings("unchecked")
 	private void failAllPendingForAgent(AString callerDID, AString agentId, String error) {
+		final AgentKey key = new AgentKey(callerDID, agentId);
 		AgentState agent = getAgent(callerDID, agentId);
 		if (agent != null) {
 			failQueuedTasks(agent.getTasks(), error);
 		}
-		ConcurrentHashMap<Blob, Job> agentChats = activeChats.remove(agentId);
+		ConcurrentHashMap<Blob, Job> agentChats = activeChats.remove(key);
 		if (agentChats != null) {
 			for (Job chatJob : agentChats.values()) {
 				if (chatJob != null && !chatJob.isFinished()) {
@@ -1975,7 +2006,7 @@ public class AgentAdapter extends AAdapter {
 			}
 		}
 		ConcurrentHashMap<Blob, AMap<AString, ACell>> deferred =
-			deferredCompletions.remove(agentId);
+			deferredCompletions.remove(key);
 		if (deferred != null) {
 			for (var e : deferred.entrySet()) {
 				Job pending = engine.jobs().getJob(e.getKey());

--- a/venue/src/main/java/covia/adapter/TestAdapter.java
+++ b/venue/src/main/java/covia/adapter/TestAdapter.java
@@ -25,7 +25,17 @@ import covia.venue.RequestContext;
 public class TestAdapter extends AAdapter {
 	
 	public static final Logger log=LoggerFactory.getLogger(TestAdapter.class);
-	
+
+    /**
+     * Test-only sink: the {@code capturectx} op records the {@link RequestContext}
+     * it was invoked under, keyed by the owner DID it ran as (its caller DID).
+     * Lets tests assert deterministically which identity / proofs / caps a
+     * transition actually ran with — including that two same-named agents owned
+     * by different users run under their own identities (see #91).
+     */
+    public static final java.util.concurrent.ConcurrentHashMap<AString, RequestContext> CAPTURED_CTX
+        = new java.util.concurrent.ConcurrentHashMap<>();
+
     private final SecureRandom random = new SecureRandom();
     
     @Override
@@ -49,6 +59,8 @@ public class TestAdapter extends AAdapter {
             switch (testOp) {
                 case "echo":
                     return CompletableFuture.completedFuture(handleEcho(input));
+                case "capturectx":
+                    return CompletableFuture.completedFuture(handleCaptureCtx(ctx, input));
                 case "taskcomplete":
                     return CompletableFuture.completedFuture(handleTaskComplete(ctx, input));
                 case "wakeresponse":
@@ -98,6 +110,7 @@ public class TestAdapter extends AAdapter {
 			// Test primitives — registered under /v/test/ops/<name>, not /v/ops/.
 			installTestAsset("random",       BASE+"randomop.json");
 			installTestAsset("echo",         BASE+"echoop.json");
+			installTestAsset("capturectx",   BASE+"capturectxop.json");
 			installTestAsset("llm",          BASE+"testllm.json");
 			installTestAsset("toolllm",      BASE+"testtoolllm.json");
 			installTestAsset("taskllm",      BASE+"testtaskllm.json");
@@ -201,6 +214,16 @@ public class TestAdapter extends AAdapter {
 
 	private ACell handleEcho(ACell input) {
         // Simply return the input
+        return input;
+    }
+
+    /**
+     * Records the invoking {@link RequestContext} keyed by agentId, then behaves
+     * like echo so the run loop merges cleanly and sleeps. Used by tests to
+     * assert the identity / proofs / caps a transition ran under.
+     */
+    private ACell handleCaptureCtx(RequestContext ctx, ACell input) {
+        if (ctx.getCallerDID() != null) CAPTURED_CTX.put(ctx.getCallerDID(), ctx);
         return input;
     }
 

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -66,6 +66,7 @@ import covia.adapter.agent.LLMAgentAdapter;
 import covia.adapter.UCANAdapter;
 import covia.adapter.TestAdapter;
 import covia.api.Fields;
+import covia.exception.CoviaException;
 import covia.grid.AContent;
 import covia.grid.Asset;
 import covia.grid.Grid;
@@ -1713,16 +1714,23 @@ public class Engine {
 		if (name.isEmpty()) return null;
 
 		User user = venueState.users().get(callerDID);
-		if (user == null) return null;
+		if (user == null) return null;   // identity has no store — genuinely absent
 
+		AString value;
 		try {
 			byte[] encKey = SecretStore.deriveKey(keyPair);
-			AString value = user.secrets().decrypt(Strings.create(name), encKey);
-			return (value != null) ? value.toString() : null;
+			value = user.secrets().decrypt(Strings.create(name), encKey);
 		} catch (Exception e) {
-			log.debug("Could not resolve secret '{}': {}", name, e.getMessage());
-			return null;
+			// A decrypt/key failure is NOT the same as "secret not set".
+			// Collapsing both to null (the old behaviour) masked real errors as
+			// absence and made #91-class identity/key misconfigurations
+			// undiagnosable — a failed resolution looked identical to a missing
+			// key. Surface it loudly instead. Values are never logged.
+			log.warn("Secret '{}' resolution errored for caller {}: {}",
+				name, callerDID, e.toString());
+			throw new CoviaException("Secret resolution failed for '" + name + "'", e);
 		}
+		return (value != null) ? value.toString() : null;   // null == genuinely absent
 	}
 
 	/**

--- a/venue/src/main/resources/asset-examples/capturectxop.json
+++ b/venue/src/main/resources/asset-examples/capturectxop.json
@@ -1,0 +1,10 @@
+{
+	"name": "Capture Context Operation",
+	"description": "Test-only transition op: records the RequestContext it ran under (keyed by agentId) and echoes the input. Used to assert agent run-loop identity (#91).",
+	"dateCreated": "2026-06-17T00:00:00Z",
+	"operation": {
+		"adapter": "test:capturectx",
+		"input": {},
+		"output": {}
+	}
+}

--- a/venue/src/test/java/covia/adapter/AgentAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/AgentAdapterTest.java
@@ -765,7 +765,7 @@ public class AgentAdapterTest {
 		// A never-completing placeholder Job holds the slot.
 		Job placeholder = Job.create(Maps.of(Fields.STATUS, Status.STARTED));
 		agentAdapter.reserveChatSlotForTest(
-			Strings.create("chat-busy-agent"), sid, placeholder);
+			ALICE_DID, Strings.create("chat-busy-agent"), sid, placeholder);
 
 		// Now an agent_chat on the same session must fail fast
 		Job chatJob = engine.jobs().invokeOperation(

--- a/venue/src/test/java/covia/adapter/AgentRunLoopIdentityTest.java
+++ b/venue/src/test/java/covia/adapter/AgentRunLoopIdentityTest.java
@@ -1,0 +1,141 @@
+package covia.adapter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import convex.core.data.ACell;
+import convex.core.data.AString;
+import convex.core.data.Blob;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import covia.api.Fields;
+import covia.venue.AgentState;
+import covia.venue.Engine;
+import covia.venue.RequestContext;
+import covia.venue.SecretStore;
+import covia.venue.TestEngine;
+import covia.venue.User;
+
+/**
+ * Regression for #91 and the related cross-user run-loop keying.
+ *
+ * <p>An agent's run loop executes within the agent owner's identity, derived
+ * from the agent's address ({@code ownerDID} + {@code agentId}), never from the
+ * caller that woke it. {@link AgentAdapter#wakeAgent} is a pure mechanism keyed
+ * on that address — there is no caller parameter for an identity to leak
+ * through — and the in-memory run-loop registries key on the full address, so
+ * two users' agents that share a name do not collide.</p>
+ *
+ * <p>Deterministic — each test drives wakes and waits on the run-loop
+ * completion futures; no timing assumptions.</p>
+ */
+public class AgentRunLoopIdentityTest {
+
+	final Engine engine = TestEngine.ENGINE;
+	private AString ALICE_DID;
+	private AString BOB_DID;
+
+	@BeforeEach
+	public void setup(TestInfo info) {
+		ALICE_DID = TestEngine.uniqueDID(info);
+		BOB_DID = Strings.create(ALICE_DID.toString() + "-bob");
+		TestAdapter.CAPTURED_CTX.remove(ALICE_DID);
+		TestAdapter.CAPTURED_CTX.remove(BOB_DID);
+	}
+
+	/** Creates an agent owned by {@code owner} whose transition records the
+	 *  context it runs under, stores an owner-only secret, and queues a message
+	 *  so the loop fires. Returns the agentId. */
+	private AString prepareAgent(AString owner, String name, String secretName, String secretValue) {
+		AString agentId = Strings.create(name);
+		engine.jobs().invokeOperation(
+			"v/ops/agent/create",
+			Maps.of(Fields.AGENT_ID, agentId,
+				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/capturectx")),
+			RequestContext.of(owner)).awaitResult(5000);
+
+		User user = engine.getVenueState().users().ensure(owner);
+		byte[] encKey = SecretStore.deriveKey(engine.getKeyPair());
+		user.secrets().store(secretName, secretValue, encKey);
+
+		AgentState agent = user.agent(name);
+		Blob sid = Blob.fromHex("12340001123400011234000112340001");
+		agent.ensureSession(sid, owner);
+		agent.appendSessionPending(sid, Maps.of(
+			Fields.SESSION_ID, Strings.create(sid.toHexString()),
+			Fields.MESSAGE, Maps.of("content", "hi")));
+		return agentId;
+	}
+
+	private AgentAdapter adapter() {
+		return (AgentAdapter) engine.getAdapter("agent");
+	}
+
+	@Test
+	public void testRunLoopRunsUnderOwnerContext() {
+		AString agentId = prepareAgent(ALICE_DID, "own-ident", "RUNLOOP_KEY", "alice-secret");
+		adapter().wakeAgent(ALICE_DID, agentId, true).join();
+
+		RequestContext seen = TestAdapter.CAPTURED_CTX.get(ALICE_DID);
+		assertNotNull(seen, "transition must have executed");
+		assertEquals(ALICE_DID, seen.getCallerDID(),
+			"run loop must execute under the agent owner's DID");
+		assertNull(seen.getProofs(), "run context must carry no proofs");
+		assertNull(seen.getCaps(),   "run context must carry no caps");
+		assertEquals("alice-secret", engine.resolveSecret("RUNLOOP_KEY", seen),
+			"owner-scoped secret must resolve under the run-loop context");
+	}
+
+	@Test
+	public void testRunLoopIdentityFollowsOwnerNotCaller() {
+		// The agent is owned by BOB. The loop must run as BOB and resolve BOB's
+		// secret — identity follows the agent's address, not the surrounding
+		// fixture's primary user (ALICE).
+		AString agentId = prepareAgent(BOB_DID, "bob-ident", "BOB_KEY", "bob-secret");
+		adapter().wakeAgent(BOB_DID, agentId, true).join();
+
+		RequestContext seen = TestAdapter.CAPTURED_CTX.get(BOB_DID);
+		assertNotNull(seen, "transition must have executed");
+		assertEquals(BOB_DID, seen.getCallerDID(),
+			"run loop must execute under the owner (BOB)");
+		assertEquals("bob-secret", engine.resolveSecret("BOB_KEY", seen),
+			"BOB's owner-scoped secret must resolve under the run-loop context");
+		assertNull(engine.resolveSecret("BOB_KEY", RequestContext.of(ALICE_DID)),
+			"BOB's secret must not resolve under a different identity");
+	}
+
+	@Test
+	public void testSameNameAgentsForDifferentOwnersDoNotCollide() {
+		// Both users own an agent called "shared". testUserIsolation proves the
+		// lattice records are isolated; this proves the in-memory run-loop
+		// registries are too — each loop runs under its own identity and
+		// resolves its own secret. Pre-fix, the registries keyed on the bare
+		// agentId, so the two loops shared a slot.
+		AString agentId = prepareAgent(ALICE_DID, "shared", "K", "alice-secret");
+		prepareAgent(BOB_DID, "shared", "K", "bob-secret");
+
+		// Drive both concurrently; both must run their own loop to completion.
+		CompletableFuture<ACell> a = adapter().wakeAgent(ALICE_DID, agentId, true);
+		CompletableFuture<ACell> b = adapter().wakeAgent(BOB_DID, agentId, true);
+		assertNotNull(a, "Alice's wake should start a loop");
+		assertNotNull(b, "Bob's wake should start a loop");
+		a.join();
+		b.join();
+
+		RequestContext aSeen = TestAdapter.CAPTURED_CTX.get(ALICE_DID);
+		RequestContext bSeen = TestAdapter.CAPTURED_CTX.get(BOB_DID);
+		assertNotNull(aSeen, "Alice's agent must have run");
+		assertNotNull(bSeen, "Bob's agent must have run");
+		assertEquals(ALICE_DID, aSeen.getCallerDID());
+		assertEquals(BOB_DID, bSeen.getCallerDID());
+		assertEquals("alice-secret", engine.resolveSecret("K", aSeen),
+			"Alice's loop resolves Alice's secret");
+		assertEquals("bob-secret", engine.resolveSecret("K", bSeen),
+			"Bob's loop resolves Bob's secret");
+	}
+}

--- a/venue/src/test/java/covia/venue/JobCancellationTest.java
+++ b/venue/src/test/java/covia/venue/JobCancellationTest.java
@@ -176,7 +176,7 @@ public class JobCancellationTest {
 		covia.adapter.AgentAdapter agentAdapter =
 			(covia.adapter.AgentAdapter) engine.getAdapter("agent");
 		AString agentIdStr = Strings.create("chat-cancel-agent");
-		assertNotNull(agentAdapter.getActiveChatForTest(agentIdStr, sid),
+		assertNotNull(agentAdapter.getActiveChatForTest(ALICE_DID, agentIdStr, sid),
 			"Chat slot should be reserved before cancel");
 
 		chatJob.cancel();
@@ -186,7 +186,7 @@ public class JobCancellationTest {
 		// slot immediately via the cancel hook registered in handleChat.
 		// No need to wait for the run loop — the slot is freed synchronously
 		// when chatJob.cancel() fires the hook.
-		assertNull(agentAdapter.getActiveChatForTest(agentIdStr, sid),
+		assertNull(agentAdapter.getActiveChatForTest(ALICE_DID, agentIdStr, sid),
 			"Chat slot should be released immediately on caller-Job cancel");
 	}
 


### PR DESCRIPTION
Closes #91.

## Problem

An agent's run loop inherited the `RequestContext` of whichever caller won the wake, so the calling thread's DID, proofs and caps leaked into agent execution. Every identity-scoped access during the run (secrets `/s/`, workspace `w/`, job ownership, per-user cursors) then resolved in the wrong namespace.

## Fix

Model an agent's address explicitly as **`(ownerDID, agentId)`** — the owner is the namespace the agent lives in (per the `did:.../g/<id>` structure), not a stored field and not the caller.

- **`wakeAgent(ownerDID, agentId, force)` is now a pure mechanism keyed on the address.** It runs the agent under a fresh `RequestContext.of(ownerDID)` — there is no caller/ctx parameter, so a waker's identity/proofs/caps cannot leak in by construction. Authorization and provenance stay in the entry handlers, where the caller is known.
- **Registry-keying bug fixed along the way.** The in-memory registries (`runningLoops`, `activeTransitions`, `activeChats`, `deferredCompletions`) were keyed by the bare `agentId`. Since agents are per-user, two users with a same-named agent shared a run-loop slot. They now key on an `AgentKey(owner, id)`. `testUserIsolation` proves the lattice records are isolated but never wakes, so this was uncovered.
- **`Engine.resolveSecret` distinguishes absent from errored** — returns `null` for a genuinely unset secret, but logs at WARN and throws on a decrypt/key error instead of collapsing both to `null` at DEBUG (which had masked this class of misconfiguration as "key not found").

## Tests

`AgentRunLoopIdentityTest`: run-as-owner with a fresh context (no proofs/caps), identity-follows-owner-not-caller, and same-name agents for different owners not colliding. Full venue suite green (1357 tests).

## Deliberately deferred

- **End-to-end cross-user wake/message wiring** — resolving an explicit owner from the request and authorizing a cross-user caller — is scoped out of this change. Same-venue cross-user authz can reuse the **existing Phase C1 machinery** (`CoviaAdapter.verifyProofs` / venue-signed UCANs, as already done for `w/`); it is **not** blocked. Only *cross-venue* agent access additionally needs the cross-venue trust model (#100). `ownerDID` is a first-class parameter, so the contract is ready and no dead authz code was added.
- The `resolveSecret` change is cross-cutting (affects all secret consumers); it rode along here for diagnosability and could be split if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
