### PR TITLE
fix: prevent EtchStore data loss on deploy

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -65,6 +65,7 @@ jobs:
           # Run new container
           docker run -d \
             --name covia-venue \
+            --stop-timeout 30 \
             -p 8080:8080 \
             -v /home/azureuser/covia-data:/data \
             --restart unless-stopped \

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -49,17 +49,19 @@ jobs:
           docker ps -q --filter publish=8080 | xargs -r docker stop
           docker ps -aq --filter publish=8080 | xargs -r docker rm
 
-          # Reset data directory and write fresh config
-          rm -rf /home/ec2-user/covia-data
+          # Ensure data directory exists with correct config (preserve existing etch store)
           mkdir -p /home/ec2-user/covia-data
-          printf '{"venues":[{"name":"Covia Venue (EC2)","hostname":"venue-3.covia.ai","port":8080,"store":"/data/venue.etch","mcp":{"enabled":true}}]}\n' \
-            > /home/ec2-user/covia-data/config.json
+          if [ ! -f /home/ec2-user/covia-data/config.json ]; then
+            printf '{"venues":[{"name":"Covia Venue (EC2)","hostname":"venue-3.covia.ai","port":8080,"store":"/data/venue.etch","mcp":{"enabled":true}}]}\n' \
+              > /home/ec2-user/covia-data/config.json
+          fi
           # Container runs as UID 1001 (appuser) — grant write access to data dir
           sudo chown -R 1001:1001 /home/ec2-user/covia-data
 
           # Run new container
           docker run -d \
             --name covia-venue \
+            --stop-timeout 30 \
             -p 8080:8080 \
             -v /home/ec2-user/covia-data:/data \
             --log-driver=awslogs \

--- a/venue/src/main/java/covia/venue/MainVenue.java
+++ b/venue/src/main/java/covia/venue/MainVenue.java
@@ -19,6 +19,8 @@ import convex.core.data.AString;
 import convex.core.data.AVector;
 import convex.core.data.Maps;
 import convex.core.data.Vectors;
+import java.util.ArrayList;
+import java.util.List;
 import convex.core.lang.RT;
 import convex.core.util.FileUtils;
 import convex.core.util.JSON;
@@ -63,10 +65,18 @@ public class MainVenue {
 		}
 		
 		AVector<AMap<AString,ACell>> venues=RT.getIn(config, Fields.VENUES);
+		List<VenueServer> servers = new ArrayList<>();
 		for (AMap<AString,ACell> venueConfig: venues) {
-			@SuppressWarnings("unused")
-			VenueServer server=VenueServer.launch(venueConfig);
+			servers.add(VenueServer.launch(venueConfig));
 		}
+
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+			log.info("Shutdown signal received — closing {} venue(s)", servers.size());
+			for (VenueServer server : servers) {
+				try { server.close(); } catch (Exception e) { log.warn("Error closing venue", e); }
+			}
+			log.info("All venues closed");
+		}, "shutdown-hook"));
 	}
 	
 	private static void configureLogging(ACell config) throws JoranException, IOException {


### PR DESCRIPTION
## Summary

- **`deploy-ec2.yml`**: Removed `rm -rf covia-data` that was unconditionally deleting the entire etch store on every deploy. Now uses the same conditional config-write-if-missing pattern already used by Azure.
- **`deploy-ec2.yml` + `deploy-azure.yml`**: Added `--stop-timeout 30` to both `docker run` commands, giving the JVM 30 seconds to flush before Docker escalates to SIGKILL.
- **`MainVenue.java`**: Registered a JVM shutdown hook that calls `VenueServer.close()` on SIGTERM — triggering the engine's final synchronous EtchStore flush and `venueState` fork merge before the process exits.

## Root cause

Without the shutdown hook, `docker stop` (SIGTERM) caused the JVM to exit without flushing, leaving up to 10 s of writes unflushed. After the 10 s default timeout, Docker sent SIGKILL which could hit the EtchStore mid-write and corrupt the file. The `rm -rf` in the EC2 deploy then wiped the corrupted file (and all good data) on the next deploy.

## Test plan

- [x] Compile verified clean (`mvn compile -pl venue -am`)
- [x] `SoftKillPersistenceTest` — 7/7 tests pass (verifies `VenueServer.close()` flushes correctly across flushed writes, unflushed writes, burst writes, multiple restart cycles, stable DID)
- [x] `HardKillPersistenceTest` — 1/1 tests pass (verifies data survives hard kill via background sweep, etch file not corrupted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)