### PR TITLE
Add GET /api/v1/adapters — job-free adapter listing

### DIFF
--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -110,6 +110,7 @@ public class CoviaAPI extends ACoviaAPI {
 		routes.post(ROUTE+"invoke", this::invokeOperation);
 		routes.get(ROUTE+"operations", this::getOperations);
 		routes.get(ROUTE+"operations/{name}", this::getOperation);
+		routes.get(ROUTE+"adapters", this::getAdapters);
 		routes.get(ROUTE+"jobs/<id>", this::getJobStatus);
 		routes.post(ROUTE+"jobs/<id>", this::sendMessage);
 		routes.put(ROUTE+"jobs/<id>/cancel", this::cancelJob);
@@ -937,6 +938,25 @@ public class CoviaAPI extends ACoviaAPI {
 				}
 				result.add(opInfo);
 			}
+		}
+		buildResult(ctx, 200, result);
+	}
+
+	@OpenApi(path = ROUTE + "adapters",
+			methods = HttpMethod.GET,
+			tags = { "Covia"},
+			summary = "List all adapters registered on this venue.",
+			operationId = "getAdapters")
+	protected void getAdapters(Context ctx) {
+		ArrayList<Object> result = new ArrayList<>();
+		for (var name : engine().getAdapterNames()) {
+			AAdapter aa = engine().getAdapter(name);
+			if (aa == null) continue;
+			Map<String, Object> info = new HashMap<>();
+			info.put("name", name);
+			info.put("description", aa.getDescription());
+			info.put("operationCount", aa.pendingCatalogEntries.size());
+			result.add(info);
 		}
 		buildResult(ctx, 200, result);
 	}


### PR DESCRIPTION
Closes #189

## Summary
- Adds `GET /api/v1/adapters`, mirroring the existing `GET /api/v1/operations` idiom: a bare JSON array of every adapter registered on the venue, `{ name, description, operationCount }` per entry.
- Unconditionally public (no `requireCapability` call), consistent with `getOperations`/`getAssets`/`getStatus` — this is static venue-config data, not caller-scoped.
- `operationCount` is `adapter.pendingCatalogEntries.size()`, the same field `getOperations()` already iterates, so it stays internally consistent with the existing operations list.

## Why
Backend slice of [covia-ai/frontend#178](https://github.com/covia-ai/frontend/issues/178) part 1 (a venue subpage listing registered adapters). Today the only adapter listing is a server-rendered HTML page (`CoviaWebApp`'s `/adapters`), and the frontend's existing Operations-page adapter dropdown only *infers* adapter names from operation catalog paths — an adapter with zero catalog operations (or one that's configured but currently inactive) never shows up there. This endpoint gives the authoritative list straight from `engine.getAdapterNames()`.

The SDK (`covia-sdk`) and frontend changes (a new `venue.adapters.list()` method and a `/venues/[slug]/adapters` page) will follow in separate PRs once this merges.

## Test plan
- [x] `mvn test -pl venue -am` — all 1435 tests pass
- [x] Built and ran the venue locally (`local-dev.json`), confirmed `GET /api/v1/adapters` returns a bare array of all 24 registered adapters with `name`/`description`/`operationCount`
- [x] Cross-checked `operationCount` for `mcp` (2) against `GET /api/v1/operations` filtered to `v/ops/mcp/*` — matches exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)