### PR TITLE
feat(langchain): add Gemini, xAI, and DeepSeek as first-class LLM providers

### DIFF
--- a/venue/src/main/java/covia/adapter/LangChainAdapter.java
+++ b/venue/src/main/java/covia/adapter/LangChainAdapter.java
@@ -126,6 +126,7 @@ public class LangChainAdapter extends AAdapter {
 		installAsset("langchain/anthropic", "/adapters/langchain/anthropic.json");
 		installAsset("langchain/gemini",    "/adapters/langchain/gemini.json");
 		installAsset("langchain/xai",       "/adapters/langchain/xai.json");
+		installAsset("langchain/deepseek",  "/adapters/langchain/deepseek.json");
 
 		// Example configurations — stored in CAS, not in /v/ops/.
 		installExampleAsset("/asset-examples/qwen.json");   // langchain:ollama:qwen3
@@ -225,7 +226,8 @@ public class LangChainAdapter extends AAdapter {
 	// ========== Model construction ==========
 
 	static boolean providerNeedsApiKey(String provider) {
-		return "openai".equals(provider) || "anthropic".equals(provider) || "gemini".equals(provider);
+		return "openai".equals(provider) || "anthropic".equals(provider) || "gemini".equals(provider)
+			|| "xai".equals(provider) || "deepseek".equals(provider);
 	}
 
 	private ChatModel buildProviderModel(String provider, String modelName, String apiKey, AString urlParam) {
@@ -244,6 +246,14 @@ public class LangChainAdapter extends AAdapter {
 		} else if ("gemini".equals(provider)) {
 			String baseUrl = (urlParam != null) ? urlParam.toString() : "https://generativelanguage.googleapis.com/v1beta/openai/";
 			String model = (modelName != null) ? modelName : "gemini-2.5-flash";
+			return buildOpenAiModel(apiKey, baseUrl, model, IO_TIMEOUT);
+		} else if ("xai".equals(provider)) {
+			String baseUrl = (urlParam != null) ? urlParam.toString() : "https://api.x.ai/v1";
+			String model = (modelName != null) ? modelName : "grok-4";
+			return buildOpenAiModel(apiKey, baseUrl, model, IO_TIMEOUT);
+		} else if ("deepseek".equals(provider)) {
+			String baseUrl = (urlParam != null) ? urlParam.toString() : "https://api.deepseek.com/v1";
+			String model = (modelName != null) ? modelName : "deepseek-chat";
 			return buildOpenAiModel(apiKey, baseUrl, model, IO_TIMEOUT);
 		}
 		return null;

--- a/venue/src/main/java/covia/adapter/LangChainAdapter.java
+++ b/venue/src/main/java/covia/adapter/LangChainAdapter.java
@@ -124,6 +124,7 @@ public class LangChainAdapter extends AAdapter {
 		installAsset("langchain/openai",    "/adapters/langchain/openai.json");
 		installAsset("langchain/ollama",    "/adapters/langchain/ollama.json");
 		installAsset("langchain/anthropic", "/adapters/langchain/anthropic.json");
+		installAsset("langchain/gemini",    "/adapters/langchain/gemini.json");
 		installAsset("langchain/xai",       "/adapters/langchain/xai.json");
 
 		// Example configurations — stored in CAS, not in /v/ops/.
@@ -224,7 +225,7 @@ public class LangChainAdapter extends AAdapter {
 	// ========== Model construction ==========
 
 	static boolean providerNeedsApiKey(String provider) {
-		return "openai".equals(provider) || "anthropic".equals(provider);
+		return "openai".equals(provider) || "anthropic".equals(provider) || "gemini".equals(provider);
 	}
 
 	private ChatModel buildProviderModel(String provider, String modelName, String apiKey, AString urlParam) {
@@ -240,6 +241,10 @@ public class LangChainAdapter extends AAdapter {
 			String baseUrl = (urlParam != null) ? urlParam.toString() : "https://api.anthropic.com/v1/";
 			String model = (modelName != null) ? modelName : "claude-sonnet-4-6";
 			return buildAnthropicModel(apiKey, baseUrl, model, IO_TIMEOUT);
+		} else if ("gemini".equals(provider)) {
+			String baseUrl = (urlParam != null) ? urlParam.toString() : "https://generativelanguage.googleapis.com/v1beta/openai/";
+			String model = (modelName != null) ? modelName : "gemini-2.5-flash";
+			return buildOpenAiModel(apiKey, baseUrl, model, IO_TIMEOUT);
 		}
 		return null;
 	}

--- a/venue/src/main/resources/adapters/langchain/deepseek.json
+++ b/venue/src/main/resources/adapters/langchain/deepseek.json
@@ -6,7 +6,8 @@
 	"dateModified": "2025-09-16T00:00:00Z",
 	"keywords":["LLM", "model", "deepseek"],
 	"operation": {
-		"adapter": "langchain:openai",
+		"adapter": "langchain:deepseek",
+		"secretKey": "DEEPSEEK_API_KEY",
 		"secretFields": ["apiKey"],
 
 		"input":{

--- a/venue/src/main/resources/adapters/langchain/gemini.json
+++ b/venue/src/main/resources/adapters/langchain/gemini.json
@@ -6,7 +6,8 @@
 	"dateModified": "2025-09-16T00:00:00Z",
 	"keywords":["LLM", "model", "gemini"],
 	"operation": {
-		"adapter": "langchain:openai",
+		"adapter": "langchain:gemini",
+		"secretKey": "GOOGLE_API_KEY",
 		"secretFields": ["apiKey"],
 		"info":{
             "featured":true

--- a/venue/src/main/resources/adapters/langchain/xai.json
+++ b/venue/src/main/resources/adapters/langchain/xai.json
@@ -5,7 +5,7 @@
 	"dateCreated": "2026-04-15T00:00:00Z",
 	"keywords": ["LLM", "model", "xai", "grok"],
 	"operation": {
-		"adapter": "langchain:openai",
+		"adapter": "langchain:xai",
 		"secretFields": ["apiKey"],
 		"secretKey": "XAI_API_KEY",
 		"input": {


### PR DESCRIPTION
## Summary

- **Gemini** — installs `v/ops/langchain/gemini` with dedicated `langchain:gemini` provider case; default model `gemini-2.5-flash`; resolves `GOOGLE_API_KEY` from secret store; routes via Google's OpenAI-compatible endpoint (`generativelanguage.googleapis.com/v1beta/openai/`)
- **xAI (Grok)** — fixes `xai.json` adapter routing from `langchain:openai` → `langchain:xai`; adds dedicated provider case with default URL `api.x.ai/v1` and model `grok-4`; resolves `XAI_API_KEY`
- **DeepSeek** — was an uninstalled JSON stub; now installed as `v/ops/langchain/deepseek`; adds `secretKey: DEEPSEEK_API_KEY`; dedicated provider case with URL `api.deepseek.com/v1` and model `deepseek-chat`

All three use the existing `buildOpenAiModel` builder (OpenAI-compatible wire protocol) with provider-specific default URLs and secret keys, matching the pattern established by `langchain/anthropic` and `langchain/openai`.

## Files changed

- `venue/src/main/java/covia/adapter/LangChainAdapter.java` — install, routing, provider cases, key checks
- `venue/src/main/resources/adapters/langchain/gemini.json` — adapter + secretKey
- `venue/src/main/resources/adapters/langchain/xai.json` — adapter routing fix
- `venue/src/main/resources/adapters/langchain/deepseek.json` — secretKey + adapter routing fix

## Test plan

- [ ] Build passes (`mvn clean install`)
- [ ] `v/ops/langchain/gemini` resolves and calls Google endpoint with `GOOGLE_API_KEY`
- [ ] `v/ops/langchain/xai` resolves and calls xAI endpoint with `XAI_API_KEY`
- [ ] `v/ops/langchain/deepseek` resolves and calls DeepSeek endpoint with `DEEPSEEK_API_KEY`
- [ ] Missing key returns clear error (not a raw HTTP failure)
- [ ] Existing `openai`, `anthropic`, `ollama` operations unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)