### PR TITLE
Upgrade to Convex 0.8.6 and migrate venue HTTP layer to Javalin 7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ covia/                          # ai.covia:covia:0.2.0-SNAPSHOT (parent POM)
 
 - **Java 21+** (JDK; the published Docker image runs on Java 25)
 - **Maven 3.7+** (enforced by maven-enforcer-plugin)
-- **Convex 0.8.5** — released, resolves from Maven Central. To develop against unreleased Convex changes, `mvn install` from `../convex` and point `convex.version` at its snapshot.
+- **Convex 0.8.6** — released, resolves from Maven Central. To develop against unreleased Convex changes, `mvn install` from `../convex` and point `convex.version` at its snapshot.
 
 ## Build & Run
 
@@ -87,12 +87,12 @@ mvn test -pl covia-core
 
 | Dependency | Version | Purpose |
 |------------|---------|---------|
-| Convex | 0.8.5 | Lattice platform, immutable data, cryptography |
-| Javalin | 6.7.0 | HTTP server with OpenAPI/Swagger/ReDoc |
-| LangChain4j | 1.5.0 | LLM orchestration (OpenAI, Ollama, Gemini, DeepSeek) |
+| Convex | 0.8.6 | Lattice platform, immutable data, cryptography |
+| Javalin | 7.2.2 | HTTP server with OpenAPI/Swagger/ReDoc |
+| LangChain4j | 1.16.2 | LLM orchestration (OpenAI, Ollama, Gemini, DeepSeek) |
 | MCP SDK | 0.13.0 | Model Context Protocol |
 | A2A | 1.0.0.Beta1 | Agent-to-Agent protocol |
-| JUnit | 6.0.1 | Testing |
+| JUnit | 6.1.0 | Testing |
 | SLF4J/Logback | 2.0.17/1.5.18 | Logging |
 
 ## Architecture Overview

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
 		<maven.compiler.release>21</maven.compiler.release>
 		<maven.compiler.source>21</maven.compiler.source>
 		<junit.version>6.1.0</junit.version>
-		<convex.version>0.8.5</convex.version>
+		<convex.version>0.8.6</convex.version>
 		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		
 		<logback.version>1.5.18</logback.version>
 		<slf4j.version>2.0.17</slf4j.version>
 		<hc.version>5.5</hc.version>
-		<javalin.version>6.7.0</javalin.version>
+		<javalin.version>7.2.2</javalin.version>
 		<langchain.version>1.16.2</langchain.version>
 		<mcp.version>0.13.0</mcp.version>
 		<a2a.version>1.0.0.Beta1</a2a.version>

--- a/venue/src/main/java/covia/venue/api/A2A.java
+++ b/venue/src/main/java/covia/venue/api/A2A.java
@@ -38,7 +38,7 @@ import covia.venue.Engine;
 import covia.venue.RequestContext;
 import covia.venue.server.AuthMiddleware;
 import covia.venue.server.SseServer;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 import io.javalin.http.sse.SseHandler;
 
@@ -102,9 +102,9 @@ public class A2A extends ACoviaAPI {
 		this.agentProvider = new AgentProvider(orgName, orgUrl);
 	}
 
-	public void addRoutes(Javalin javalin) {
-		javalin.get("/.well-known/agent-card.json", this::getAgentCard);
-		javalin.post("/a2a", this::handleJsonRpc);
+	public void addRoutes(RoutesConfig routes) {
+		routes.get("/.well-known/agent-card.json", this::getAgentCard);
+		routes.post("/a2a", this::handleJsonRpc);
 	}
 
 	// ==================== Agent Card ====================

--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -37,7 +37,7 @@ import covia.venue.SecretStore;
 import covia.venue.User;
 import covia.venue.server.AuthMiddleware;
 import covia.venue.server.SseServer;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.openapi.HttpMethod;
@@ -90,38 +90,38 @@ public class CoviaAPI extends ACoviaAPI {
 		});
 	}
 
