### PR TITLE
fix(deploy): stop systemd service and kill port-8080 containers before redeploy

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -40,9 +40,14 @@ jobs:
           # Pull latest image
           docker pull ghcr.io/covia-ai/covia:latest
 
-          # Stop and remove existing container
+          # Stop legacy systemd service if still present
+          sudo systemctl stop covia-venue.service 2>/dev/null || true
+
+          # Stop and remove existing container (by name, then any container still using port 8080)
           docker stop covia-venue 2>/dev/null || true
           docker rm covia-venue 2>/dev/null || true
+          docker ps -q --filter publish=8080 | xargs -r docker stop
+          docker ps -aq --filter publish=8080 | xargs -r docker rm
 
           # Run new container
           docker run -d \


### PR DESCRIPTION
## Summary
- Deploys to venue-3 were failing with `bind: address already in use` on port 8080
- Root cause: the legacy `covia-venue.service` systemd unit (or an orphaned Docker container from a prior failed deploy) still held port 8080 even after `docker stop covia-venue` succeeded
- Fix: stop the systemd unit first, then force-remove any container still publishing port 8080 before starting the new one

## Changes
- `deploy-ec2.yml`: stop `covia-venue.service` via systemctl before Docker stop; add fallback `docker ps --filter publish=8080 | xargs docker stop/rm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)