### PR TITLE
Unit-test MCP client bearer-auth customizer

### DIFF
--- a/venue/src/main/java/covia/adapter/McpClientSession.java
+++ b/venue/src/main/java/covia/adapter/McpClientSession.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.spec.McpClientTransport;
 
 /**
@@ -55,16 +56,31 @@ public class McpClientSession implements AutoCloseable {
 		}
 	}
 
+	/**
+	 * Per-request customizer that attaches {@code Authorization: Bearer <token>}
+	 * to every outbound MCP HTTP request when a non-blank access token is
+	 * configured, and leaves the request untouched otherwise.
+	 *
+	 * <p>mcp 2.0 replaced {@code customizeRequest(Consumer<HttpRequest.Builder>)}
+	 * with {@link McpSyncHttpClientRequestCustomizer}, invoked per request.
+	 * Factored out (package-private) so the auth contract can be unit-tested
+	 * without opening a network connection — see {@code McpClientSessionTest}.</p>
+	 *
+	 * @param accessToken bearer token to attach; null/blank means no auth header
+	 * @return a request customizer applying the above rule
+	 */
+	static McpSyncHttpClientRequestCustomizer bearerAuthCustomizer(String accessToken) {
+		return (builder, method, endpoint, body, context) -> {
+			if (accessToken != null && !accessToken.isEmpty()) {
+				builder.header("Authorization", "Bearer " + accessToken);
+			}
+		};
+	}
+
 	private McpSyncClient doConnect() throws Exception {
 		String mcpUrl = serverUrl.endsWith("/mcp") ? serverUrl : serverUrl + "/mcp";
 		McpClientTransport transport = HttpClientStreamableHttpTransport.builder(mcpUrl)
-				// mcp 2.0 replaced customizeRequest(Consumer<HttpRequest.Builder>)
-				// with a synchronous request customizer invoked per request.
-				.httpRequestCustomizer((builder, method, endpoint, body, context) -> {
-					if (accessToken != null && !accessToken.isEmpty()) {
-						builder.header("Authorization", "Bearer " + accessToken);
-					}
-				})
+				.httpRequestCustomizer(bearerAuthCustomizer(accessToken))
 				.build();
 		client = McpClient.sync(transport)
 				.requestTimeout(Duration.ofSeconds(10))

--- a/venue/src/test/java/covia/adapter/McpClientSessionTest.java
+++ b/venue/src/test/java/covia/adapter/McpClientSessionTest.java
@@ -1,0 +1,53 @@
+package covia.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
+import io.modelcontextprotocol.common.McpTransportContext;
+
+/**
+ * Unit tests for {@link McpClientSession#bearerAuthCustomizer} — pure function
+ * tests, no network. They pin the outbound-auth contract: the customizer
+ * attaches {@code Authorization: Bearer <token>} iff a non-blank token is
+ * configured. This is the client-side half of MCP auth; the venue's server-side
+ * bearer handling is covered by OAuthTest / UCANBearerTransportTest.
+ */
+public class McpClientSessionTest {
+
+	private static final URI ENDPOINT = URI.create("http://venue.example/mcp");
+
+	/** Run the customizer over a fresh request builder and return the built request. */
+	private static HttpRequest customize(String token) {
+		HttpRequest.Builder builder = HttpRequest.newBuilder(ENDPOINT);
+		McpSyncHttpClientRequestCustomizer customizer = McpClientSession.bearerAuthCustomizer(token);
+		customizer.customize(builder, "POST", ENDPOINT, "{}", McpTransportContext.EMPTY);
+		return builder.build();
+	}
+
+	@Test
+	public void testAttachesBearerWhenTokenPresent() {
+		Optional<String> auth = customize("tok-123").headers().firstValue("Authorization");
+		assertTrue(auth.isPresent(), "Authorization header should be set when a token is configured");
+		assertEquals("Bearer tok-123", auth.get());
+	}
+
+	@Test
+	public void testNoAuthHeaderWhenTokenNull() {
+		assertFalse(customize(null).headers().firstValue("Authorization").isPresent(),
+			"No Authorization header should be added when token is null");
+	}
+
+	@Test
+	public void testNoAuthHeaderWhenTokenEmpty() {
+		assertFalse(customize("").headers().firstValue("Authorization").isPresent(),
+			"No Authorization header should be added when token is blank");
+	}
+}


### PR DESCRIPTION
## Summary
Closes the client-side MCP-auth test gap flagged in #156. The mcp 2.0 upgrade moved outbound `Authorization`-header injection into a per-request `httpRequestCustomizer`, but it lived as an anonymous lambda inside `doConnect()` with no coverage of the token branch (existing tests only connect with a `null` token).

- Extracts the customizer into a package-private factory `McpClientSession.bearerAuthCustomizer(token)` — a testable seam that also documents the contract. `doConnect()` delegates to it; behaviour is unchanged.
- Adds `McpClientSessionTest` asserting both branches: `Authorization: Bearer <token>` present when a token is set, absent when `null`/blank. Pure unit tests, no network — matches the `A2ACodecTest` style.

Server-side bearer handling stays covered by `OAuthTest` / `UCANBearerTransportTest`; this fills in the client half.

## Tests
- `McpClientSessionTest` — 3, new.
- `MCPTest` — 23, green (regression: still connects through the refactored `doConnect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)