-	public void addRoutes(Javalin javalin) {
-		javalin.get(ROUTE+"status", this::getStatus);
+	public void addRoutes(RoutesConfig routes) {
+		routes.get(ROUTE+"status", this::getStatus);
 		// <id> matches slashes, so the asset metadata route accepts any lattice
 		// address (a/<hash>, w/…, o/…, <DID>/…) as well as a bare hash. The more
 		// specific {id}/content route below is registered too; Javalin prefers
 		// the more specific match (covered by CoviaAssetRefTest).
-		javalin.get(ROUTE+"assets/{id}/content", this::getContent);
-		javalin.get(ROUTE+"assets/<id>", this::getAsset);
-		javalin.put(ROUTE+"assets/{id}/content", this::putContent);
+		routes.get(ROUTE+"assets/{id}/content", this::getContent);
+		routes.get(ROUTE+"assets/<id>", this::getAsset);
+		routes.put(ROUTE+"assets/{id}/content", this::putContent);
 
-		javalin.get(ROUTE+"assets", this::getAssets);
-		javalin.post(ROUTE+"assets", this::addAsset);
-		javalin.post(ROUTE+"invoke", this::invokeOperation);
-		javalin.get(ROUTE+"operations", this::getOperations);
-		javalin.get(ROUTE+"operations/{name}", this::getOperation);
-		javalin.get(ROUTE+"jobs/<id>", this::getJobStatus);
-		javalin.post(ROUTE+"jobs/<id>", this::sendMessage);
-		javalin.put(ROUTE+"jobs/<id>/cancel", this::cancelJob);
-		javalin.put(ROUTE+"jobs/<id>/pause", this::pauseJob);
-		javalin.put(ROUTE+"jobs/<id>/resume", this::resumeJob);
-		javalin.put(ROUTE+"jobs/<id>/delete", this::deleteJob);
-		javalin.sse(ROUTE+"jobs/<id>/sse", sseServer.registerSSE);
-		javalin.get(ROUTE+"jobs", this::getJobs);
-		
+		routes.get(ROUTE+"assets", this::getAssets);
+		routes.post(ROUTE+"assets", this::addAsset);
+		routes.post(ROUTE+"invoke", this::invokeOperation);
+		routes.get(ROUTE+"operations", this::getOperations);
+		routes.get(ROUTE+"operations/{name}", this::getOperation);
+		routes.get(ROUTE+"jobs/<id>", this::getJobStatus);
+		routes.post(ROUTE+"jobs/<id>", this::sendMessage);
+		routes.put(ROUTE+"jobs/<id>/cancel", this::cancelJob);
+		routes.put(ROUTE+"jobs/<id>/pause", this::pauseJob);
+		routes.put(ROUTE+"jobs/<id>/resume", this::resumeJob);
+		routes.put(ROUTE+"jobs/<id>/delete", this::deleteJob);
+		routes.sse(ROUTE+"jobs/<id>/sse", sseServer.registerSSE);
+		routes.get(ROUTE+"jobs", this::getJobs);
+
 		// Secrets
-		javalin.get(ROUTE+"secrets", this::listSecrets);
-		javalin.put(ROUTE+"secrets/{name}", this::putSecret);
-		javalin.delete(ROUTE+"secrets/{name}", this::deleteSecret);
+		routes.get(ROUTE+"secrets", this::listSecrets);
+		routes.put(ROUTE+"secrets/{name}", this::putSecret);
+		routes.delete(ROUTE+"secrets/{name}", this::deleteSecret);
 
 		// DIDs
-		javalin.get("/.well-known/did.json", this::getDIDDocument);
-		javalin.get("/a/{id}/did.json", this::getAssetDIDDocument);
+		routes.get("/.well-known/did.json", this::getDIDDocument);
+		routes.get("/a/{id}/did.json", this::getAssetDIDDocument);
 	}
 	 
 	@OpenApi(path = ROUTE + "status", 

--- a/venue/src/main/java/covia/venue/api/MCP.java
+++ b/venue/src/main/java/covia/venue/api/MCP.java
@@ -37,7 +37,7 @@ import covia.venue.LocalVenue;
 import covia.venue.RequestContext;
 import covia.venue.server.AuthMiddleware;
 import covia.venue.server.SseServer;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -241,13 +241,13 @@ public class MCP extends McpServer {
 	// ==================== Route registration ====================
 
 	@Override
-	public void addRoutes(Javalin app) {
+	public void addRoutes(RoutesConfig routes) {
 		// McpServer registers POST /mcp and GET /.well-known/mcp
-		super.addRoutes(app);
+		super.addRoutes(routes);
 
 		// SSE session routes
-		app.get("/mcp", this::handleMcpGet);
-		app.delete("/mcp", this::handleMcpDelete);
+		routes.get("/mcp", this::handleMcpGet);
+		routes.delete("/mcp", this::handleMcpDelete);
 	}
 
 	// ==================== Tool listing (dynamic, from adapters) ====================

--- a/venue/src/main/java/covia/venue/api/UserAPI.java
+++ b/venue/src/main/java/covia/venue/api/UserAPI.java
@@ -13,7 +13,7 @@ import convex.core.data.Strings;
 import convex.core.data.Vectors;
 import covia.api.Fields;
 import covia.grid.Venue;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 import io.javalin.openapi.HttpMethod;
 import io.javalin.openapi.OpenApi;
@@ -39,8 +39,8 @@ public class UserAPI extends ACoviaAPI {
 		super(venue);
 	}
 
-	public void addRoutes(Javalin javalin) {
-		javalin.get("/u/{id}/did.json", this::getUserDIDDocument);
+	public void addRoutes(RoutesConfig routes) {
+		routes.get("/u/{id}/did.json", this::getUserDIDDocument);
 	}
 
 	@OpenApi(path = "/u/{id}/did.json",

--- a/venue/src/main/java/covia/venue/api/impl/APIConstants.java
+++ b/venue/src/main/java/covia/venue/api/impl/APIConstants.java
@@ -5,5 +5,5 @@ import io.javalin.http.ContentType;
 
 public class APIConstants {
 
-	ContentType CVX=ContentType.getContentType(ContentTypes.CVX);
+	ContentType CVX=ContentType.Companion.contentType(ContentTypes.CVX);
 }

--- a/venue/src/main/java/covia/venue/server/AuthMiddleware.java
+++ b/venue/src/main/java/covia/venue/server/AuthMiddleware.java
@@ -24,7 +24,7 @@ import covia.venue.Auth;
 import covia.venue.RequestContext;
 import covia.venue.auth.JWKSClient;
 import covia.venue.auth.OAuthConfig;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 
 /**
@@ -170,18 +170,18 @@ public class AuthMiddleware {
 	 * so multiple VenueServers in the same JVM (production multi-tenant or
 	 * parallel test classes) do not share state.
 	 *
-	 * @param app Javalin application
+	 * @param routes Javalin routes configuration
 	 * @param venueAccountKey The venue's public key for verifying venue-signed JWTs
 	 * @param auth Auth instance for access control configuration
 	 * @param venueDIDString The venue's DID string for deriving user DIDs
 	 * @return The constructed middleware instance (rarely needed by callers,
 	 *         but useful for tests).
 	 */
-	public static AuthMiddleware register(Javalin app, AccountKey venueAccountKey, Auth auth, AString venueDIDString) {
+	public static AuthMiddleware register(RoutesConfig routes, AccountKey venueAccountKey, Auth auth, AString venueDIDString) {
 		AuthMiddleware mw = new AuthMiddleware(venueAccountKey, auth, venueDIDString);
-		app.before("/api/*", mw::extractIdentity);
-		app.before("/a2a", mw::extractIdentity);
-		app.before("/mcp", mw::extractIdentity);
+		routes.before("/api/*", mw::extractIdentity);
+		routes.before("/a2a", mw::extractIdentity);
+		routes.before("/mcp", mw::extractIdentity);
 		return mw;
 	}
 

--- a/venue/src/main/java/covia/venue/server/CoviaWebApp.java
+++ b/venue/src/main/java/covia/venue/server/CoviaWebApp.java
@@ -39,7 +39,7 @@ import covia.venue.Engine;
 import covia.venue.LocalVenue;
 import covia.venue.api.MCP;
 import covia.venue.api.CoviaAPI;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 import j2html.tags.DomContent;
 import j2html.tags.Text;
@@ -54,17 +54,17 @@ public class CoviaWebApp  {
 		this.toolPage = new ToolPage(engine);
 	}
 
-	public void addRoutes(Javalin javalin) {
-		javalin.get("/index.html", this::indexPage);
-		javalin.get("/", this::indexPage);
-		javalin.get("/404.html", this::missingPage);
-		javalin.get("/status", this::statusPage);
-		javalin.get("/config", this::configPage);
-		javalin.get("/adapters", this::adaptersPage);
-		javalin.get("/adapters/{name}", this::adapterDetailPage);
-		javalin.get("/tools/{hash}", ctx -> toolPage.toolDetailPage(ctx, ctx.pathParam("hash")));
-		javalin.get("/llms.txt",this::llmsTxt);
-		javalin.get("/sitemap.xml",this::siteMap);
+	public void addRoutes(RoutesConfig routes) {
+		routes.get("/index.html", this::indexPage);
+		routes.get("/", this::indexPage);
+		routes.get("/404.html", this::missingPage);
+		routes.get("/status", this::statusPage);
+		routes.get("/config", this::configPage);
+		routes.get("/adapters", this::adaptersPage);
+		routes.get("/adapters/{name}", this::adapterDetailPage);
+		routes.get("/tools/{hash}", ctx -> toolPage.toolDetailPage(ctx, ctx.pathParam("hash")));
+		routes.get("/llms.txt",this::llmsTxt);
+		routes.get("/sitemap.xml",this::siteMap);
 
 	}
 	

--- a/venue/src/main/java/covia/venue/server/VenueServer.java
+++ b/venue/src/main/java/covia/venue/server/VenueServer.java
@@ -6,6 +6,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.http.UriCompliance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,9 +42,9 @@ import covia.venue.api.UserAPI;
 import covia.venue.auth.LoginProviders;
 import io.javalin.Javalin;
 import io.javalin.config.JavalinConfig;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.HttpResponseException;
 import io.javalin.http.staticfiles.Location;
-import io.javalin.openapi.plugin.DefinitionConfiguration;
 import io.javalin.openapi.plugin.OpenApiPlugin;
 import io.javalin.openapi.plugin.swagger.SwaggerPlugin;
 
@@ -234,9 +237,6 @@ public class VenueServer {
 		server.getEngine().provisionConfiguredSecrets();
 		server.getEngine().jobs().recoverJobs();
 
-		// Mount DLFS WebDAV if adapter is registered
-		server.mountDLFSWebDAV();
-
 		return server;
 	}
 
@@ -259,9 +259,6 @@ public class VenueServer {
 		}
 
 		javalin=buildApp();
-		AuthMiddleware.register(javalin, engine.getAccountKey(), engine.getAuth(), engine.getDIDString());
-		addLoginRoutes(javalin);
-		addAPIRoutes(javalin);
 		start(javalin,port);
 		log.info("Venue server started on port: "+javalin.port());
 	}
@@ -289,14 +286,17 @@ public class VenueServer {
 
 	
 	/**
-	 * Mounts DLFS WebDAV routes if the DLFS adapter is registered.
-	 * Creates a DLFSDriveManager that delegates to the adapter's
+	 * Mounts DLFS WebDAV routes when WebDAV is enabled in config.
+	 * Creates a DLFSDriveManager that delegates to the DLFS adapter's
 	 * lattice-backed drives.
+	 *
+	 * <p>Routes are registered at server-create time (Javalin 7 requires this),
+	 * but the {@code dlfs} adapter is registered later by {@code addDemoAssets}.
+	 * The manager therefore resolves the adapter <em>lazily per request</em>; a
+	 * request that arrives before the adapter exists simply yields no drive.</p>
 	 */
-	private void mountDLFSWebDAV() {
-		if (!engine.hasAdapter("dlfs")) return;
+	private void mountDLFSWebDAV(RoutesConfig routes) {
 		if (!config.isWebDAVEnabled()) return;
-		DLFSAdapter dlfs = (DLFSAdapter) engine.getAdapter("dlfs");
 
 		// Wrap the adapter's lattice drives as a DLFSDriveManager for WebDAV.
 		// Unauthenticated requests use the venue's public DID (must match
@@ -309,6 +309,8 @@ public class VenueServer {
 
 			@Override
 			public java.nio.file.FileSystem getDrive(String identity, String driveName) {
+				DLFSAdapter dlfs = (DLFSAdapter) engine.getAdapter("dlfs");
+				if (dlfs == null) return null; // adapter not registered (yet)
 				try {
 					return dlfs.getDriveForIdentity(resolveIdentity(identity), driveName);
 				} catch (Exception e) {
@@ -319,23 +321,22 @@ public class VenueServer {
 
 			@Override
 			public boolean createDrive(String identity, String driveName) {
-				getDrive(identity, driveName); // auto-creates via DLFS.connect
-				return true;
+				return getDrive(identity, driveName) != null; // auto-creates via DLFS.connect
 			}
 		};
 
 		DLFSWebDAV webdav = new DLFSWebDAV(webdavManager);
-		webdav.addRoutes(javalin);
+		webdav.addRoutes(routes);
 
 		log.info("DLFS WebDAV mounted at /dlfs/");
 	}
 
-	private void addAPIRoutes(Javalin javalin) {
-		api.addRoutes(javalin);
-		userApi.addRoutes(javalin);
-		webApp.addRoutes(javalin);
-		if (mcp!=null) mcp.addRoutes(javalin);
-		if (a2a!=null) a2a.addRoutes(javalin);
+	private void addAPIRoutes(RoutesConfig routes) {
+		api.addRoutes(routes);
+		userApi.addRoutes(routes);
+		webApp.addRoutes(routes);
+		if (mcp!=null) mcp.addRoutes(routes);
+		if (a2a!=null) a2a.addRoutes(routes);
 	}
 	
 
@@ -348,13 +349,26 @@ public class VenueServer {
 	
 	protected void setupJettyServer(org.eclipse.jetty.server.Server jettyServer, Integer port) {
 		if (port==null) port=8080;
+		// Allow encoded path separators (%2F) in URIs. Catalog operation names
+		// contain slashes (e.g. "v/ops/jvm/string-concat") and are percent-encoded
+		// into a single path segment by VenueHTTP.getOperationId — the GET
+		// /api/v1/operations/{name} contract. Jetty 12's default UriCompliance
+		// rejects %2F as an "ambiguous path separator" (400); Jetty 11 and
+		// Javalin's own connector permit it. Since we build the connector
+		// ourselves (below), we must opt back in here or named catalog lookups
+		// — and cross-venue named references — break.
+		HttpConfiguration httpConfig = new HttpConfiguration();
+		httpConfig.setUriCompliance(UriCompliance.from(
+			"DEFAULT,AMBIGUOUS_PATH_SEPARATOR,AMBIGUOUS_PATH_ENCODING"));
+
 		// Size the connector's acceptor/selector threads explicitly. Jetty defaults
 		// selectors to cores/2, which is wrong here: handlers run on virtual threads
 		// (useVirtualThreads=true), so the selectors only pump non-blocking I/O. The
 		// default exploded the platform-thread count when many venues share a JVM
 		// (N×cores/2 selectors), starving the connectors. See Config.DEFAULT_HTTP_SELECTORS.
 		ServerConnector connector = new ServerConnector(jettyServer,
-			config.getHttpAcceptors(), config.getHttpSelectors());
+			config.getHttpAcceptors(), config.getHttpSelectors(),
+			new HttpConnectionFactory(httpConfig));
 		connector.setPort(port);
 		// Restrict the listening interface when a bind address is configured.
 		// When unset, Jetty binds the wildcard address (0.0.0.0 / all
@@ -370,7 +384,6 @@ public class VenueServer {
 
 	private Javalin buildApp() {
 		final String corsOrigins = this.config.getCorsOrigins();
-		final boolean allowPrivateNetwork = this.config.isAllowPrivateNetwork();
 		Javalin app = Javalin.create(config -> {
 			config.bundledPlugins.enableCors(cors -> {
 				cors.addRule(corsConfig -> {
@@ -389,15 +402,13 @@ public class VenueServer {
 				staticFiles.hostedPath = "/";
 				staticFiles.location = Location.CLASSPATH; // Specify resources from classpath
 				staticFiles.directory = "/covia/pub"; // Resource location in classpath
-				staticFiles.precompress = false; // if the files should be pre-compressed and cached in memory
-													// (optimization)
 				staticFiles.aliasCheck = null; // you can configure this to enable symlinks (=
 												// ContextHandler.ApproveAliases())
 				staticFiles.skipFileFunction = req -> false; // you can use this to skip certain files in the dir, based
 																// on the HttpServletRequest
 			});
 			
-			config.useVirtualThreads=true;
+			config.concurrency.useVirtualThreads=true;
 
 			// Raise HTTP body size limit (default 1 MB is too low for vault uploads).
 			config.http.maxRequestSize = 10_000_000L;
@@ -412,34 +423,54 @@ public class VenueServer {
 			// We can't simply setSessionHandler(null) — Jetty NPEs. Instead
 			// we install a custom SessionIdManager whose HouseKeeper has
 			// interval=0, which disables scheduling so no thread is created.
+			// Jetty 12 dropped Server.setSessionIdManager: register it as a
+			// server bean instead — the SessionHandler resolves its manager
+			// from the server beans at startup, so ours (no scavenge thread)
+			// wins over the lazily-created default.
 			config.jetty.modifyServer(server -> {
 				try {
-					org.eclipse.jetty.server.session.DefaultSessionIdManager idMgr =
-						new org.eclipse.jetty.server.session.DefaultSessionIdManager(server);
-					org.eclipse.jetty.server.session.HouseKeeper hk =
-						new org.eclipse.jetty.server.session.HouseKeeper();
+					org.eclipse.jetty.session.DefaultSessionIdManager idMgr =
+						new org.eclipse.jetty.session.DefaultSessionIdManager(server);
+					org.eclipse.jetty.session.HouseKeeper hk =
+						new org.eclipse.jetty.session.HouseKeeper();
 					hk.setIntervalSec(0); // disabled — no scavenge thread
 					idMgr.setSessionHouseKeeper(hk);
-					server.setSessionIdManager(idMgr);
+					server.addBean(idMgr);
 				} catch (Exception e) {
 					log.warn("Failed to disable Jetty session housekeeper", e);
 				}
 			});
+
+			// Javalin 7: every handler (routes, before/after filters, exception
+			// mappers) must be registered via config.routes at create time —
+			// the Javalin instance no longer exposes per-verb registration.
+			addHandlers(config.routes);
 		});
-		
-		
-		app.exception(HttpResponseException.class, (e, ctx) -> {
+
+		return app;
+	}
+
+	/**
+	 * Registers all HTTP handlers on the routes configuration: exception
+	 * mappers, CORS preflight/after filters, the lattice-sync after filters,
+	 * auth middleware, and the login / API / WebDAV routes.
+	 */
+	private void addHandlers(RoutesConfig routes) {
+		final String corsOrigins = this.config.getCorsOrigins();
+		final boolean allowPrivateNetwork = this.config.isAllowPrivateNetwork();
+
+		routes.exception(HttpResponseException.class, (e, ctx) -> {
 			VenueServer.this.api.buildError(ctx,e.getStatus(),e.getMessage());
 		});
 
-		app.exception(Exception.class, (e, ctx) -> {
+		routes.exception(Exception.class, (e, ctx) -> {
 			log.error("Unhandled exception in {} {}", ctx.method(), ctx.path(), e);
 			String message = "Unexpected error: " + e;
 			ctx.result(message);
 			ctx.status(500);
 		});
-		
-		app.options("/api/*", ctx-> {
+
+		routes.options("/api/*", ctx-> {
 			ctx.status(204);
 			ctx.removeHeader("Content-type");
 			ctx.header("access-control-allow-headers", "content-type, authorization, x-covia-user");
@@ -448,9 +479,9 @@ public class VenueServer {
 			ctx.header("vary","Origin, Access-Control-Request-Headers");
 		});
 
-		// Use app.after (not afterMatched) so headers are added to ALL responses,
+		// Use after (not afterMatched) so headers are added to ALL responses,
 		// including CORS preflights handled by the Javalin CORS plugin
-		app.after(ctx->{
+		routes.after(ctx->{
 			ctx.header("access-control-allow-origin", corsOrigins);
 			// Private Network Access lets a public web origin reach a venue on a
 			// private/loopback address from the browser. Off by default — it
@@ -467,17 +498,21 @@ public class VenueServer {
 		// (/mcp), and A2A endpoints. Without this, MCP-driven writes
 		// (agent_create, covia_write, asset_store, etc.) live only in
 		// memory and are lost on shutdown — silently.
-		app.after("/api/*", ctx -> engine.syncState());
-		app.after("/mcp",   ctx -> engine.syncState());
-		app.after("/mcp/*", ctx -> engine.syncState());
-		app.after("/a2a",   ctx -> engine.syncState());
-		app.after("/a2a/*", ctx -> engine.syncState());
+		routes.after("/api/*", ctx -> engine.syncState());
+		routes.after("/mcp",   ctx -> engine.syncState());
+		routes.after("/mcp/*", ctx -> engine.syncState());
+		routes.after("/a2a",   ctx -> engine.syncState());
+		routes.after("/a2a/*", ctx -> engine.syncState());
 
+		// Auth middleware: before-handlers extracting caller identity.
+		AuthMiddleware.register(routes, engine.getAccountKey(), engine.getAuth(), engine.getDIDString());
 
-		return app;
+		addLoginRoutes(routes);
+		addAPIRoutes(routes);
+		mountDLFSWebDAV(routes);
 	}
-	
-	private void addLoginRoutes(Javalin app) {
+
+	private void addLoginRoutes(RoutesConfig app) {
 		if (!loginProviders.hasProviders()) return;
 
         // Login route for any provider
@@ -493,29 +528,22 @@ public class VenueServer {
 	}
 
 	protected void addOpenApiPlugins(JavalinConfig config) {
-		//String docsPath="/openapi-plugin/openapi-covia-v1.json";
-		
-		config.registerPlugin(new SwaggerPlugin(swaggerConfiguration->{
-			swaggerConfiguration.setDocumentationPath("/openapi");
-			//swaggerConfiguration.setDocumentationPath(docsPath);
-		}));
+		String docsPath = "/openapi";
 
 		config.registerPlugin(new OpenApiPlugin(pluginConfig -> {
-            pluginConfig
-            //.withDocumentationPath(docsPath)
-            .withDefinitionConfiguration((version, definition) -> {
-            	DefinitionConfiguration def=definition;
-                def=def.withInfo(
-                		info -> {
-							info.setTitle("Covia API");
-							info.setVersion("0.1.0");
-		                });
-            });
+			pluginConfig
+			.withDocumentationPath(docsPath)
+			.withDefinitionConfiguration((version, definition) -> {
+				definition.info(info -> {
+					info.title("Covia API");
+					info.version("0.1.0");
+				});
+			});
 		}));
 
-		//for (JsonSchemaResource generatedJsonSchema : new JsonSchemaLoader().loadGeneratedSchemes()) {
-	    //    System.out.println(generatedJsonSchema.getName());
-	    //}
+		config.registerPlugin(new SwaggerPlugin(swaggerConfiguration->{
+			swaggerConfiguration.documentationPath = docsPath;
+		}));
 	}
 
 	/**

--- a/venue/src/test/java/covia/venue/VenueServerTest.java
+++ b/venue/src/test/java/covia/venue/VenueServerTest.java
@@ -429,4 +429,34 @@ public class VenueServerTest {
 		assertTrue(caller.toString().endsWith(":public"),
 			"Anonymous caller DID should end with :public, got: " + caller);
 	}
+
+	/**
+	 * Catalog operation names contain slashes (e.g. "v/ops/jvm/string-concat")
+	 * and are percent-encoded into a single path segment by the client
+	 * ({@link VenueHTTP#getOperationId}): GET /api/v1/operations/v%2Fops%2F…
+	 * Jetty 12's default UriCompliance rejects %2F as an "ambiguous path
+	 * separator" (400) — Jetty 11 / Javalin's own connector allowed it. The
+	 * venue connector opts back in ({@code VenueServer.setupJettyServer}); this
+	 * test guards that config, so named catalog lookups — and the cross-venue
+	 * named references built on them — keep working after the Javalin 7 / Jetty
+	 * 12 upgrade. Regression guard for the upgrade; see RemoteAssetFetchTest /
+	 * RemoteOperationTest for the end-to-end cross-venue coverage.
+	 */
+	@Test
+	public void testEncodedSlashInCatalogNamePath() throws Exception {
+		String name = "v/ops/jvm/string-concat";
+		String encoded = java.net.URLEncoder.encode(name, java.nio.charset.StandardCharsets.UTF_8);
+		HttpClient client = HttpClient.newBuilder().build();
+		HttpRequest req = HttpRequest.newBuilder()
+			.uri(new URI("http://localhost:" + PORT + "/api/v1/operations/" + encoded))
+			.GET().timeout(Duration.ofSeconds(10)).build();
+		HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+		assertEquals(200, resp.statusCode(),
+			() -> "Encoded-slash catalog path must not be rejected as ambiguous: "
+				+ resp.statusCode() + " " + resp.body());
+		// The handler resolves the percent-decoded name to a content-addressed id.
+		ACell body = JSON.parse(resp.body());
+		assertNotNull(RT.getIn(body, "asset"),
+			"operations/{name} must return the resolved asset id for a slashed catalog name");
+	}
 }


### PR DESCRIPTION
## Summary

Convex 0.8.6 bumps Javalin 6.7.0 → 7.2.2 (Jetty 11 → 12), a breaking change for the venue server. This adopts it so covia stays in sync with the latest Convex release.

### Javalin 7 API migration
- `addRoutes(Javalin)` → `addRoutes(RoutesConfig)` across `CoviaAPI`, `A2A`, `UserAPI`, `CoviaWebApp`, `MCP`, `AuthMiddleware`.
- `VenueServer` registers all handlers via a single `addHandlers(routes)` call inside `Javalin.create()`; `start()` no longer wires routes/auth/login separately and `launch()` no longer mounts DLFS WebDAV post-start.
- DLFS WebDAV registers at create time but resolves the `dlfs` adapter **lazily per request** (it is registered later by `addDemoAssets`).
- OpenAPI uses the fluent `definition.info(...)` API; virtual threads move to `config.concurrency`; static-files `precompress` dropped.
- Jetty 12 relocated session classes and dropped `Server.setSessionIdManager` — the no-scavenge `SessionIdManager` is now registered as a server bean.

### Runtime fix: encoded slashes
Jetty 12's default `UriCompliance` rejects encoded slashes (`%2F`) as an ambiguous path separator, which broke percent-encoded catalog-name lookups (`GET /api/v1/operations/v%2Fops%2F…`) and the cross-venue named references built on them. The venue connector now opts back in via `UriCompliance`, matching Jetty 11 / Javalin's own connector.

## Tests
- New regression guard `VenueServerTest.testEncodedSlashInCatalogNamePath`.
- Full build green: **venue 1404 tests, 0 failures, 0 errors** (1 pre-existing skip); covia-core 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)