### PR TITLE
fix(covia): check resolver canWrite before validateWritablePath in covia:write/delete/append

### DIFF
--- a/venue/src/main/java/covia/adapter/CoviaAdapter.java
+++ b/venue/src/main/java/covia/adapter/CoviaAdapter.java
@@ -583,16 +583,7 @@ public class CoviaAdapter extends AAdapter {
 	private ACell handleWrite(RequestContext ctx, ACell input) {
 		requireCap(ctx, input, Capability.CRUD_WRITE);
 		ACell[] jsonKeys = parsePath(RT.getIn(input, Fields.PATH));
-		if (!isWritableNamespace(jsonKeys)) validateWritablePath(jsonKeys);
-		// Per-call write authorisation for virtual namespaces (e.g. /v/
-		// requires the venue identity). Static isWritableNamespace doesn't
-		// know about the caller; canWrite(ctx) does.
-		if (jsonKeys.length > 0) {
-			NamespaceResolver resolver = resolvers.get(jsonKeys[0].toString());
-			if (resolver != null && !resolver.canWrite(ctx)) {
-				throw new RuntimeException("Write permission denied for namespace: " + jsonKeys[0]);
-			}
-		}
+		requireWriteAccess(ctx, jsonKeys);
 		// A write must supply a 'value'. An absent key means the caller (often an
 		// LLM tool call) forgot the argument — fail loudly so it retries with the
 		// value instead of silently creating a null entry. An explicit null is
@@ -656,7 +647,7 @@ public class CoviaAdapter extends AAdapter {
 	private ACell handleDelete(RequestContext ctx, ACell input) {
 		requireCap(ctx, input, Capability.CRUD_DELETE);
 		ACell[] jsonKeys = parsePath(RT.getIn(input, Fields.PATH));
-		if (!isWritableNamespace(jsonKeys)) validateWritablePath(jsonKeys);
+		requireWriteAccess(ctx, jsonKeys);
 
 		// Check job-scoped virtual namespace (t/)
 		NamespaceResolver.ResolvedNamespace vns = resolveVirtual(ctx, jsonKeys);
@@ -699,7 +690,7 @@ public class CoviaAdapter extends AAdapter {
 	private ACell handleAppend(RequestContext ctx, ACell input) {
 		requireCap(ctx, input, Capability.CRUD_WRITE);
 		ACell[] jsonKeys = parsePath(RT.getIn(input, Fields.PATH));
-		if (!isWritableNamespace(jsonKeys)) validateWritablePath(jsonKeys);
+		requireWriteAccess(ctx, jsonKeys);
 
 		// Cursor-based virtual (n/) or physical namespace
 		NamespaceResolver.ResolvedNamespace vns = resolveVirtual(ctx, jsonKeys);
@@ -768,6 +759,32 @@ public class CoviaAdapter extends AAdapter {
 				+ "Writable namespaces: w/ (workspace), o/ (operation pins); "
 				+ "n/ and t/ are writable within an agent or job run.");
 		}
+	}
+
+	/**
+	 * Checks that the caller has write access to the namespace addressed by
+	 * {@code jsonKeys}. Virtual namespaces with a registered {@link NamespaceResolver}
+	 * (e.g. {@code v/}, {@code n/}, {@code t/}) delegate auth to
+	 * {@link NamespaceResolver#canWrite(RequestContext)}; plain namespaces fall
+	 * back to the {@link #WRITABLE_NAMESPACES} allowlist ({@code w/}, {@code o/}).
+	 *
+	 * <p>Calling this before {@link #validateWritablePath} ensures that resolver-
+	 * managed namespaces (like {@code v/}) aren't blocked by the static allowlist
+	 * before their per-caller auth check can run.</p>
+	 *
+	 * @throws RuntimeException if the caller lacks write access
+	 */
+	private void requireWriteAccess(RequestContext ctx, ACell[] jsonKeys) {
+		if (jsonKeys.length > 0) {
+			NamespaceResolver resolver = resolvers.get(jsonKeys[0].toString());
+			if (resolver != null) {
+				if (!resolver.canWrite(ctx)) {
+					throw new RuntimeException("Write permission denied for namespace: " + jsonKeys[0]);
+				}
+				return;
+			}
+		}
+		if (!isWritableNamespace(jsonKeys)) validateWritablePath(jsonKeys);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #160

## Problem

Since the switch from `RequestContext.INTERNAL` to `engine.venueContext()` for startup writes, `materialiseVOps()` and `materialiseVenueInfo()` have silently been a no-op on every container restart.

### Root cause

`CoviaAdapter.handleWrite()` (and `handleDelete`, `handleAppend`) had this guard order:

```java
// 1. Called first — throws for any namespace not in {"w", "o"}
if (!isWritableNamespace(jsonKeys)) validateWritablePath(jsonKeys);

// 2. Never reached for v/ because (1) already threw
if (resolver != null && !resolver.canWrite(ctx)) {
    throw new RuntimeException("Write permission denied for namespace: " + jsonKeys[0]);
}
```

When `engine.venueContext()` calls `covia:write` with path `v/ops/langchain/gemini` (or `v/info/version`, etc.), step (1) throws `"Namespace 'v' is not writable"` before step (2) — the `VenueGlobalsResolver.canWrite(ctx)` check that is specifically designed to authorise writes from the venue's own DID — can run. The exception is caught inside `materialiseVOps()` / `writeVenueInfo()` and logged as a warning, so startup appears to succeed but nothing is written.

### Observable impact

- `v/ops/langchain/gemini` and `v/ops/langchain/deepseek` never appear in the lattice after PR #155–#158 deploys, even though `LangChainAdapter.installAssets()` correctly registers them in `pendingCatalogEntries`.
- `v/info/started`, `v/info/version`, `v/info/adapters/*` haven't updated since the last deploy that used the old `INTERNAL` context (2026-06-17).
- `venue-3.covia.ai` still reports `version: 0.0.2-SNAPSHOT` in the lattice despite the JAR being `0.2.1-SNAPSHOT`.

## Fix

Extract a `requireWriteAccess(ctx, jsonKeys)` helper that checks the registered `NamespaceResolver` **before** falling back to the static allowlist:

```java
private void requireWriteAccess(RequestContext ctx, ACell[] jsonKeys) {
    if (jsonKeys.length > 0) {
        NamespaceResolver resolver = resolvers.get(jsonKeys[0].toString());
        if (resolver != null) {
            // Virtual namespace (v/, n/, t/, c/) — resolver decides auth
            if (!resolver.canWrite(ctx)) {
                throw new RuntimeException("Write permission denied for namespace: " + jsonKeys[0]);
            }
            return;
        }
    }
    // Physical namespace — must be in WRITABLE_NAMESPACES (w/, o/)
    if (!isWritableNamespace(jsonKeys)) validateWritablePath(jsonKeys);
}
```

This is called instead of the inline checks in `handleWrite`, `handleDelete`, and `handleAppend`. `VenueGlobalsResolver.canWrite()` already implements the correct policy: allow if `callerDID.equals(venueDID)`, deny otherwise. Regular users still cannot write to `v/`.

## Test plan

- [ ] Deploy to venue-3, confirm `v/info/version` updates to `0.2.1-SNAPSHOT` on restart
- [ ] Confirm `v/ops/langchain/gemini` and `v/ops/langchain/deepseek` appear in the lattice
- [ ] Confirm regular-user writes to `v/` are still rejected (existing `CapabilityCheckerTest`)
- [ ] Confirm `w/` and `o/` writes still work for regular users

🤖 Generated with [Claude Code](https://claude.com/claude-code)