### PR TITLE
fix(deploy): reset data dir and write fresh config.json on EC2 deploy

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -49,6 +49,21 @@ jobs:
           docker ps -q --filter publish=8080 | xargs -r docker stop
           docker ps -aq --filter publish=8080 | xargs -r docker rm
 
+          # Reset data directory and write fresh config
+          rm -rf /home/ec2-user/covia-data
+          mkdir -p /home/ec2-user/covia-data
+          cat > /home/ec2-user/covia-data/config.json << 'COVIA_CONFIG'
+          {
+            "venues": [{
+              "name": "Covia Venue (EC2)",
+              "hostname": "venue-3.covia.ai",
+              "port": 8080,
+              "store": "/data/venue.etch",
+              "mcp": { "enabled": true }
+            }]
+          }
+          COVIA_CONFIG
+
           # Run new container
           docker run -d \
             --name covia-venue \

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -40,9 +40,14 @@ jobs:
           # Pull latest image
           docker pull ghcr.io/covia-ai/covia:latest
 
-          # Stop and remove existing container
+          # Stop legacy systemd service if still present
+          sudo systemctl stop covia-venue.service 2>/dev/null || true
+
+          # Stop and remove existing container (by name, then any container still using port 8080)
           docker stop covia-venue 2>/dev/null || true
           docker rm covia-venue 2>/dev/null || true
+          docker ps -q --filter publish=8080 | xargs -r docker stop
+          docker ps -aq --filter publish=8080 | xargs -r docker rm
 
           # Run new container
           docker run -d \


### PR DESCRIPTION
## Summary
- Venue was crash-looping: `Config file does not exist: /data/config.json`
- The data volume had no config (old systemd-based deploy used a different path)
- Fix: wipe the data directory on each deploy and write a fresh minimal `config.json` so the venue always boots cleanly with a known-good config
- Venue will regenerate its Etch store and identity key on first start

## Changes
- `deploy-ec2.yml`: `rm -rf /home/ec2-user/covia-data` + `mkdir` + write `config.json` before `docker run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)