### PR TITLE
Upgrade MCP SDK to 2.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ mvn test -pl covia-core
 | Convex | 0.8.6 | Lattice platform, immutable data, cryptography |
 | Javalin | 7.2.2 | HTTP server with OpenAPI/Swagger/ReDoc |
 | LangChain4j | 1.16.2 | LLM orchestration (OpenAI, Ollama, Gemini, DeepSeek) |
-| MCP SDK | 0.13.0 | Model Context Protocol |
+| MCP SDK | 2.0.0 | Model Context Protocol |
 | A2A | 1.0.0.Final | Agent-to-Agent protocol |
 | JUnit | 6.1.0 | Testing |
 | SLF4J/Logback | 2.0.17/1.5.18 | Logging |

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<hc.version>5.5</hc.version>
 		<javalin.version>7.2.2</javalin.version>
 		<langchain.version>1.16.2</langchain.version>
-		<mcp.version>0.13.0</mcp.version>
+		<mcp.version>2.0.0</mcp.version>
 		<a2a.version>1.0.0.Final</a2a.version>
 	</properties>
 

--- a/venue/src/main/java/covia/adapter/MCPAdapter.java
+++ b/venue/src/main/java/covia/adapter/MCPAdapter.java
@@ -25,7 +25,6 @@ import covia.venue.RequestContext;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 
@@ -222,69 +221,27 @@ public class MCPAdapter extends AAdapter {
 	}
 	
 	/**
-	 * Converts MCP JsonSchema to Convex format
-	 * @param jsonSchema The MCP JsonSchema object
-	 * @return ACell representing the JSON schema in Convex format
+	 * Converts an MCP tool's input schema to Convex ACell format.
+	 *
+	 * <p>As of mcp 2.0 {@code Tool.inputSchema()} is a raw
+	 * {@code Map<String,Object>} holding the JSON Schema (earlier releases
+	 * exposed a typed {@code JsonSchema} record). We convert it generically,
+	 * which faithfully preserves the whole schema (type, properties, required,
+	 * {@code $defs}, {@code items}, descriptions, …) rather than copying a
+	 * hand-picked subset of fields.</p>
+	 *
+	 * @param inputSchema The tool's JSON Schema as a raw map (may be null/empty)
+	 * @return ACell representing the schema; a minimal object schema if absent
 	 */
