### PR TITLE
ucan:issue as a granting surface (COG-17) + adversarial tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+- `ucan:issue` is a granting surface — mints over another principal's resource under a presented `grant/<ability>` right, expiry-capped by the right's validity
+
 ### Changed
 - Job lifecycle hardening — atomic updates, post-commit persistence, shutdown admission gate
 - Job polling improved — caller-side timeouts no longer fail jobs

--- a/venue/docs/UCAN.md
+++ b/venue/docs/UCAN.md
@@ -109,7 +109,13 @@ Resources are **DID URLs** — the DID identifies the authority (user/owner), th
 
 This aligns with `DIDURL` from convex-core — the DID is the authority, the path is the namespace scope.
 
-**Canonical vs. shorthand.** A `with` is always absolute (owner-named) as above. For convenience, Covia accepts a **bare** lattice path (`w/projects/foo`) as shorthand for the *caller's own* resource — this is how an agent's `caps` are written. Enforcement canonicalises it to the absolute form (`<callerDID>/w/projects/foo`) before matching, so a bare (own-namespace) grant and a DID-URL grant compare identically. The same applies to bare `dlfs/<drive>/…` paths. Only `file://…` resources are scheme-qualified (host-filesystem, not DID-scoped) and are left unchanged.
+**Canonical vs. shorthand.** A canonical `with` is absolute (owner-named) as above; a **bare** lattice path is shorthand whose owner is implied by context, always the same principal: **the authority whose grant it is**.
+
+- **Agent caps / self-attenuation ceilings**: a bare `w/projects/foo` is the *caller's own* resource; enforcement canonicalises it to `<callerDID>/w/projects/foo` before matching, so bare and DID-URL grants compare identically. The same applies to bare `dlfs/<drive>/…` paths.
+- **Signed UCAN tokens**: a bare `with` means the **token issuer's own** namespace, resolved at evaluation against the token's signed `iss` (`CapabilityChecker.normaliseProofs`, applied inside `proofsCover` recursively per chain hop — a bare path in a re-delegation binds to the re-delegator). A self-sovereign owner can therefore sign bare paths naturally; they can never be reinterpreted against the presenter or the target.
+- **Custodial issuance** (`ucan:issue`): the venue signs, so its `iss` is not the caller — bare paths are absolutised to the *caller's* DID before signing (§4.1). Tokens minted by the venue always carry the canonical form.
+
+Only `file://…` resources are scheme-qualified (host-filesystem, not DID-scoped) and are left unchanged; scheme forms are not issuable.
 
 ### 3.2 Abilities (`can`)
 
