### PR TITLE
Upgrade a2a SDK to 1.0.0.Final

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ mvn test -pl covia-core
 | Javalin | 7.2.2 | HTTP server with OpenAPI/Swagger/ReDoc |
 | LangChain4j | 1.16.2 | LLM orchestration (OpenAI, Ollama, Gemini, DeepSeek) |
 | MCP SDK | 0.13.0 | Model Context Protocol |
-| A2A | 1.0.0.Beta1 | Agent-to-Agent protocol |
+| A2A | 1.0.0.Final | Agent-to-Agent protocol |
 | JUnit | 6.1.0 | Testing |
 | SLF4J/Logback | 2.0.17/1.5.18 | Logging |
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<javalin.version>7.2.2</javalin.version>
 		<langchain.version>1.16.2</langchain.version>
 		<mcp.version>0.13.0</mcp.version>
-		<a2a.version>1.0.0.Beta1</a2a.version>
+		<a2a.version>1.0.0.Final</a2a.version>
 	</properties>
 
 	<modules>

--- a/venue/pom.xml
+++ b/venue/pom.xml
@@ -141,7 +141,7 @@
 
 		<!-- A2A: Agent-to-Agent protocol. Official SDK used at the wire
 		     boundary (server parse/encode) and in the outbound A2AAdapter.
-		     Pre-1.0; pin exact version to avoid drift. -->
+		     Pin exact version to avoid drift. -->
 		<dependency>
 			<groupId>org.a2aproject.sdk</groupId>
 			<artifactId>a2a-java-sdk-spec</artifactId>

--- a/venue/src/main/java/covia/venue/api/A2ACodec.java
+++ b/venue/src/main/java/covia/venue/api/A2ACodec.java
@@ -141,8 +141,11 @@ public class A2ACodec {
 		String taskId = jobId.toHexString();
 		String contextId = extractContextId(jobData, taskId);
 		TaskStatus status = toTaskStatus(jobData);
-		boolean isFinal = status.state().isFinal();
-		return new TaskStatusUpdateEvent(taskId, status, contextId, isFinal, null);
+		// a2a 1.0.0.Final: TaskStatusUpdateEvent.isFinal() is derived from the
+		// status state (status.state().isFinal()), so the terminal flag is no
+		// longer a constructor argument — the canonical constructor is
+		// (taskId, status, contextId, metadata).
+		return new TaskStatusUpdateEvent(taskId, status, contextId, null);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Bumps the A2A SDK from `1.0.0.Beta1` to `1.0.0.Final`. The version-only dependabot PR (#126) failed to compile because `TaskStatusUpdateEvent`'s canonical constructor changed; this PR carries the bump **plus** the one-line API migration.

### API change
`TaskStatusUpdateEvent(taskId, status, contextId, isFinal, metadata)` → `TaskStatusUpdateEvent(taskId, status, contextId, metadata)`. The terminal flag is no longer a constructor argument — `isFinal()` is now derived internally as `status.state().isFinal()`, **identical** to the value covia computed and passed manually. So the SSE stream-end signal is behaviourally unchanged. `A2ACodec.toStatusUpdate` drops the now-redundant boolean.

Also refreshes the stale "Pre-1.0" pin comment in `venue/pom.xml` and the `AGENTS.md` dependency table.

## Tests
- Venue A2A suite green: `A2ACodecTest`, `A2AStreamingTest`, `A2ATest`, `A2AAdapterTest` — **41 tests, 0 failures** (streaming exercises the `isFinal` path).
- Full venue module compiles clean.

Supersedes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)