### PR TITLE
fix(deploy): use printf instead of heredoc to avoid YAML parse error

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -52,17 +52,8 @@ jobs:
           # Reset data directory and write fresh config
           rm -rf /home/ec2-user/covia-data
           mkdir -p /home/ec2-user/covia-data
-          cat > /home/ec2-user/covia-data/config.json << 'COVIA_CONFIG'
-{
-  "venues": [{
-    "name": "Covia Venue (EC2)",
-    "hostname": "venue-3.covia.ai",
-    "port": 8080,
-    "store": "/data/venue.etch",
-    "mcp": { "enabled": true }
-  }]
-}
-COVIA_CONFIG
+          printf '{"venues":[{"name":"Covia Venue (EC2)","hostname":"venue-3.covia.ai","port":8080,"store":"/data/venue.etch","mcp":{"enabled":true}}]}\n' \
+            > /home/ec2-user/covia-data/config.json
           # Container runs as UID 1001 (appuser) — grant write access to data dir
           sudo chown -R 1001:1001 /home/ec2-user/covia-data
 


### PR DESCRIPTION
## Summary
- The heredoc (`<< 'COVIA_CONFIG'`) with content starting at column 0 broke YAML parsing — GitHub Actions couldn't load the workflow at all
- Replaced with `printf '...' > config.json` which stays within the indented block scalar

🤖 Generated with [Claude Code](https://claude.com/claude-code)