@@ -212,9 +218,26 @@ ucan:issue {
 }
 ```
 
-The venue signs the token with the caller's key (resolved from their DID)
+The venue signs the token with the **venue key pair** (the venue is the
+issuer — custodial attestation on the authenticated caller's instruction)
 and returns the complete signed token. The token is self-contained — it
 includes everything needed for verification.
+
+Resource rules at issuance (`UCANAdapter.handleIssue`):
+
+- A **bare** path (`/w/`, `w/projects/`) is absolutised to the *caller's*
+  DID before signing — in a venue-signed token a stored-bare path would
+  denote the venue's own namespace (§3.1). Empty paths and scheme forms
+  are rejected.
+- A DID URL in the **caller's own namespace** is issuable on root
+  authority — ownership is the authority.
+- A DID URL in **another principal's namespace** is issuable only under a
+  held **granting right** (COG-17): the caller's transport-presented
+  proofs must cover `grant/<can>` on the resource (proofs travel in the
+  proof channel, never in operation input), and the minted `exp` must not
+  outlive the enabling right (coverage is re-evaluated at the minted
+  expiry). This makes `ucan:issue` a *granting surface* — the `grant/…`
+  rule binds token production; chain resolution stays grant-agnostic.
 
 ### 4.2 Delivery
 
@@ -876,6 +899,17 @@ so there are no mode flags or auth fields anywhere:
 - Signature verification on every capability check
 - Time bounds (`exp`, `nbf`) enforced
 - Cross-user reads work when valid proof is presented
+
+### Phase C1c: Issuer-bound bare resources + granting surface ✓ (COG-17)
+
+- Bare `with` in signed tokens resolves against the token's `iss` at
+  evaluation (`normaliseProofs` in `proofsCover`, per chain hop)
+- `ucan:issue` absolutises bare paths to the caller DID before signing;
+  mints over another principal's resource only under a presented
+  `grant/<can>` granting right, with `exp` capped by the right's validity
+- `ucan:verify` canonicalises bare queried resources against the audience
+  so diagnostics match enforcement
+- Verification remains grant-agnostic — `grant/…` binds production only
 
 ### Phase C1b: Self-attenuation on the direct invoke path ✓ (#131)
 

--- a/venue/src/main/java/covia/adapter/UCANAdapter.java
+++ b/venue/src/main/java/covia/adapter/UCANAdapter.java
@@ -16,6 +16,7 @@ import convex.core.data.Vectors;
 import convex.core.data.prim.CVMLong;
 import convex.core.lang.RT;
 import covia.api.Fields;
+import covia.lattice.CapabilityChecker;
 import covia.venue.RequestContext;
 
 /**
@@ -96,10 +97,16 @@ public class UCANAdapter extends AAdapter {
 		// own resource and is qualified with the caller's DID before signing, so
 		// the token in the wild always carries the absolute form (verification
 		// never canonicalises — a bare `with` in a presented token is inert).
-		// Explicit DID URLs must lie within the caller's own namespace; scheme
-		// forms (file://, dlfs://) are not issuable — use the DID-scoped path form.
+		// Scheme forms (file://, dlfs://) are not issuable — use the DID-scoped
+		// path form. A DID URL outside the caller's namespace is issuable ONLY
+		// under a held GRANTING RIGHT (COG-17): the caller's presented proofs
+		// must cover grant/<can> on the resource. This is issuance as a granting
+		// surface — the grant/ rule binds token production, never resolution.
+		// Proofs travel in the transport proof channel (COG-15), never in
+		// operation input (input is persisted in job records).
 		AString callerDID = ctx.getCallerDID();
 		String callerPrefix = callerDID.toString() + "/";
+		long now = System.currentTimeMillis() / 1000;
 		AVector<ACell> canonAtt = Vectors.empty();
 		for (long i = 0; i < att.count(); i++) {
 			AMap<AString, ACell> cap = RT.castMap(att.get(i));
@@ -107,14 +114,34 @@ public class UCANAdapter extends AAdapter {
 			String w = (with != null) ? with.toString() : null;
 			if (cap == null || w == null || w.contains("://")) {
 				throw new RuntimeException("att[" + i + "].with must be a resource path — "
-					+ "bare (scoped to your own namespace, e.g. w/) or a DID URL in your "
-					+ "namespace (e.g. " + callerPrefix + "w/)");
+					+ "bare (scoped to your own namespace, e.g. w/) or a DID URL "
+					+ "(e.g. " + callerPrefix + "w/)");
+			}
+			AString can = RT.ensureString(cap.get(Capability.CAN));
+			if (can == null) {
+				throw new RuntimeException("att[" + i + "].can (ability) is required");
 			}
 			if (w.startsWith("did:")) {
 				if (!w.startsWith(callerPrefix)) {
-					throw new RuntimeException("att[" + i + "].with must be within your own "
-						+ "namespace (" + callerPrefix + "…) — you cannot issue grants over "
-						+ "another principal's resources");
+					// Held granting right: minting over another principal's resource
+					// requires proofs covering grant/<can> on it — and the minted
+					// authority must not outlive the granting right enabling it
+					// (checked by evaluating the same coverage at the minted expiry).
+					AString grantAbility = Strings.create("grant/" + can);
+					AString resource = Strings.create(w);
+					if (!CapabilityChecker.proofsCover(ctx.getProofs(), callerDID,
+							engine.getDIDString(), resource, grantAbility, now)) {
+						throw new RuntimeException("att[" + i + "].with is outside your namespace "
+							+ "and your presented proofs do not establish the granting right "
+							+ grantAbility + " over " + w + " — present a delegation from the "
+							+ "resource owner (transport ucans / bearer), or use your own namespace");
+					}
+					if (!CapabilityChecker.proofsCover(ctx.getProofs(), callerDID,
+							engine.getDIDString(), resource, grantAbility, exp - 1)) {
+						throw new RuntimeException("att[" + i + "]: exp exceeds the validity of the "
+							+ "granting right enabling this issuance — minted authority must not "
+							+ "outlive the right it was minted under; request a shorter exp");
+					}
 				}
 			} else {
 				String path = w.startsWith("/") ? w.substring(1) : w;
@@ -250,8 +277,13 @@ public class UCANAdapter extends AAdapter {
 		if (reqWith != null && reqCan != null) {
 			AString audience = RT.ensureString(RT.getIn(input, UCAN.AUD));
 			if (audience == null) audience = ctx.getCallerDID();
-			boolean authorises = covia.lattice.CapabilityChecker.proofsCover(
-				Vectors.of(token.toMap()), audience, venueDID, reqWith, reqCan, now);
+			// Canonicalise a bare queried resource against the audience — the
+			// same rule enforcement applies to a caller's bare paths — so the
+			// diagnostic answers match what enforcement would actually decide.
+			String canonWith = CapabilityChecker.canonicalResource(reqWith.toString(), audience);
+			boolean authorises = CapabilityChecker.proofsCover(
+				Vectors.of(token.toMap()), audience, venueDID,
+				Strings.create(canonWith), reqCan, now);
 			result = result.assoc(K_AUTHORISES, convex.core.data.prim.CVMBool.of(authorises));
 			result = result.assoc(K_AUDIENCE, audience);
 		}

--- a/venue/src/main/java/covia/lattice/CapabilityChecker.java
+++ b/venue/src/main/java/covia/lattice/CapabilityChecker.java
@@ -432,7 +432,7 @@ public class CapabilityChecker {
 	 * an absolute (token) grant and a bare (agent-config) grant match a bare
 	 * own-namespace operation the same way.</p>
 	 */
-	static String canonicalResource(String resource, AString ownerDID) {
+	public static String canonicalResource(String resource, AString ownerDID) {
 		if (resource == null || resource.isEmpty()) return resource;
 		if (resource.startsWith("did:")) return resource;   // already owner-qualified (DID URL)
 		// Legacy own-drive shorthand: "dlfs://<drive>/…" is accepted and normalised

--- a/venue/src/test/java/covia/venue/UCANTest.java
+++ b/venue/src/test/java/covia/venue/UCANTest.java
@@ -340,6 +340,212 @@ public class UCANTest {
 			"a bare-with grant binds to its issuer, not to the requested target");
 	}
 
+	// ========== Granting rights at issuance (COG-17) ==========
+	//
+	// grant/X binds token PRODUCTION: the issuance surface mints over another
+	// principal's resource only when the caller's presented proofs cover
+	// grant/<can> on it. Verification stays grant-agnostic.
+
+	/** Steward mints a read grant under a held granting right, end-to-end. */
+	@Test
+	public void testIssueWithGrantingRight() {
+		RequestContext CAROL = RequestContext.of(CAROL_DID);
+		engine.jobs().invokeOperation("v/ops/covia/write",
+			Maps.of(Fields.PATH, "w/shared/doc", Fields.VALUE, Strings.create("carol content")),
+			CAROL).awaitResult(5000);
+
+		long now = System.currentTimeMillis() / 1000;
+		UCAN grantRight = UCAN.create(CAROL_KP, UCAN.fromDIDKey(ALICE_DID), now + 2 * HOUR,
+			Vectors.of(Capability.create(
+				Strings.create(CAROL_DID + "/w/"), Strings.create("grant/crud/read"))),
+			Vectors.empty());
+
+		// Alice mints for Bob, inside the granting right's validity window.
+		Job issueJob = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/shared/"), Capability.CRUD_READ)),
+				UCAN.EXP, CVMLong.create(now + HOUR)),
+			withProofs(ALICE, grantRight.toMap()));
+		AString jwt = RT.ensureString(RT.getIn(issueJob.awaitResult(5000), "token"));
+		assertNotNull(jwt, "a held granting right must let the surface mint");
+
+		// End-to-end: Bob reads Carol's doc with the minted, chain-free token.
+		Job readJob = engine.jobs().invokeOperation("v/ops/covia/read",
+			Maps.of(Fields.PATH, CAROL_DID + "/w/shared/doc"),
+			withProofs(BOB, UCAN.fromJWT(jwt).toMap()));
+		assertEquals(Strings.create("carol content"),
+			RT.getIn(readJob.awaitResult(5000), "value"));
+	}
+
+	/** ADVERSARIAL: a USE right is not a granting right — holding crud/read
+	 *  does not let the surface mint crud/read for someone else. */
+	@Test
+	public void testIssueWithUseRightOnlyDenied() {
+		long now = System.currentTimeMillis() / 1000;
+		UCAN useRight = UCAN.create(CAROL_KP, UCAN.fromDIDKey(ALICE_DID), now + 2 * HOUR,
+			Vectors.of(Capability.create(
+				Strings.create(CAROL_DID + "/w/"), Capability.CRUD_READ)),
+			Vectors.empty());
+		Job job = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/shared/"), Capability.CRUD_READ)),
+				UCAN.EXP, CVMLong.create(now + HOUR)),
+			withProofs(ALICE, useRight.toMap()));
+		assertThrows(Exception.class, () -> job.awaitResult(5000),
+			"holding crud/read must not mint — grant/crud/read is required");
+	}
+
+	/** ADVERSARIAL: the granting right's resource scope binds — a right over
+	 *  w/shared/ cannot mint over w/private/. */
+	@Test
+	public void testIssueGrantingRightWrongResourceDenied() {
+		long now = System.currentTimeMillis() / 1000;
+		UCAN grantRight = UCAN.create(CAROL_KP, UCAN.fromDIDKey(ALICE_DID), now + 2 * HOUR,
+			Vectors.of(Capability.create(
+				Strings.create(CAROL_DID + "/w/shared/"), Strings.create("grant/crud/read"))),
+			Vectors.empty());
+		Job job = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/private/"), Capability.CRUD_READ)),
+				UCAN.EXP, CVMLong.create(now + HOUR)),
+			withProofs(ALICE, grantRight.toMap()));
+		assertThrows(Exception.class, () -> job.awaitResult(5000));
+	}
+
+	/** ADVERSARIAL: grant/crud/read mints exactly crud/read — not crud/write,
+	 *  and not another grant/crud/read (stewardship re-grant needs grant/grant/…). */
+	@Test
+	public void testIssueGrantingRightWrongAbilityDenied() {
+		long now = System.currentTimeMillis() / 1000;
+		UCAN grantRight = UCAN.create(CAROL_KP, UCAN.fromDIDKey(ALICE_DID), now + 2 * HOUR,
+			Vectors.of(Capability.create(
+				Strings.create(CAROL_DID + "/w/"), Strings.create("grant/crud/read"))),
+			Vectors.empty());
+
+		Job writeJob = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/"), Capability.CRUD_WRITE)),
+				UCAN.EXP, CVMLong.create(now + HOUR)),
+			withProofs(ALICE, grantRight.toMap()));
+		assertThrows(Exception.class, () -> writeJob.awaitResult(5000),
+			"grant/crud/read must not mint crud/write");
+
+		Job regrantJob = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/"), Strings.create("grant/crud/read"))),
+				UCAN.EXP, CVMLong.create(now + HOUR)),
+			withProofs(ALICE, grantRight.toMap()));
+		assertThrows(Exception.class, () -> regrantJob.awaitResult(5000),
+			"re-granting the granting right requires grant/grant/crud/read");
+	}
+
+	/** ADVERSARIAL: minted authority must not outlive the granting right that
+	 *  enables it — an exp beyond the right's validity is refused. */
+	@Test
+	public void testIssueOutlivingGrantingRightDenied() {
+		long now = System.currentTimeMillis() / 1000;
+		UCAN grantRight = UCAN.create(CAROL_KP, UCAN.fromDIDKey(ALICE_DID), now + HOUR,
+			Vectors.of(Capability.create(
+				Strings.create(CAROL_DID + "/w/"), Strings.create("grant/crud/read"))),
+			Vectors.empty());
+
+		Job longJob = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/"), Capability.CRUD_READ)),
+				UCAN.EXP, CVMLong.create(now + 2 * HOUR)),
+			withProofs(ALICE, grantRight.toMap()));
+		assertThrows(Exception.class, () -> longJob.awaitResult(5000),
+			"minted exp beyond the granting right's validity must be refused");
+
+		Job shortJob = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/"), Capability.CRUD_READ)),
+				UCAN.EXP, CVMLong.create(now + HOUR / 2)),
+			withProofs(ALICE, grantRight.toMap()));
+		assertNotNull(RT.getIn(shortJob.awaitResult(5000), "token"),
+			"an exp inside the granting right's validity must mint");
+	}
+
+	/** ADVERSARIAL: a "granting right" signed by a non-owner third party roots
+	 *  no authority — the surface must refuse to mint under it. */
+	@Test
+	public void testIssueThirdPartyGrantingRightDenied() {
+		long now = System.currentTimeMillis() / 1000;
+		// Bob (who does not own Carol's namespace) "grants" Alice a granting right over it.
+		UCAN rogue = UCAN.create(BOB_KP, UCAN.fromDIDKey(ALICE_DID), now + 2 * HOUR,
+			Vectors.of(Capability.create(
+				Strings.create(CAROL_DID + "/w/"), Strings.create("grant/crud/read"))),
+			Vectors.empty());
+		Job job = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/"), Capability.CRUD_READ)),
+				UCAN.EXP, CVMLong.create(now + HOUR)),
+			withProofs(ALICE, rogue.toMap()));
+		assertThrows(Exception.class, () -> job.awaitResult(5000),
+			"a third-party granting right must root nothing");
+	}
+
+	/** Recursion: grant/grant/crud/read appoints a steward (mints grant/crud/read),
+	 *  who can then mint reads — but the appointer cannot mint reads directly. */
+	@Test
+	public void testIssueRecursiveGrantingRight() {
+		RequestContext CAROL = RequestContext.of(CAROL_DID);
+		engine.jobs().invokeOperation("v/ops/covia/write",
+			Maps.of(Fields.PATH, "w/shared/doc", Fields.VALUE, Strings.create("carol content")),
+			CAROL).awaitResult(5000);
+
+		long now = System.currentTimeMillis() / 1000;
+		UCAN metaRight = UCAN.create(CAROL_KP, UCAN.fromDIDKey(ALICE_DID), now + 3 * HOUR,
+			Vectors.of(Capability.create(
+				Strings.create(CAROL_DID + "/w/"), Strings.create("grant/grant/crud/read"))),
+			Vectors.empty());
+
+		// grant/grant/crud/read does NOT cover grant/crud/read — no direct use-grants.
+		Job directJob = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/"), Capability.CRUD_READ)),
+				UCAN.EXP, CVMLong.create(now + HOUR)),
+			withProofs(ALICE, metaRight.toMap()));
+		assertThrows(Exception.class, () -> directJob.awaitResult(5000),
+			"grant/grant/crud/read must not mint crud/read directly");
+
+		// Appoint Bob as steward: mint grant/crud/read for him.
+		Job stewardJob = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, BOB_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/"), Strings.create("grant/crud/read"))),
+				UCAN.EXP, CVMLong.create(now + 2 * HOUR)),
+			withProofs(ALICE, metaRight.toMap()));
+		AString stewardJwt = RT.ensureString(RT.getIn(stewardJob.awaitResult(5000), "token"));
+		assertNotNull(stewardJwt, "the meta-right must appoint a steward");
+
+		// The steward mints a read for Dave, who then reads Carol's doc.
+		AKeyPair DAVE_KP = AKeyPair.generate();
+		AString DAVE_DID = UCAN.toDIDKey(DAVE_KP.getAccountKey());
+		Job daveGrantJob = engine.jobs().invokeOperation("v/ops/ucan/issue",
+			Maps.of(UCAN.AUD, DAVE_DID,
+				UCAN.ATT, Vectors.of(Capability.create(
+					Strings.create(CAROL_DID + "/w/shared/"), Capability.CRUD_READ)),
+				UCAN.EXP, CVMLong.create(now + HOUR)),
+			withProofs(BOB, UCAN.fromJWT(stewardJwt).toMap()));
+		AString daveJwt = RT.ensureString(RT.getIn(daveGrantJob.awaitResult(5000), "token"));
+
+		Job readJob = engine.jobs().invokeOperation("v/ops/covia/read",
+			Maps.of(Fields.PATH, CAROL_DID + "/w/shared/doc"),
+			withProofs(RequestContext.of(DAVE_DID), UCAN.fromJWT(daveJwt).toMap()));
+		assertEquals(Strings.create("carol content"),
+			RT.getIn(readJob.awaitResult(5000), "value"));
+	}
+
 	@Test
 	public void testCrossUserReadWithValidProof() {
 		AMap<AString, ACell> token = issueToken(BOB_DID, ALICE_DID, "/w/", "crud/read", 3600);


### PR DESCRIPTION
Implements COG-17's granting surface in `ucan:issue`, plus consistency fixes:

- **Granting surface**: a DID URL outside the caller's namespace mints iff transport-presented proofs cover `grant/<can>` on the resource; minted `exp` is capped by the enabling right's validity (coverage re-evaluated at expiry time). Proofs travel in the COG-15 proof channel, never operation input.
- **`ucan:verify`**: bare queried resources canonicalise against the audience, so diagnostics match enforcement.
- **Tests**: 7 new deterministic/adversarial cases — steward mint end-to-end, use-right ≠ granting right, wrong-resource/wrong-ability denials, minted-expiry-outliving-right boundary (both sides), third-party rogue right, and recursive stewardship (`grant/grant/crud/read` → appoint steward → steward mints → grantee reads).
- **UCAN.md**: §3.1 three-context bare-path rule, §4.1 corrected (venue signs with the venue key; issuance resource rules), Phase C1c entry.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