-	private ACell getInputSchema(JsonSchema jsonSchema) {
+	private ACell getInputSchema(Map<String, Object> inputSchema) {
+		if (inputSchema == null || inputSchema.isEmpty()) {
+			return Maps.of(Fields.TYPE, Strings.create("object"));
+		}
 		try {
-			// Build the schema map from the record fields
-			AMap<AString, ACell> schemaMap = Maps.empty();
-			
-			// Add type if present
-			if (jsonSchema.type() != null) {
-				schemaMap = schemaMap.assoc(Fields.TYPE, Strings.create(jsonSchema.type()));
-			}
-
-			// Add properties if present
-			if (jsonSchema.properties() != null && !jsonSchema.properties().isEmpty()) {
-				AMap<AString, ACell> propertiesMap = Maps.empty();
-				for (Map.Entry<String, Object> entry : jsonSchema.properties().entrySet()) {
-					ACell value = convertToConvex(entry.getValue());
-					propertiesMap = propertiesMap.assoc(Strings.create(entry.getKey()), value);
-				}
-				schemaMap = schemaMap.assoc(Fields.PROPERTIES, propertiesMap);
-			}
-
-			// Add required fields if present
-			if (jsonSchema.required() != null && !jsonSchema.required().isEmpty()) {
-				AVector<AString> requiredVector = Vectors.empty();
-				for (String required : jsonSchema.required()) {
-					requiredVector = requiredVector.conj(Strings.create(required));
-				}
-				schemaMap = schemaMap.assoc(Fields.REQUIRED, requiredVector);
-			}
-
-			// Add additionalProperties if present
-			if (jsonSchema.additionalProperties() != null) {
-				schemaMap = schemaMap.assoc(Fields.ADDITIONAL_PROPERTIES, RT.cvm(jsonSchema.additionalProperties()));
-			}
-
-			// Add $defs if present
-			if (jsonSchema.defs() != null && !jsonSchema.defs().isEmpty()) {
-				AMap<AString, ACell> defsMap = Maps.empty();
-				for (Map.Entry<String, Object> entry : jsonSchema.defs().entrySet()) {
-					ACell value = convertToConvex(entry.getValue());
-					defsMap = defsMap.assoc(Strings.create(entry.getKey()), value);
-				}
-				schemaMap = schemaMap.assoc(Fields.DEFS, defsMap);
-			}
-
-			// Add definitions if present (legacy field)
-			if (jsonSchema.definitions() != null && !jsonSchema.definitions().isEmpty()) {
-				AMap<AString, ACell> definitionsMap = Maps.empty();
-				for (Map.Entry<String, Object> entry : jsonSchema.definitions().entrySet()) {
-					ACell value = convertToConvex(entry.getValue());
-					definitionsMap = definitionsMap.assoc(Strings.create(entry.getKey()), value);
-				}
-				schemaMap = schemaMap.assoc(Fields.DEFINITIONS, definitionsMap);
-			}
-			
-			return schemaMap;
-			
+			return convertToConvex(inputSchema);
 		} catch (Exception e) {
 			// If conversion fails, return a basic schema structure
-			log.warn("Failed to convert JsonSchema to Convex format: " + e.getMessage());
+			log.warn("Failed to convert tool input schema to Convex format: " + e.getMessage());
 			return Maps.of(
 				"type", "object",
 				"description", "Input parameters for the tool"

--- a/venue/src/main/java/covia/adapter/McpClientSession.java
+++ b/venue/src/main/java/covia/adapter/McpClientSession.java
@@ -58,9 +58,11 @@ public class McpClientSession implements AutoCloseable {
 	private McpSyncClient doConnect() throws Exception {
 		String mcpUrl = serverUrl.endsWith("/mcp") ? serverUrl : serverUrl + "/mcp";
 		McpClientTransport transport = HttpClientStreamableHttpTransport.builder(mcpUrl)
-				.customizeRequest(b -> {
+				// mcp 2.0 replaced customizeRequest(Consumer<HttpRequest.Builder>)
+				// with a synchronous request customizer invoked per request.
+				.httpRequestCustomizer((builder, method, endpoint, body, context) -> {
 					if (accessToken != null && !accessToken.isEmpty()) {
-						b.header("Authorization", "Bearer " + accessToken);
+						builder.header("Authorization", "Bearer " + accessToken);
 					}
 				})
 				.build();


### PR DESCRIPTION
## Summary
Bumps the MCP SDK from `0.13.0` to `2.0.0` (major). The version-only dependabot PR (#127) failed to compile; this PR carries the bump **plus** the API migration.

mcp 2.0 modularises the SDK (`mcp` = `mcp-core` + `mcp-json-jackson3`) and makes two breaking changes the venue relied on:

### 1. `Tool.inputSchema()` → raw `Map<String,Object>`
Previously a typed `McpSchema.JsonSchema` record. `MCPAdapter.getInputSchema` is rewritten to convert the schema map **generically** via the existing `convertToConvex`, which faithfully preserves the entire JSON Schema (type, properties, required, `$defs`, `items`, descriptions, …) rather than copying a hand-picked subset of top-level fields. Keeps a minimal `{"type":"object"}` fallback when absent. Net: ~55 lines of field-by-field extraction and the now-unused `JsonSchema` import removed.

### 2. Transport request customizer
`HttpClientStreamableHttpTransport.Builder.customizeRequest(Consumer<HttpRequest.Builder>)` → `httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)`, whose `customize(builder, method, endpoint, body, context)` runs per request. `McpClientSession.doConnect` adopts it; the `Authorization`-header injection behaviour is unchanged.

## Tests
- **Full venue suite green — 1404 tests, 0 failures** (1 pre-existing skip).
- `MCPTest` exercises the real mcp 2.0 streamable-HTTP client end-to-end against the venue's own `/mcp`: `initialize`, `listTools`, `listMCPTools` (covers the new `getInputSchema`), and `callMCPTool` over the wire with the new request customizer installed. The Jackson 3 wire path is therefore exercised at runtime.

Supersedes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)