### PR TITLE
HITL cleanliness: Hitl builders, pure validation module, slim adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 
 ### Added
 - HITL requests (COG-16) — `hitl:request`/`respond`/`list` over the per-user `h/` inbox, typed asks, choice-bound grants with echo-consent, restart-safe expiry; `hitl` skill
+- `Hitl` builders (covia-core) — fluent, transport-portable construction of HITL requests, asks and responses
 - `ucan:issue` is a granting surface — mints over another principal's resource under a presented `grant/<ability>` right, expiry-capped by the right's validity
 
 ### Changed

--- a/covia-core/src/main/java/covia/grid/hitl/Hitl.java
+++ b/covia-core/src/main/java/covia/grid/hitl/Hitl.java
@@ -1,0 +1,303 @@
+package covia.grid.hitl;
+
+import convex.core.data.ACell;
+import convex.core.data.AMap;
+import convex.core.data.AString;
+import convex.core.data.AVector;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+import convex.core.data.prim.CVMBool;
+import convex.core.data.prim.CVMLong;
+
+/**
+ * Human-in-the-Loop shapes (COG-16): the shared field vocabulary and fluent
+ * builders for HITL requests and responses.
+ *
+ * <p>A HITL flow is driven with three calls against any venue (local Engine or
+ * remote via the Grid API — the built maps are transport-portable JSON):</p>
+ *
+ * <pre>
+ * // 1. Request — returns a Job that parks INPUT_REQUIRED until the human acts
+ * Job job = venue.invoke("v/ops/hitl/request",
+ *     Hitl.request("Pay invoice INV-4711")
+ *         .description("Acme Ltd, £12,400, matched to PO-2231.")
+ *         .ask(Hitl.approval("pay", "Approve payment?").required()
+ *             .grant("w/payments/", "crud/read"))
+ *         .timeout(86400)
+ *         .build());
+ *
+ * // 2. Response — the inbox owner answers (or Hitl.reject(id, reason))
+ * venue.invoke("v/ops/hitl/respond",
+ *     Hitl.answer(requestId)
+ *         .answer("pay", true)
+ *         .echo("w/payments/", "crud/read")   // explicit grant consent
+ *         .comment("Approved for this invoice only")
+ *         .build());
+ *
+ * // 3. Completion — the requester's Job resolves
+ * ACell output = job.awaitResult();           // {id, outcome, answers, token?, ...}
+ * </pre>
+ *
+ * <p>Builders construct shapes only; all validation is venue-side at
+ * submission/response time, so a malformed build fails loudly at the venue,
+ * never silently.</p>
+ */
+public class Hitl {
+
+	// ========== Field names ==========
+
+	public static final AString ID          = Strings.intern("id");
+	public static final AString FROM        = Strings.intern("from");
+	public static final AString AGENT       = Strings.intern("agent");
+	public static final AString TITLE       = Strings.intern("title");
+	public static final AString DESCRIPTION = Strings.intern("description");
+	public static final AString ASKS        = Strings.intern("asks");
+	public static final AString STATUS      = Strings.intern("status");
+	public static final AString CREATED     = Strings.intern("created");
+	public static final AString EXPIRES     = Strings.intern("expires");
+	public static final AString RESPONSE    = Strings.intern("response");
+
+	public static final AString TYPE     = Strings.intern("type");
+	public static final AString PROMPT   = Strings.intern("prompt");
+	public static final AString OPTIONS  = Strings.intern("options");
+	public static final AString REQUIRED = Strings.intern("required");
+	public static final AString LABEL    = Strings.intern("label");
+	public static final AString GRANTS   = Strings.intern("grants");
+
+	public static final AString USER     = Strings.intern("user");
+	public static final AString TIMEOUT  = Strings.intern("timeout");
+	public static final AString OUTCOME  = Strings.intern("outcome");
+	public static final AString ANSWERS  = Strings.intern("answers");
+	public static final AString COMMENTS = Strings.intern("comments");
+	public static final AString COMMENT  = Strings.intern("comment");
+	public static final AString TOKEN    = Strings.intern("token");
+	public static final AString ITEMS    = Strings.intern("items");
+	public static final AString COUNT    = Strings.intern("count");
+
+	public static final AString WITH = Strings.intern("with");
+	public static final AString CAN  = Strings.intern("can");
+	public static final AString EXP  = Strings.intern("exp");
+
+	// ========== Record statuses ==========
+
+	public static final AString OPEN      = Strings.intern("open");
+	public static final AString ANSWERED  = Strings.intern("answered");
+	public static final AString REJECTED  = Strings.intern("rejected");
+	public static final AString EXPIRED   = Strings.intern("expired");
+	public static final AString CANCELLED = Strings.intern("cancelled");
+
+	// ========== Ask types ==========
+
+	public static final AString TEXT       = Strings.intern("text");
+	public static final AString APPROVAL   = Strings.intern("approval");
+	public static final AString CHOICE     = Strings.intern("choice");
+	public static final AString CHECKBOXES = Strings.intern("checkboxes");
+
+	// ========== Outcomes ==========
+
+	public static final AString ANSWER = Strings.intern("answer");
+	public static final AString REJECT = Strings.intern("reject");
+
+	private Hitl() {}
+
+	// ========== Entry points ==========
+
+	/** Starts a request to the caller's own user (an agent asking its owner). */
+	public static RequestBuilder request(String title) {
+		return new RequestBuilder(title);
+	}
+
+	public static AskBuilder text(String id, String prompt)       { return new AskBuilder(id, TEXT, prompt); }
+	public static AskBuilder approval(String id, String prompt)   { return new AskBuilder(id, APPROVAL, prompt); }
+	public static AskBuilder choice(String id, String prompt)     { return new AskBuilder(id, CHOICE, prompt); }
+	public static AskBuilder checkboxes(String id, String prompt) { return new AskBuilder(id, CHECKBOXES, prompt); }
+
+	/** A capability grant offer {with, can} — bare paths mean the responder's own namespace. */
+	public static AMap<AString, ACell> grant(String with, String can) {
+		return Maps.of(WITH, Strings.create(with), CAN, Strings.create(can));
+	}
+
+	/** A grant offer with an explicit expiry (unix seconds). */
+	public static AMap<AString, ACell> grant(String with, String can, long exp) {
+		return grant(with, can).assoc(EXP, CVMLong.create(exp));
+	}
+
+	/** Starts an {@code answer} response for a request in the caller's inbox. */
+	public static ResponseBuilder answer(String requestId) {
+		return new ResponseBuilder(requestId, ANSWER);
+	}
+
+	/** A complete {@code reject} response — the comment is the reason the requester sees. */
+	public static AMap<AString, ACell> reject(String requestId, String comment) {
+		AMap<AString, ACell> m = Maps.of(ID, Strings.create(requestId), OUTCOME, REJECT);
+		if (comment != null) m = m.assoc(COMMENT, Strings.create(comment));
+		return m;
+	}
+
+	// ========== Builders ==========
+
+	/** Builds a {@code hitl:request} input. */
+	public static class RequestBuilder {
+		private AMap<AString, ACell> map;
+		private AVector<ACell> asks = Vectors.empty();
+
+		private RequestBuilder(String title) {
+			map = Maps.of(TITLE, Strings.create(title));
+		}
+
+		/** Targets another user's inbox (requires a hitl/request delegation from them). */
+		public RequestBuilder to(String userDID) {
+			map = map.assoc(USER, Strings.create(userDID));
+			return this;
+		}
+
+		/** Markdown context — the human sees only the record, so include everything. */
+		public RequestBuilder description(String markdown) {
+			map = map.assoc(DESCRIPTION, Strings.create(markdown));
+			return this;
+		}
+
+		public RequestBuilder ask(AskBuilder ask) {
+			return ask(ask.build());
+		}
+
+		public RequestBuilder ask(AMap<AString, ACell> ask) {
+			asks = asks.conj(ask);
+			return this;
+		}
+
+		/** Seconds until the request expires (Job FAILED, record 'expired'). */
+		public RequestBuilder timeout(long seconds) {
+			map = map.assoc(TIMEOUT, CVMLong.create(seconds));
+			return this;
+		}
+
+		public AMap<AString, ACell> build() {
+			return map.assoc(ASKS, asks);
+		}
+	}
+
+	/** Builds one typed ask. */
+	public static class AskBuilder {
+		private AMap<AString, ACell> map;
+		private AVector<ACell> options = Vectors.empty();
+		private AVector<ACell> grants = Vectors.empty();
+
+		private AskBuilder(String id, AString type, String prompt) {
+			map = Maps.of(ID, Strings.create(id), TYPE, type, PROMPT, Strings.create(prompt));
+		}
+
+		/** An {@code answer} outcome must answer this ask. */
+		public AskBuilder required() {
+			map = map.assoc(REQUIRED, CVMBool.TRUE);
+			return this;
+		}
+
+		/** Clients should offer a free-text comment alongside the answer. */
+		public AskBuilder allowComment() {
+			map = map.assoc(COMMENT, CVMBool.TRUE);
+			return this;
+		}
+
+		/** Offers a grant conferred if this (approval) ask is approved. */
+		public AskBuilder grant(String with, String can) {
+			return grant(Hitl.grant(with, can));
+		}
+
+		public AskBuilder grant(AMap<AString, ACell> grant) {
+			grants = grants.conj(grant);
+			return this;
+		}
+
+		/** Adds a selectable option (choice/checkboxes). */
+		public AskBuilder option(String id, String label) {
+			options = options.conj(Maps.of(ID, Strings.create(id), LABEL, Strings.create(label)));
+			return this;
+		}
+
+		/** Adds an option that confers a grant when selected. */
+		public AskBuilder option(String id, String label, AMap<AString, ACell> grant) {
+			options = options.conj(Maps.of(
+				ID, Strings.create(id), LABEL, Strings.create(label),
+				GRANTS, Vectors.of((ACell) grant)));
+			return this;
+		}
+
+		public AMap<AString, ACell> build() {
+			AMap<AString, ACell> m = map;
+			if (options.count() > 0) m = m.assoc(OPTIONS, options);
+			if (grants.count() > 0) m = m.assoc(GRANTS, grants);
+			return m;
+		}
+	}
+
+	/** Builds a {@code hitl:respond} input for an {@code answer} outcome. */
+	public static class ResponseBuilder {
+		private AMap<AString, ACell> map;
+		private AMap<AString, ACell> answers = Maps.empty();
+		private AMap<AString, ACell> comments = Maps.empty();
+		private AVector<ACell> echoed = Vectors.empty();
+
+		private ResponseBuilder(String requestId, AString outcome) {
+			map = Maps.of(ID, Strings.create(requestId), OUTCOME, outcome);
+		}
+
+		/** Answers an approval ask. */
+		public ResponseBuilder answer(String askId, boolean approved) {
+			answers = answers.assoc(Strings.create(askId), CVMBool.of(approved));
+			return this;
+		}
+
+		/** Answers a text ask, or a choice ask by option id. */
+		public ResponseBuilder answer(String askId, String value) {
+			answers = answers.assoc(Strings.create(askId), Strings.create(value));
+			return this;
+		}
+
+		/** Answers a checkboxes ask with the selected option ids. */
+		public ResponseBuilder select(String askId, String... optionIds) {
+			AVector<ACell> ids = Vectors.empty();
+			for (String o : optionIds) ids = ids.conj(Strings.create(o));
+			answers = answers.assoc(Strings.create(askId), ids);
+			return this;
+		}
+
+		/** Raw answer form, for anything the typed overloads don't cover. */
+		public ResponseBuilder answerRaw(String askId, ACell value) {
+			answers = answers.assoc(Strings.create(askId), value);
+			return this;
+		}
+
+		/** Per-ask free-text comment. */
+		public ResponseBuilder commentOn(String askId, String text) {
+			comments = comments.assoc(Strings.create(askId), Strings.create(text));
+			return this;
+		}
+
+		/** Overall comment. */
+		public ResponseBuilder comment(String text) {
+			map = map.assoc(COMMENT, Strings.create(text));
+			return this;
+		}
+
+		/** Echoes an offered grant the responder explicitly approves — without an
+		 *  echo, nothing is conferred; an echo that was not offered-and-triggered
+		 *  fails the response. */
+		public ResponseBuilder echo(String with, String can) {
+			return echo(Hitl.grant(with, can));
+		}
+
+		public ResponseBuilder echo(AMap<AString, ACell> grant) {
+			echoed = echoed.conj(grant);
+			return this;
+		}
+
+		public AMap<AString, ACell> build() {
+			AMap<AString, ACell> m = map.assoc(ANSWERS, answers);
+			if (comments.count() > 0) m = m.assoc(COMMENTS, comments);
+			if (echoed.count() > 0) m = m.assoc(GRANTS, echoed);
+			return m;
+		}
+	}
+}

--- a/venue/src/main/java/covia/adapter/HITLAdapter.java
+++ b/venue/src/main/java/covia/adapter/HITLAdapter.java
@@ -1,7 +1,5 @@
 package covia.adapter;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -10,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import convex.auth.ucan.Capability;
 import convex.core.data.ACell;
 import convex.core.data.AMap;
 import convex.core.data.AString;
@@ -19,12 +16,13 @@ import convex.core.data.Blob;
 import convex.core.data.Maps;
 import convex.core.data.Strings;
 import convex.core.data.Vectors;
-import convex.core.data.prim.CVMBool;
 import convex.core.data.prim.CVMLong;
 import convex.core.lang.RT;
+import covia.adapter.hitl.HitlValidation;
 import covia.exception.AuthException;
 import covia.grid.Job;
 import covia.grid.Status;
+import covia.grid.hitl.Hitl;
 import covia.lattice.CapabilityChecker;
 import covia.venue.RequestContext;
 import covia.venue.User;
@@ -48,68 +46,17 @@ import covia.venue.User;
  *       {@code h/}).</li>
  * </ul>
  *
- * <p>Delivery into another user's inbox is a cross-user act gated by the
- * {@code hitl/request} ability on {@code <target>/h/} — checked against the
- * caller's ceiling and, cross-user, their presented proofs. Records are
- * venue-mediated: {@code h/} is not writable via {@code covia:write}, so
- * {@code from} is always the verified caller identity.</p>
- *
- * <p>Grants ride explicit choices only (approval asks and options). On an
- * {@code answer} outcome the response must ECHO the grants it approves; the
- * venue issues exactly the intersection of echoed and offered-and-triggered,
- * via {@code ucan:issue} under the responder's own authority (the granting
- * surface, COG-17).</p>
+ * <p>This adapter owns authorisation, persistence and job control only. The
+ * domain rules — ask/answer validation and the echo-consent grant intersection
+ * — live in {@link HitlValidation} (pure, engine-free); the shared field
+ * vocabulary and client builders live in {@link Hitl} (covia-core). The clean
+ * drive is: {@code hitl:request} (Job parks {@code INPUT_REQUIRED}) →
+ * {@code hitl:respond} by the inbox owner → Job completes with the response
+ * (or fails on reject/expiry).</p>
  */
 public class HITLAdapter extends AAdapter {
 
 	private static final Logger log = LoggerFactory.getLogger(HITLAdapter.class);
-
-	// ========== Record field keys ==========
-
-	static final AString K_ID          = Strings.intern("id");
-	static final AString K_FROM        = Strings.intern("from");
-	static final AString K_AGENT       = Strings.intern("agent");
-	static final AString K_TITLE       = Strings.intern("title");
-	static final AString K_DESCRIPTION = Strings.intern("description");
-	static final AString K_ASKS        = Strings.intern("asks");
-	static final AString K_STATUS      = Strings.intern("status");
-	static final AString K_CREATED     = Strings.intern("created");
-	static final AString K_EXPIRES     = Strings.intern("expires");
-	static final AString K_RESPONSE    = Strings.intern("response");
-
-	// Ask / option fields
-	static final AString K_TYPE     = Strings.intern("type");
-	static final AString K_PROMPT   = Strings.intern("prompt");
-	static final AString K_OPTIONS  = Strings.intern("options");
-	static final AString K_REQUIRED = Strings.intern("required");
-	static final AString K_LABEL    = Strings.intern("label");
-	static final AString K_GRANTS   = Strings.intern("grants");
-
-	// Request / response fields
-	static final AString K_USER     = Strings.intern("user");
-	static final AString K_TIMEOUT  = Strings.intern("timeout");
-	static final AString K_OUTCOME  = Strings.intern("outcome");
-	static final AString K_ANSWERS  = Strings.intern("answers");
-	static final AString K_COMMENTS = Strings.intern("comments");
-	static final AString K_COMMENT  = Strings.intern("comment");
-	static final AString K_TOKEN    = Strings.intern("token");
-	static final AString K_ITEMS    = Strings.intern("items");
-	static final AString K_COUNT    = Strings.intern("count");
-
-	// Record statuses
-	static final AString S_OPEN      = Strings.intern("open");
-	static final AString S_ANSWERED  = Strings.intern("answered");
-	static final AString S_REJECTED  = Strings.intern("rejected");
-	static final AString S_EXPIRED   = Strings.intern("expired");
-	static final AString S_CANCELLED = Strings.intern("cancelled");
-
-	// Ask types / outcomes
-	static final AString T_TEXT       = Strings.intern("text");
-	static final AString T_APPROVAL   = Strings.intern("approval");
-	static final AString T_CHOICE     = Strings.intern("choice");
-	static final AString T_CHECKBOXES = Strings.intern("checkboxes");
-	static final AString O_ANSWER = Strings.intern("answer");
-	static final AString O_REJECT = Strings.intern("reject");
 
 	/** Delivery ability for cross-user asks: {@code hitl/request} on {@code <target>/h/}. */
 	public static final AString ABILITY_HITL_REQUEST = Strings.intern("hitl/request");
@@ -179,77 +126,84 @@ public class HITLAdapter extends AAdapter {
 		handleRequest(job, ctx, input); // throws -> JobManager fails the job
 	}
 
-	// ========== hitl:request ==========
+	// ========== hitl:request — validate, authorise, deliver, park ==========
 
-	@SuppressWarnings("unchecked")
 	private void handleRequest(Job job, RequestContext ctx, ACell input) {
 		AString caller = ctx.getCallerDID();
 		if (caller == null) throw new AuthException("Authentication required for HITL requests");
 
-		AString target = RT.ensureString(RT.getIn(input, K_USER));
+		AString target = RT.ensureString(RT.getIn(input, Hitl.USER));
 		if (target == null) target = caller;
-
-		AString title = RT.ensureString(RT.getIn(input, K_TITLE));
+		AString title = RT.ensureString(RT.getIn(input, Hitl.TITLE));
 		if (title == null) throw new IllegalArgumentException("title is required");
-		AVector<ACell> asks = validateAsks(RT.getIn(input, K_ASKS));
+		AVector<ACell> asks = HitlValidation.validateAsks(RT.getIn(input, Hitl.ASKS));
+		Long timeoutSecs = parseTimeout(RT.getIn(input, Hitl.TIMEOUT));
 
-		// Delivery authorisation: a self-ask is always permitted; delivering into
-		// ANOTHER user's inbox requires hitl/request on <target>/h/ — checked
-		// against the caller's ceiling AND (cross-user) their presented proofs.
-		if (!target.equals(caller)) {
-			AString resource = Strings.create(target + "/h/");
-			ctx.requireCapability(resource, ABILITY_HITL_REQUEST);
-			long now = System.currentTimeMillis() / 1000;
-			if (!CapabilityChecker.proofsCover(ctx.getProofs(), caller, engine.getDIDString(),
-					resource, ABILITY_HITL_REQUEST, now)) {
-				throw new AuthException("HITL delivery denied: requires " + ABILITY_HITL_REQUEST
-					+ " on " + resource + " — present a delegation from the target user "
-					+ "(transport ucans / bearer)");
-			}
-		}
+		requireDeliverable(ctx, caller, target);
 
+		// Build and deliver the record (venue-mediated: `from` is the verified
+		// caller, and h/ is not writable via covia:write), then park the Job.
 		long nowMs = System.currentTimeMillis();
 		AString id = Strings.create(job.getID().toHexString());
-		AMap<AString, ACell> record = Maps.of(
-			K_ID, id,
-			K_FROM, caller,
-			K_TITLE, title,
-			K_ASKS, asks,
-			K_STATUS, S_OPEN,
-			K_CREATED, CVMLong.create(nowMs));
-		AString description = RT.ensureString(RT.getIn(input, K_DESCRIPTION));
-		if (description != null) record = record.assoc(K_DESCRIPTION, description);
-		AString agentId = ctx.getAgentId();
-		if (agentId != null) record = record.assoc(K_AGENT, agentId);
+		AMap<AString, ACell> record = buildRecord(id, caller, ctx.getAgentId(), title,
+			RT.ensureString(RT.getIn(input, Hitl.DESCRIPTION)), asks, nowMs, timeoutSecs);
 
-		Long timeoutSecs = null;
-		ACell timeoutCell = RT.getIn(input, K_TIMEOUT);
-		if (timeoutCell != null) {
-			CVMLong t = RT.ensureLong(timeoutCell);
-			if (t == null || t.longValue() <= 0) {
-				throw new IllegalArgumentException("timeout must be a positive number of seconds");
-			}
-			timeoutSecs = t.longValue();
-			record = record.assoc(K_EXPIRES, CVMLong.create(nowMs + timeoutSecs * 1000));
-		}
-
-		// Venue-mediated delivery into the target's inbox, then park the Job.
 		final AString targetDID = target;
 		engine.getVenueState().users().ensure(targetDID).putHitlRequest(id, record);
 		Blob jobId = job.getID();
-		job.setCancelHook(() -> markResolved(targetDID, id, S_CANCELLED, null));
+		job.setCancelHook(() -> markResolved(targetDID, id, Hitl.CANCELLED, null));
 		job.setStatus(Status.INPUT_REQUIRED);
 		if (timeoutSecs != null) scheduleExpiry(targetDID, id, jobId, timeoutSecs * 1000);
 		log.info("HITL request {} delivered to {} (from {})", id, targetDID, caller);
 	}
 
-	// ========== hitl:respond ==========
+	/** A self-ask is always permitted; delivering into ANOTHER user's inbox
+	 *  requires hitl/request on {@code <target>/h/} — checked against the
+	 *  caller's ceiling AND (cross-user) their presented proofs. */
+	private void requireDeliverable(RequestContext ctx, AString caller, AString target) {
+		if (target.equals(caller)) return;
+		AString resource = Strings.create(target + "/h/");
+		ctx.requireCapability(resource, ABILITY_HITL_REQUEST);
+		long now = System.currentTimeMillis() / 1000;
+		if (!CapabilityChecker.proofsCover(ctx.getProofs(), caller, engine.getDIDString(),
+				resource, ABILITY_HITL_REQUEST, now)) {
+			throw new AuthException("HITL delivery denied: requires " + ABILITY_HITL_REQUEST
+				+ " on " + resource + " — present a delegation from the target user "
+				+ "(transport ucans / bearer)");
+		}
+	}
+
+	private static AMap<AString, ACell> buildRecord(AString id, AString from, AString agentId,
+			AString title, AString description, AVector<ACell> asks, long nowMs, Long timeoutSecs) {
+		AMap<AString, ACell> record = Maps.of(
+			Hitl.ID, id,
+			Hitl.FROM, from,
+			Hitl.TITLE, title,
+			Hitl.ASKS, asks,
+			Hitl.STATUS, Hitl.OPEN,
+			Hitl.CREATED, CVMLong.create(nowMs));
+		if (description != null) record = record.assoc(Hitl.DESCRIPTION, description);
+		if (agentId != null) record = record.assoc(Hitl.AGENT, agentId);
+		if (timeoutSecs != null) record = record.assoc(Hitl.EXPIRES, CVMLong.create(nowMs + timeoutSecs * 1000));
+		return record;
+	}
+
+	private static Long parseTimeout(ACell timeoutCell) {
+		if (timeoutCell == null) return null;
+		CVMLong t = RT.ensureLong(timeoutCell);
+		if (t == null || t.longValue() <= 0) {
+			throw new IllegalArgumentException("timeout must be a positive number of seconds");
+		}
+		return t.longValue();
+	}
+
+	// ========== hitl:respond — resolve record and job ==========
 
 	@SuppressWarnings("unchecked")
 	private ACell handleRespond(RequestContext ctx, ACell input) {
 		AString caller = ctx.getCallerDID();
 		if (caller == null) throw new AuthException("Authentication required");
-		AString id = RT.ensureString(RT.getIn(input, K_ID));
+		AString id = RT.ensureString(RT.getIn(input, Hitl.ID));
 		if (id == null) throw new IllegalArgumentException("id is required");
 
 		// Structural authorisation: respond reads the CALLER's own inbox only.
@@ -258,61 +212,72 @@ public class HITLAdapter extends AAdapter {
 		if (record == null) {
 			throw new IllegalArgumentException("No HITL request " + id + " in your inbox");
 		}
-		if (!S_OPEN.equals(record.get(K_STATUS))) {
+		if (!Hitl.OPEN.equals(record.get(Hitl.STATUS))) {
 			throw new IllegalStateException("HITL request " + id + " is not open (status: "
-				+ record.get(K_STATUS) + ")");
+				+ record.get(Hitl.STATUS) + ")");
 		}
 		// Lazy expiry: a due-but-untriggered timer (e.g. lost on restart before
 		// re-arm) must not let an expired request be answered.
-		CVMLong expires = RT.ensureLong(record.get(K_EXPIRES));
+		CVMLong expires = RT.ensureLong(record.get(Hitl.EXPIRES));
 		if (expires != null && System.currentTimeMillis() > expires.longValue()) {
 			expireRequest(caller, id, Blob.parse(id.toString()));
 			throw new IllegalStateException("HITL request " + id + " has expired");
 		}
 
-		AString outcome = RT.ensureString(RT.getIn(input, K_OUTCOME));
-		if (!O_ANSWER.equals(outcome) && !O_REJECT.equals(outcome)) {
-			throw new IllegalArgumentException("outcome must be 'answer' or 'reject'");
-		}
-		AString comment = RT.ensureString(RT.getIn(input, K_COMMENT));
+		AString outcome = RT.ensureString(RT.getIn(input, Hitl.OUTCOME));
+		AString comment = RT.ensureString(RT.getIn(input, Hitl.COMMENT));
 		Job job = engine.jobs().getJob(Blob.parse(id.toString()));
-
-		if (O_REJECT.equals(outcome)) {
-			AMap<AString, ACell> response = Maps.of(K_OUTCOME, O_REJECT);
-			if (comment != null) response = response.assoc(K_COMMENT, comment);
-			user.putHitlRequest(id, record.assoc(K_STATUS, S_REJECTED).assoc(K_RESPONSE, response));
-			if (job != null && !job.isFinished()) {
-				job.fail("HITL request rejected" + (comment != null ? ": " + comment : ""));
-			}
-			return Maps.of(K_ID, id, K_STATUS, S_REJECTED);
+		if (Hitl.REJECT.equals(outcome)) {
+			return resolveReject(user, id, record, comment, job);
 		}
+		if (Hitl.ANSWER.equals(outcome)) {
+			return resolveAnswer(user, id, record, input, comment, job);
+		}
+		throw new IllegalArgumentException("outcome must be 'answer' or 'reject'");
+	}
 
-		// outcome == answer: validate against the asks, collecting triggered offers.
-		AVector<ACell> asks = (AVector<ACell>) RT.getIn(record, K_ASKS);
-		ACell answersCell = RT.getIn(input, K_ANSWERS);
+	private ACell resolveReject(User user, AString id, AMap<AString, ACell> record,
+			AString comment, Job job) {
+		AMap<AString, ACell> response = Maps.of(Hitl.OUTCOME, Hitl.REJECT);
+		if (comment != null) response = response.assoc(Hitl.COMMENT, comment);
+		user.putHitlRequest(id, record.assoc(Hitl.STATUS, Hitl.REJECTED).assoc(Hitl.RESPONSE, response));
+		if (job != null && !job.isFinished()) {
+			// The reason must travel in the job error — the requester cannot
+			// read the responder's inbox.
+			job.fail("HITL request rejected" + (comment != null ? ": " + comment : ""));
+		}
+		return Maps.of(Hitl.ID, id, Hitl.STATUS, Hitl.REJECTED);
+	}
+
+	@SuppressWarnings("unchecked")
+	private ACell resolveAnswer(User user, AString id, AMap<AString, ACell> record,
+			ACell input, AString comment, Job job) {
+		AVector<ACell> asks = (AVector<ACell>) RT.getIn(record, Hitl.ASKS);
+		ACell answersCell = RT.getIn(input, Hitl.ANSWERS);
 		AMap<AString, ACell> answers = (answersCell instanceof AMap)
 			? (AMap<AString, ACell>) answersCell : Maps.empty();
-		AVector<ACell> triggered = validateAnswers(asks, answers);
 
-		// Echo-consent: issue exactly the intersection of echoed and triggered.
-		AVector<ACell> approved = intersectEchoedGrants(RT.getIn(input, K_GRANTS), triggered);
+		// Domain rules: validate answers, compute triggered offers, then the
+		// echo-consent intersection — all pure (HitlValidation).
+		AVector<ACell> triggered = HitlValidation.validateAnswers(asks, answers);
+		AVector<ACell> approved = HitlValidation.intersectEchoedGrants(RT.getIn(input, Hitl.GRANTS), triggered);
 		AString token = (approved.count() > 0)
-			? issueGrants(caller, RT.ensureString(record.get(K_FROM)), approved)
+			? issueGrants(user.getDID(), RT.ensureString(record.get(Hitl.FROM)), approved)
 			: null;
 
-		AMap<AString, ACell> response = Maps.of(K_OUTCOME, O_ANSWER, K_ANSWERS, answers);
-		ACell comments = RT.getIn(input, K_COMMENTS);
-		if (comments instanceof AMap) response = response.assoc(K_COMMENTS, comments);
-		if (comment != null) response = response.assoc(K_COMMENT, comment);
-		if (approved.count() > 0) response = response.assoc(K_GRANTS, approved);
-		user.putHitlRequest(id, record.assoc(K_STATUS, S_ANSWERED).assoc(K_RESPONSE, response));
+		AMap<AString, ACell> response = Maps.of(Hitl.OUTCOME, Hitl.ANSWER, Hitl.ANSWERS, answers);
+		ACell comments = RT.getIn(input, Hitl.COMMENTS);
+		if (comments instanceof AMap) response = response.assoc(Hitl.COMMENTS, comments);
+		if (comment != null) response = response.assoc(Hitl.COMMENT, comment);
+		if (approved.count() > 0) response = response.assoc(Hitl.GRANTS, approved);
+		user.putHitlRequest(id, record.assoc(Hitl.STATUS, Hitl.ANSWERED).assoc(Hitl.RESPONSE, response));
 
 		if (job != null && !job.isFinished()) {
-			AMap<AString, ACell> output = response.assoc(K_ID, id);
-			if (token != null) output = output.assoc(K_TOKEN, token);
+			AMap<AString, ACell> output = response.assoc(Hitl.ID, id);
+			if (token != null) output = output.assoc(Hitl.TOKEN, token);
 			job.completeWith(output);
 		}
-		return Maps.of(K_ID, id, K_STATUS, S_ANSWERED);
+		return Maps.of(Hitl.ID, id, Hitl.STATUS, Hitl.ANSWERED);
 	}
 
 	/** Issues the approved grants as a single token via the granting surface
@@ -323,16 +288,16 @@ public class HITLAdapter extends AAdapter {
 		long now = System.currentTimeMillis() / 1000;
 		long exp = now + DEFAULT_GRANT_LIFETIME_SECS;
 		for (long i = 0; i < approved.count(); i++) {
-			CVMLong g = RT.ensureLong(RT.getIn(approved.get(i), Strings.intern("exp")));
+			CVMLong g = RT.ensureLong(RT.getIn(approved.get(i), Hitl.EXP));
 			if (g != null && g.longValue() > now && g.longValue() < exp) exp = g.longValue();
 		}
 		try {
 			ACell result = engine.jobs().invokeInternal("v/ops/ucan/issue",
 				Maps.of(Strings.intern("aud"), requester,
 					Strings.intern("att"), approved,
-					Strings.intern("exp"), CVMLong.create(exp)),
+					Hitl.EXP, CVMLong.create(exp)),
 				RequestContext.of(responder)).get(30, TimeUnit.SECONDS);
-			AString token = RT.ensureString(RT.getIn(result, K_TOKEN));
+			AString token = RT.ensureString(RT.getIn(result, Hitl.TOKEN));
 			if (token == null) throw new IllegalStateException("ucan:issue returned no token");
 			return token;
 		} catch (RuntimeException e) {
@@ -349,216 +314,24 @@ public class HITLAdapter extends AAdapter {
 	private ACell handleList(RequestContext ctx, ACell input) {
 		AString caller = ctx.getCallerDID();
 		if (caller == null) throw new AuthException("Authentication required");
-		AString filter = RT.ensureString(RT.getIn(input, K_STATUS));
+		AString filter = RT.ensureString(RT.getIn(input, Hitl.STATUS));
 		AMap<AString, ACell> all = engine.getVenueState().users().ensure(caller).getHitlRequests();
 		AVector<ACell> items = Vectors.empty();
 		for (long i = 0; i < all.count(); i++) {
 			ACell v = all.entryAt(i).getValue();
 			if (!(v instanceof AMap)) continue;
 			AMap<AString, ACell> rec = (AMap<AString, ACell>) v;
-			if (filter != null && !filter.equals(rec.get(K_STATUS))) continue;
+			if (filter != null && !filter.equals(rec.get(Hitl.STATUS))) continue;
 			AMap<AString, ACell> summary = Maps.of(
-				K_ID, rec.get(K_ID),
-				K_FROM, rec.get(K_FROM),
-				K_TITLE, rec.get(K_TITLE),
-				K_STATUS, rec.get(K_STATUS),
-				K_CREATED, rec.get(K_CREATED));
-			if (rec.get(K_EXPIRES) != null) summary = summary.assoc(K_EXPIRES, rec.get(K_EXPIRES));
+				Hitl.ID, rec.get(Hitl.ID),
+				Hitl.FROM, rec.get(Hitl.FROM),
+				Hitl.TITLE, rec.get(Hitl.TITLE),
+				Hitl.STATUS, rec.get(Hitl.STATUS),
+				Hitl.CREATED, rec.get(Hitl.CREATED));
+			if (rec.get(Hitl.EXPIRES) != null) summary = summary.assoc(Hitl.EXPIRES, rec.get(Hitl.EXPIRES));
 			items = items.conj(summary);
 		}
-		return Maps.of(K_ITEMS, items, K_COUNT, CVMLong.create(items.count()));
-	}
-
-	// ========== Validation ==========
-
-	private static final Set<String> ASK_TYPES = Set.of("text", "approval", "choice", "checkboxes");
-
-	/** Validates the asks at submission (COG-16): ids unique, types known,
-	 *  options present/unique where required, grants only on approval asks and
-	 *  options. Throws IllegalArgumentException — no record, no parked job. */
-	@SuppressWarnings("unchecked")
-	static AVector<ACell> validateAsks(ACell asksCell) {
-		if (!(asksCell instanceof AVector) || ((AVector<ACell>) asksCell).count() == 0) {
-			throw new IllegalArgumentException("asks must be a non-empty array");
-		}
-		AVector<ACell> asks = (AVector<ACell>) asksCell;
-		Set<String> ids = new HashSet<>();
-		for (long i = 0; i < asks.count(); i++) {
-			AMap<AString, ACell> ask = RT.castMap(asks.get(i));
-			if (ask == null) throw new IllegalArgumentException("asks[" + i + "] must be an object");
-			AString id = RT.ensureString(ask.get(K_ID));
-			AString type = RT.ensureString(ask.get(K_TYPE));
-			AString prompt = RT.ensureString(ask.get(K_PROMPT));
-			if (id == null || !ids.add(id.toString())) {
-				throw new IllegalArgumentException("asks[" + i + "].id is required and must be unique");
-			}
-			if (type == null || !ASK_TYPES.contains(type.toString())) {
-				throw new IllegalArgumentException("asks[" + i + "].type must be one of " + ASK_TYPES);
-			}
-			if (prompt == null) throw new IllegalArgumentException("asks[" + i + "].prompt is required");
-			boolean optionType = T_CHOICE.equals(type) || T_CHECKBOXES.equals(type);
-			ACell optionsCell = ask.get(K_OPTIONS);
-			if (optionType) {
-				if (!(optionsCell instanceof AVector) || ((AVector<ACell>) optionsCell).count() == 0) {
-					throw new IllegalArgumentException("asks[" + i + "].options must be a non-empty array");
-				}
-				Set<String> optionIds = new HashSet<>();
-				AVector<ACell> options = (AVector<ACell>) optionsCell;
-				for (long j = 0; j < options.count(); j++) {
-					AMap<AString, ACell> opt = RT.castMap(options.get(j));
-					AString optId = (opt != null) ? RT.ensureString(opt.get(K_ID)) : null;
-					if (opt == null || optId == null || !optionIds.add(optId.toString())) {
-						throw new IllegalArgumentException("asks[" + i + "].options[" + j
-							+ "] must be an object with a unique id");
-					}
-					validateGrantList(opt.get(K_GRANTS), "asks[" + i + "].options[" + j + "]");
-				}
-			} else if (optionsCell != null) {
-				throw new IllegalArgumentException("asks[" + i + "]: options only apply to choice/checkboxes");
-			}
-			// Grants attach ONLY where an explicit choice confers them:
-			// approval asks and options (validated above). Nowhere else.
-			ACell grants = ask.get(K_GRANTS);
-			if (grants != null && !T_APPROVAL.equals(type)) {
-				throw new IllegalArgumentException("asks[" + i + "]: grants only attach to approval "
-					+ "asks and options — a grant must be the consequence of an explicit choice");
-			}
-			validateGrantList(grants, "asks[" + i + "]");
-		}
-		return asks;
-	}
-
-	private static void validateGrantList(ACell grantsCell, String where) {
-		if (grantsCell == null) return;
-		if (!(grantsCell instanceof AVector)) {
-			throw new IllegalArgumentException(where + ".grants must be an array");
-		}
-		AVector<ACell> grants = (AVector<ACell>) grantsCell;
-		for (long i = 0; i < grants.count(); i++) {
-			AMap<AString, ACell> g = RT.castMap(grants.get(i));
-			if (g == null || RT.ensureString(g.get(Capability.WITH)) == null
-					|| RT.ensureString(g.get(Capability.CAN)) == null) {
-				throw new IllegalArgumentException(where + ".grants[" + i + "] must be {with, can, exp?}");
-			}
-		}
-	}
-
-	/** Validates the answers against the asks; returns the OFFERED grants that
-	 *  the choices actually triggered (approved approval asks, selected options). */
-	@SuppressWarnings("unchecked")
-	static AVector<ACell> validateAnswers(AVector<ACell> asks, AMap<AString, ACell> answers) {
-		AVector<ACell> triggered = Vectors.empty();
-		Set<String> askIds = new HashSet<>();
-		for (long i = 0; i < asks.count(); i++) {
-			AMap<AString, ACell> ask = (AMap<AString, ACell>) asks.get(i);
-			AString askId = RT.ensureString(ask.get(K_ID));
-			askIds.add(askId.toString());
-			AString type = RT.ensureString(ask.get(K_TYPE));
-			ACell answer = answers.get(askId);
-			if (answer == null) {
-				if (CVMBool.TRUE.equals(ask.get(K_REQUIRED))) {
-					throw new IllegalArgumentException("required ask '" + askId + "' is unanswered");
-				}
-				continue;
-			}
-			if (T_TEXT.equals(type)) {
-				if (RT.ensureString(answer) == null) {
-					throw new IllegalArgumentException("answer for '" + askId + "' must be a string");
-				}
-			} else if (T_APPROVAL.equals(type)) {
-				if (!(answer instanceof CVMBool)) {
-					throw new IllegalArgumentException("answer for '" + askId + "' must be a boolean");
-				}
-				if (CVMBool.TRUE.equals(answer)) {
-					triggered = appendGrants(triggered, ask.get(K_GRANTS));
-				}
-			} else { // choice / checkboxes
-				AVector<ACell> options = (AVector<ACell>) ask.get(K_OPTIONS);
-				if (T_CHOICE.equals(type)) {
-					AMap<AString, ACell> opt = findOption(options, RT.ensureString(answer));
-					if (opt == null) {
-						throw new IllegalArgumentException("answer for '" + askId + "' must name an option id");
-					}
-					triggered = appendGrants(triggered, opt.get(K_GRANTS));
-				} else {
-					if (!(answer instanceof AVector)) {
-						throw new IllegalArgumentException("answer for '" + askId + "' must be an array of option ids");
-					}
-					Set<String> seen = new HashSet<>();
-					AVector<ACell> selected = (AVector<ACell>) answer;
-					for (long j = 0; j < selected.count(); j++) {
-						AString optId = RT.ensureString(selected.get(j));
-						AMap<AString, ACell> opt = findOption(options, optId);
-						if (opt == null || !seen.add(optId.toString())) {
-							throw new IllegalArgumentException("answer for '" + askId
-								+ "' contains an unknown or duplicate option id");
-						}
-						triggered = appendGrants(triggered, opt.get(K_GRANTS));
-					}
-				}
-			}
-		}
-		// Unknown answer keys are an error — answers bind to asks, exactly.
-		for (long i = 0; i < answers.count(); i++) {
-			AString key = RT.ensureString(answers.entryAt(i).getKey());
-			if (key == null || !askIds.contains(key.toString())) {
-				throw new IllegalArgumentException("answers contains unknown ask id: " + key);
-			}
-		}
-		return triggered;
-	}
-
-	@SuppressWarnings("unchecked")
-	private static AMap<AString, ACell> findOption(AVector<ACell> options, AString optId) {
-		if (optId == null || options == null) return null;
-		for (long i = 0; i < options.count(); i++) {
-			AMap<AString, ACell> opt = (AMap<AString, ACell>) options.get(i);
-			if (optId.equals(opt.get(K_ID))) return opt;
-		}
-		return null;
-	}
-
-	private static AVector<ACell> appendGrants(AVector<ACell> acc, ACell grantsCell) {
-		if (!(grantsCell instanceof AVector)) return acc;
-		AVector<ACell> grants = (AVector<ACell>) grantsCell;
-		for (long i = 0; i < grants.count(); i++) acc = acc.conj(grants.get(i));
-		return acc;
-	}
-
-	/** Echo-consent (COG-16): the venue issues exactly the intersection of the
-	 *  ECHOED grants and the offers actually TRIGGERED by the choices made. An
-	 *  echoed grant that was not offered-and-triggered fails the response. The
-	 *  issued capability is always the OFFER's own map (with/can/exp as offered),
-	 *  matched by {with, can} equality. */
-	static AVector<ACell> intersectEchoedGrants(ACell echoedCell, AVector<ACell> triggered) {
-		if (echoedCell == null) return Vectors.empty();
-		if (!(echoedCell instanceof AVector)) {
-			throw new IllegalArgumentException("grants must be an array of {with, can} capabilities");
-		}
-		AVector<ACell> echoed = (AVector<ACell>) echoedCell;
-		AVector<ACell> approved = Vectors.empty();
-		for (long i = 0; i < echoed.count(); i++) {
-			AMap<AString, ACell> e = RT.castMap(echoed.get(i));
-			AString with = (e != null) ? RT.ensureString(e.get(Capability.WITH)) : null;
-			AString can = (e != null) ? RT.ensureString(e.get(Capability.CAN)) : null;
-			ACell match = null;
-			if (with != null && can != null) {
-				for (long j = 0; j < triggered.count(); j++) {
-					ACell offer = triggered.get(j);
-					if (with.equals(RT.getIn(offer, Capability.WITH))
-							&& can.equals(RT.getIn(offer, Capability.CAN))) {
-						match = offer;
-						break;
-					}
-				}
-			}
-			if (match == null) {
-				throw new IllegalArgumentException("echoed grant " + i + " was not offered by the "
-					+ "choices made — the venue issues only offered-and-triggered grants");
-			}
-			approved = approved.conj(match);
-		}
-		return approved;
+		return Maps.of(Hitl.ITEMS, items, Hitl.COUNT, CVMLong.create(items.count()));
 	}
 
 	// ========== Expiry ==========
@@ -576,7 +349,7 @@ public class HITLAdapter extends AAdapter {
 	/** Expires an open request: record → expired, job → FAILED. Terminal-state
 	 *  stickiness makes the race against a response commit exactly one winner. */
 	private void expireRequest(AString targetDID, AString id, Blob jobId) {
-		boolean marked = markResolved(targetDID, id, S_EXPIRED, null);
+		boolean marked = markResolved(targetDID, id, Hitl.EXPIRED, null);
 		if (!marked) return; // already resolved
 		Job job = engine.jobs().getJob(jobId);
 		if (job != null && !job.isFinished()) job.fail("HITL request expired");
@@ -588,9 +361,9 @@ public class HITLAdapter extends AAdapter {
 	private boolean markResolved(AString targetDID, AString id, AString status, AMap<AString, ACell> response) {
 		User user = engine.getVenueState().users().ensure(targetDID);
 		AMap<AString, ACell> record = user.getHitlRequest(id);
-		if (record == null || !S_OPEN.equals(record.get(K_STATUS))) return false;
-		AMap<AString, ACell> updated = record.assoc(K_STATUS, status);
-		if (response != null) updated = updated.assoc(K_RESPONSE, response);
+		if (record == null || !Hitl.OPEN.equals(record.get(Hitl.STATUS))) return false;
+		AMap<AString, ACell> updated = record.assoc(Hitl.STATUS, status);
+		if (response != null) updated = updated.assoc(Hitl.RESPONSE, response);
 		user.putHitlRequest(id, updated);
 		return true;
 	}
@@ -619,10 +392,10 @@ public class HITLAdapter extends AAdapter {
 				ACell v = reqs.entryAt(i).getValue();
 				if (!(v instanceof AMap)) continue;
 				AMap<AString, ACell> rec = (AMap<AString, ACell>) v;
-				if (!S_OPEN.equals(rec.get(K_STATUS))) continue;
-				CVMLong expires = RT.ensureLong(rec.get(K_EXPIRES));
+				if (!Hitl.OPEN.equals(rec.get(Hitl.STATUS))) continue;
+				CVMLong expires = RT.ensureLong(rec.get(Hitl.EXPIRES));
 				if (expires == null) continue;
-				AString id = RT.ensureString(rec.get(K_ID));
+				AString id = RT.ensureString(rec.get(Hitl.ID));
 				if (id == null) continue;
 				Blob jobId = Blob.parse(id.toString());
 				long delay = expires.longValue() - nowMs;

--- a/venue/src/main/java/covia/adapter/hitl/HitlValidation.java
+++ b/venue/src/main/java/covia/adapter/hitl/HitlValidation.java
@@ -1,0 +1,240 @@
+package covia.adapter.hitl;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import convex.core.data.ACell;
+import convex.core.data.AMap;
+import convex.core.data.AString;
+import convex.core.data.AVector;
+import convex.core.data.Vectors;
+import convex.core.data.prim.CVMBool;
+import convex.core.lang.RT;
+import covia.grid.hitl.Hitl;
+
+/**
+ * Pure HITL domain rules (COG-16) — request/response validation and the
+ * echo-consent grant intersection. No engine, no lattice, no side effects:
+ * every function maps immutable inputs to a result or throws
+ * {@link IllegalArgumentException} with an actionable message.
+ *
+ * <p>Kept separate from {@code HITLAdapter} (which owns authorisation,
+ * persistence and job control) so the semantics are unit-testable in
+ * isolation and reusable by any other HITL surface.</p>
+ */
+public class HitlValidation {
+
+	private static final Set<String> ASK_TYPES = Set.of("text", "approval", "choice", "checkboxes");
+
+	private HitlValidation() {}
+
+	/**
+	 * Validates the asks of a request at submission: ids unique, types known,
+	 * prompts present, options present/unique where required, and grants
+	 * attached ONLY where an explicit choice confers them — approval asks and
+	 * options (COG-16: a grant must be the consequence of a choice).
+	 *
+	 * @param asksCell the raw {@code asks} input
+	 * @return the validated asks vector
+	 * @throws IllegalArgumentException on any violation — no record is written,
+	 *         no job parks
+	 */
+	@SuppressWarnings("unchecked")
+	public static AVector<ACell> validateAsks(ACell asksCell) {
+		if (!(asksCell instanceof AVector) || ((AVector<ACell>) asksCell).count() == 0) {
+			throw new IllegalArgumentException("asks must be a non-empty array");
+		}
+		AVector<ACell> asks = (AVector<ACell>) asksCell;
+		Set<String> ids = new HashSet<>();
+		for (long i = 0; i < asks.count(); i++) {
+			AMap<AString, ACell> ask = RT.castMap(asks.get(i));
+			if (ask == null) throw new IllegalArgumentException("asks[" + i + "] must be an object");
+			AString id = RT.ensureString(ask.get(Hitl.ID));
+			AString type = RT.ensureString(ask.get(Hitl.TYPE));
+			AString prompt = RT.ensureString(ask.get(Hitl.PROMPT));
+			if (id == null || !ids.add(id.toString())) {
+				throw new IllegalArgumentException("asks[" + i + "].id is required and must be unique");
+			}
+			if (type == null || !ASK_TYPES.contains(type.toString())) {
+				throw new IllegalArgumentException("asks[" + i + "].type must be one of " + ASK_TYPES);
+			}
+			if (prompt == null) throw new IllegalArgumentException("asks[" + i + "].prompt is required");
+			boolean optionType = Hitl.CHOICE.equals(type) || Hitl.CHECKBOXES.equals(type);
+			ACell optionsCell = ask.get(Hitl.OPTIONS);
+			if (optionType) {
+				if (!(optionsCell instanceof AVector) || ((AVector<ACell>) optionsCell).count() == 0) {
+					throw new IllegalArgumentException("asks[" + i + "].options must be a non-empty array");
+				}
+				Set<String> optionIds = new HashSet<>();
+				AVector<ACell> options = (AVector<ACell>) optionsCell;
+				for (long j = 0; j < options.count(); j++) {
+					AMap<AString, ACell> opt = RT.castMap(options.get(j));
+					AString optId = (opt != null) ? RT.ensureString(opt.get(Hitl.ID)) : null;
+					if (opt == null || optId == null || !optionIds.add(optId.toString())) {
+						throw new IllegalArgumentException("asks[" + i + "].options[" + j
+							+ "] must be an object with a unique id");
+					}
+					validateGrantList(opt.get(Hitl.GRANTS), "asks[" + i + "].options[" + j + "]");
+				}
+			} else if (optionsCell != null) {
+				throw new IllegalArgumentException("asks[" + i + "]: options only apply to choice/checkboxes");
+			}
+			ACell grants = ask.get(Hitl.GRANTS);
+			if (grants != null && !Hitl.APPROVAL.equals(type)) {
+				throw new IllegalArgumentException("asks[" + i + "]: grants only attach to approval "
+					+ "asks and options — a grant must be the consequence of an explicit choice");
+			}
+			validateGrantList(grants, "asks[" + i + "]");
+		}
+		return asks;
+	}
+
+	private static void validateGrantList(ACell grantsCell, String where) {
+		if (grantsCell == null) return;
+		if (!(grantsCell instanceof AVector)) {
+			throw new IllegalArgumentException(where + ".grants must be an array");
+		}
+		AVector<ACell> grants = (AVector<ACell>) grantsCell;
+		for (long i = 0; i < grants.count(); i++) {
+			AMap<AString, ACell> g = RT.castMap(grants.get(i));
+			if (g == null || RT.ensureString(g.get(Hitl.WITH)) == null
+					|| RT.ensureString(g.get(Hitl.CAN)) == null) {
+				throw new IllegalArgumentException(where + ".grants[" + i + "] must be {with, can, exp?}");
+			}
+		}
+	}
+
+	/**
+	 * Validates a response's answers against the request's asks and computes
+	 * the OFFERED grants the choices actually triggered: grants on approval
+	 * asks answered {@code true}, and grants on selected options.
+	 *
+	 * @param asks the request's validated asks
+	 * @param answers map of ask id → answer
+	 * @return the triggered offers (capability maps, as offered)
+	 * @throws IllegalArgumentException on any violation — the record stays
+	 *         open and the job unresolved
+	 */
+	@SuppressWarnings("unchecked")
+	public static AVector<ACell> validateAnswers(AVector<ACell> asks, AMap<AString, ACell> answers) {
+		AVector<ACell> triggered = Vectors.empty();
+		Set<String> askIds = new HashSet<>();
+		for (long i = 0; i < asks.count(); i++) {
+			AMap<AString, ACell> ask = (AMap<AString, ACell>) asks.get(i);
+			AString askId = RT.ensureString(ask.get(Hitl.ID));
+			askIds.add(askId.toString());
+			AString type = RT.ensureString(ask.get(Hitl.TYPE));
+			ACell answer = answers.get(askId);
+			if (answer == null) {
+				if (CVMBool.TRUE.equals(ask.get(Hitl.REQUIRED))) {
+					throw new IllegalArgumentException("required ask '" + askId + "' is unanswered");
+				}
+				continue;
+			}
+			if (Hitl.TEXT.equals(type)) {
+				if (RT.ensureString(answer) == null) {
+					throw new IllegalArgumentException("answer for '" + askId + "' must be a string");
+				}
+			} else if (Hitl.APPROVAL.equals(type)) {
+				if (!(answer instanceof CVMBool)) {
+					throw new IllegalArgumentException("answer for '" + askId + "' must be a boolean");
+				}
+				if (CVMBool.TRUE.equals(answer)) {
+					triggered = appendGrants(triggered, ask.get(Hitl.GRANTS));
+				}
+			} else { // choice / checkboxes
+				AVector<ACell> options = (AVector<ACell>) ask.get(Hitl.OPTIONS);
+				if (Hitl.CHOICE.equals(type)) {
+					AMap<AString, ACell> opt = findOption(options, RT.ensureString(answer));
+					if (opt == null) {
+						throw new IllegalArgumentException("answer for '" + askId + "' must name an option id");
+					}
+					triggered = appendGrants(triggered, opt.get(Hitl.GRANTS));
+				} else {
+					if (!(answer instanceof AVector)) {
+						throw new IllegalArgumentException("answer for '" + askId + "' must be an array of option ids");
+					}
+					Set<String> seen = new HashSet<>();
+					AVector<ACell> selected = (AVector<ACell>) answer;
+					for (long j = 0; j < selected.count(); j++) {
+						AString optId = RT.ensureString(selected.get(j));
+						AMap<AString, ACell> opt = findOption(options, optId);
+						if (opt == null || !seen.add(optId.toString())) {
+							throw new IllegalArgumentException("answer for '" + askId
+								+ "' contains an unknown or duplicate option id");
+						}
+						triggered = appendGrants(triggered, opt.get(Hitl.GRANTS));
+					}
+				}
+			}
+		}
+		// Unknown answer keys are an error — answers bind to asks, exactly.
+		for (long i = 0; i < answers.count(); i++) {
+			AString key = RT.ensureString(answers.entryAt(i).getKey());
+			if (key == null || !askIds.contains(key.toString())) {
+				throw new IllegalArgumentException("answers contains unknown ask id: " + key);
+			}
+		}
+		return triggered;
+	}
+
+	/**
+	 * Echo-consent (COG-16): returns exactly the intersection of the ECHOED
+	 * grants and the offers actually TRIGGERED by the choices made. Matching is
+	 * by {@code {with, can}} equality; the result always carries the OFFER's
+	 * own capability map (including its {@code exp}), never the echo's.
+	 *
+	 * @param echoedCell the response's {@code grants} field (may be null)
+	 * @param triggered the offers triggered by the answers
+	 * @return the approved grants to issue
+	 * @throws IllegalArgumentException if any echoed grant was not
+	 *         offered-and-triggered
+	 */
+	public static AVector<ACell> intersectEchoedGrants(ACell echoedCell, AVector<ACell> triggered) {
+		if (echoedCell == null) return Vectors.empty();
+		if (!(echoedCell instanceof AVector)) {
+			throw new IllegalArgumentException("grants must be an array of {with, can} capabilities");
+		}
+		AVector<ACell> echoed = (AVector<ACell>) echoedCell;
+		AVector<ACell> approved = Vectors.empty();
+		for (long i = 0; i < echoed.count(); i++) {
+			AMap<AString, ACell> e = RT.castMap(echoed.get(i));
+			AString with = (e != null) ? RT.ensureString(e.get(Hitl.WITH)) : null;
+			AString can = (e != null) ? RT.ensureString(e.get(Hitl.CAN)) : null;
+			ACell match = null;
+			if (with != null && can != null) {
+				for (long j = 0; j < triggered.count(); j++) {
+					ACell offer = triggered.get(j);
+					if (with.equals(RT.getIn(offer, Hitl.WITH))
+							&& can.equals(RT.getIn(offer, Hitl.CAN))) {
+						match = offer;
+						break;
+					}
+				}
+			}
+			if (match == null) {
+				throw new IllegalArgumentException("echoed grant " + i + " was not offered by the "
+					+ "choices made — the venue issues only offered-and-triggered grants");
+			}
+			approved = approved.conj(match);
+		}
+		return approved;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static AMap<AString, ACell> findOption(AVector<ACell> options, AString optId) {
+		if (optId == null || options == null) return null;
+		for (long i = 0; i < options.count(); i++) {
+			AMap<AString, ACell> opt = (AMap<AString, ACell>) options.get(i);
+			if (optId.equals(opt.get(Hitl.ID))) return opt;
+		}
+		return null;
+	}
+
+	private static AVector<ACell> appendGrants(AVector<ACell> acc, ACell grantsCell) {
+		if (!(grantsCell instanceof AVector)) return acc;
+		AVector<ACell> grants = (AVector<ACell>) grantsCell;
+		for (long i = 0; i < grants.count(); i++) acc = acc.conj(grants.get(i));
+		return acc;
+	}
+}

--- a/venue/src/test/java/covia/adapter/HITLAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/HITLAdapterTest.java
@@ -11,26 +11,30 @@ import convex.core.crypto.AKeyPair;
 import convex.core.data.ACell;
 import convex.core.data.AMap;
 import convex.core.data.AString;
-import convex.core.data.AVector;
 import convex.core.data.Maps;
 import convex.core.data.Strings;
 import convex.core.data.Vectors;
 import convex.core.data.prim.CVMBool;
-import convex.core.data.prim.CVMLong;
 import convex.core.lang.RT;
 import covia.api.Fields;
 import covia.exception.JobFailedException;
 import covia.grid.Job;
 import covia.grid.Status;
+import covia.grid.hitl.Hitl;
 import covia.venue.Engine;
 import covia.venue.RequestContext;
 import covia.venue.TestEngine;
 
 /**
- * HITL lifecycle (COG-16): record in the target's h/ inbox + Job carrier +
- * response op. Includes the adversarial set: delivery without a hitl/request
- * delegation, non-target respond, echo of untriggered/unoffered grants,
- * answer-shape violations, respond-after-expiry, and cancel.
+ * HITL end-to-end (COG-16), driven through the {@link Hitl} builders — the
+ * clean flow this adapter exists for:
+ *
+ * <pre>request (Job parks INPUT_REQUIRED) → respond → Job completion</pre>
+ *
+ * Includes the adversarial set: delivery without a hitl/request delegation,
+ * non-target respond, echo of untriggered/unoffered grants, answer-shape
+ * violations, respond-after-expiry, and cancel. Domain-rule edge cases are
+ * unit-tested engine-free in {@code HitlValidationTest}.
  *
  * <p>Per-test key pairs isolate user namespaces on the shared engine.</p>
  */
@@ -74,29 +78,23 @@ public class HITLAdapterTest {
 		return RT.castMap(RT.getIn(result, "value"));
 	}
 
-	private static AVector<ACell> approvalAsk(String id, ACell grants) {
-		AMap<AString, ACell> ask = Maps.of(
-			"id", id, "type", "approval", "prompt", "Approve?", "required", CVMBool.TRUE);
-		if (grants != null) ask = ask.assoc(HITLAdapter.K_GRANTS, grants);
-		return Vectors.of((ACell) ask);
-	}
-
-	// ========== Lifecycle ==========
+	// ========== The clean drive: request → respond → completion ==========
 
 	@Test
 	public void testAnswerLifecycle() {
-		Job job = request(ALICE, Maps.of(
-			"title", "Pay invoice",
-			"description", "Invoice INV-1 for testing",
-			"asks", approvalAsk("pay", null)));
+		// 1. Request — the Job parks awaiting the human.
+		Job job = request(ALICE, Hitl.request("Pay invoice")
+			.description("Invoice INV-1 for testing")
+			.ask(Hitl.approval("pay", "Approve payment?").required())
+			.build());
 		assertEquals(Status.INPUT_REQUIRED, job.getStatus(),
 			"a delivered HITL request parks the job awaiting the human");
 		String id = job.getID().toHexString();
 
 		AMap<AString, ACell> record = readRecord(ALICE, id);
 		assertNotNull(record, "the record must land in the target's h/ inbox");
-		assertEquals(HITLAdapter.S_OPEN, record.get(HITLAdapter.K_STATUS));
-		assertEquals(ALICE_DID, record.get(HITLAdapter.K_FROM),
+		assertEquals(Hitl.OPEN, record.get(Hitl.STATUS));
+		assertEquals(ALICE_DID, record.get(Hitl.FROM),
 			"from is the VERIFIED caller identity, venue-set");
 
 		// The inbox listing shows the open ask.
@@ -104,134 +102,128 @@ public class HITLAdapterTest {
 			Maps.of("status", "open"), ALICE).awaitResult(5000);
 		assertTrue(RT.ensureLong(RT.getIn(list, "count")).longValue() >= 1);
 
-		respond(ALICE, Maps.of("id", id, "outcome", "answer",
-			"answers", Maps.of("pay", CVMBool.TRUE),
-			"comment", "approved"));
+		// 2. Respond — the inbox owner answers.
+		respond(ALICE, Hitl.answer(id)
+			.answer("pay", true)
+			.comment("approved")
+			.build());
 
+		// 3. Completion — the requester's Job resolves with the response.
 		assertEquals(Status.COMPLETE, job.getStatus());
 		ACell output = job.getOutput();
 		assertEquals(CVMBool.TRUE, RT.getIn(output, "answers", "pay"));
 		assertEquals(Strings.create(id), RT.getIn(output, "id"));
-		assertEquals(HITLAdapter.S_ANSWERED, readRecord(ALICE, id).get(HITLAdapter.K_STATUS));
+		assertEquals(Hitl.ANSWERED, readRecord(ALICE, id).get(Hitl.STATUS));
 	}
 
 	@Test
 	public void testRejectFailsJob() {
-		Job job = request(ALICE, Maps.of("title", "Pay?", "asks", approvalAsk("pay", null)));
+		Job job = request(ALICE, Hitl.request("Pay?")
+			.ask(Hitl.approval("pay", "Pay?").required()).build());
 		String id = job.getID().toHexString();
 
-		respond(ALICE, Maps.of("id", id, "outcome", "reject", "comment", "Wrong PO"));
+		respond(ALICE, Hitl.reject(id, "Wrong PO"));
 
 		assertEquals(Status.FAILED, job.getStatus());
 		assertTrue(job.getErrorMessage().contains("rejected"));
 		assertTrue(job.getErrorMessage().contains("Wrong PO"),
 			"the rejection reason must travel in the job error — the requester cannot read the inbox");
-		assertEquals(HITLAdapter.S_REJECTED, readRecord(ALICE, id).get(HITLAdapter.K_STATUS));
+		assertEquals(Hitl.REJECTED, readRecord(ALICE, id).get(Hitl.STATUS));
 	}
 
-	// ========== Validation (adversarial) ==========
+	// ========== Validation at the adapter boundary (adversarial) ==========
 
 	@Test
 	public void testAnswerValidationAdversarial() {
-		Job job = request(ALICE, Maps.of("title", "Setup",
-			"asks", Vectors.of(
-				(ACell) Maps.of("id", "pay", "type", "approval", "prompt", "Pay?", "required", CVMBool.TRUE),
-				(ACell) Maps.of("id", "tier", "type", "choice", "prompt", "Tier?",
-					"options", Vectors.of(
-						(ACell) Maps.of("id", "fast", "label", "Fast"),
-						(ACell) Maps.of("id", "best", "label", "Best"))))));
+		Job job = request(ALICE, Hitl.request("Setup")
+			.ask(Hitl.approval("pay", "Pay?").required())
+			.ask(Hitl.choice("tier", "Tier?").option("fast", "Fast").option("best", "Best"))
+			.build());
 		String id = job.getID().toHexString();
 
 		// Missing required ask
 		assertThrows(Exception.class, () -> respond(ALICE,
-			Maps.of("id", id, "outcome", "answer", "answers", Maps.of("tier", "fast"))));
+			Hitl.answer(id).answer("tier", "fast").build()));
 		// Unknown option id
 		assertThrows(Exception.class, () -> respond(ALICE,
-			Maps.of("id", id, "outcome", "answer",
-				"answers", Maps.of("pay", CVMBool.TRUE, "tier", "zzz"))));
+			Hitl.answer(id).answer("pay", true).answer("tier", "zzz").build()));
 		// Unknown ask id
 		assertThrows(Exception.class, () -> respond(ALICE,
-			Maps.of("id", id, "outcome", "answer",
-				"answers", Maps.of("pay", CVMBool.TRUE, "bogus", "x"))));
+			Hitl.answer(id).answer("pay", true).answer("bogus", "x").build()));
 		// Wrong answer shape for approval
 		assertThrows(Exception.class, () -> respond(ALICE,
-			Maps.of("id", id, "outcome", "answer", "answers", Maps.of("pay", "yes"))));
+			Hitl.answer(id).answer("pay", "yes").build()));
 
 		// Failed responses left the record open and the job unfinished...
-		assertEquals(HITLAdapter.S_OPEN, readRecord(ALICE, id).get(HITLAdapter.K_STATUS));
+		assertEquals(Hitl.OPEN, readRecord(ALICE, id).get(Hitl.STATUS));
 		assertFalse(job.isFinished());
 		// ...and a valid response still resolves it.
-		respond(ALICE, Maps.of("id", id, "outcome", "answer",
-			"answers", Maps.of("pay", CVMBool.TRUE, "tier", "fast")));
+		respond(ALICE, Hitl.answer(id).answer("pay", true).answer("tier", "fast").build());
 		assertEquals(Status.COMPLETE, job.getStatus());
 	}
 
 	@Test
 	public void testRequestValidationAdversarial() {
-		// Empty asks
-		assertThrows(Exception.class, () -> request(ALICE,
-			Maps.of("title", "t", "asks", Vectors.empty())));
+		// Empty asks — rejected synchronously, no record, no parked job.
+		assertThrows(Exception.class, () -> request(ALICE, Hitl.request("t").build()));
 		// Unknown ask type
 		assertThrows(Exception.class, () -> request(ALICE,
-			Maps.of("title", "t", "asks", Vectors.of(
-				(ACell) Maps.of("id", "a", "type", "essay", "prompt", "p")))));
-		// choice without options
-		assertThrows(Exception.class, () -> request(ALICE,
-			Maps.of("title", "t", "asks", Vectors.of(
-				(ACell) Maps.of("id", "a", "type", "choice", "prompt", "p")))));
+			Maps.of(Hitl.TITLE, Strings.create("t"), Hitl.ASKS, Vectors.of(
+				(ACell) Maps.of(Hitl.ID, Strings.create("a"),
+					Hitl.TYPE, Strings.create("essay"), Hitl.PROMPT, Strings.create("p"))))));
 		// Grants on a TEXT ask — a grant must ride an explicit choice
 		assertThrows(Exception.class, () -> request(ALICE,
-			Maps.of("title", "t", "asks", Vectors.of(
-				(ACell) Maps.of("id", "a", "type", "text", "prompt", "p",
-					"grants", Vectors.of((ACell) Capability.create(
-						Strings.create("w/x"), Capability.CRUD_READ)))))));
+			Maps.of(Hitl.TITLE, Strings.create("t"), Hitl.ASKS, Vectors.of(
+				(ACell) Hitl.text("a", "p").build().assoc(Hitl.GRANTS,
+					Vectors.of((ACell) Hitl.grant("w/x", "crud/read")))))));
 	}
 
 	// ========== Echo-consent grants ==========
 
 	@Test
 	public void testEchoConsentGrants() {
-		ACell offered = Vectors.of((ACell) Capability.create(
-			Strings.create("w/reports/"), Capability.CRUD_READ));
-
 		// ADVERSARIAL: echoing the grant while DENYING the approval — not triggered.
-		Job denied = request(ALICE, Maps.of("title", "g", "asks", approvalAsk("access", offered)));
+		Job denied = request(ALICE, Hitl.request("g")
+			.ask(Hitl.approval("access", "Grant?").grant("w/reports/", "crud/read")).build());
 		assertThrows(Exception.class, () -> respond(ALICE,
-			Maps.of("id", denied.getID().toHexString(), "outcome", "answer",
-				"answers", Maps.of("access", CVMBool.FALSE),
-				"grants", offered)));
+			Hitl.answer(denied.getID().toHexString())
+				.answer("access", false)
+				.echo("w/reports/", "crud/read")
+				.build()));
 		assertFalse(denied.isFinished(), "a failed response must not resolve the job");
 
 		// ADVERSARIAL: echoing a grant that was never offered.
-		Job crafted = request(ALICE, Maps.of("title", "g", "asks", approvalAsk("access", offered)));
+		Job crafted = request(ALICE, Hitl.request("g")
+			.ask(Hitl.approval("access", "Grant?").grant("w/reports/", "crud/read")).build());
 		assertThrows(Exception.class, () -> respond(ALICE,
-			Maps.of("id", crafted.getID().toHexString(), "outcome", "answer",
-				"answers", Maps.of("access", CVMBool.TRUE),
-				"grants", Vectors.of((ACell) Capability.create(
-					Strings.create("w/private/"), Strings.create("crud"))))));
+			Hitl.answer(crafted.getID().toHexString())
+				.answer("access", true)
+				.echo("w/private/", "crud")
+				.build()));
 
 		// Approving WITHOUT echoing confers nothing.
-		Job silent = request(ALICE, Maps.of("title", "g", "asks", approvalAsk("access", offered)));
-		respond(ALICE, Maps.of("id", silent.getID().toHexString(), "outcome", "answer",
-			"answers", Maps.of("access", CVMBool.TRUE)));
+		Job silent = request(ALICE, Hitl.request("g")
+			.ask(Hitl.approval("access", "Grant?").grant("w/reports/", "crud/read")).build());
+		respond(ALICE, Hitl.answer(silent.getID().toHexString()).answer("access", true).build());
 		assertEquals(Status.COMPLETE, silent.getStatus());
 		assertNull(RT.getIn(silent.getOutput(), "token"), "no echo, no token");
 		assertNull(RT.getIn(silent.getOutput(), "grants"));
 
 		// Approve + echo → token issued, audienced to the requester, resource
-		// canonicalised to the RESPONDER's namespace.
-		Job granted = request(ALICE, Maps.of("title", "g", "asks", approvalAsk("access", offered)));
-		respond(ALICE, Maps.of("id", granted.getID().toHexString(), "outcome", "answer",
-			"answers", Maps.of("access", CVMBool.TRUE),
-			"grants", offered));
+		// canonicalised to the RESPONDER's namespace at issuance.
+		Job granted = request(ALICE, Hitl.request("g")
+			.ask(Hitl.approval("access", "Grant?").grant("w/reports/", "crud/read")).build());
+		respond(ALICE, Hitl.answer(granted.getID().toHexString())
+			.answer("access", true)
+			.echo("w/reports/", "crud/read")
+			.build());
 		assertEquals(Status.COMPLETE, granted.getStatus());
 		AString jwt = RT.ensureString(RT.getIn(granted.getOutput(), "token"));
 		assertNotNull(jwt, "echoed-and-triggered grants must issue a token");
 		UCAN token = UCAN.fromJWT(jwt);
 		assertEquals(ALICE_DID, token.getAudience(), "audience is the requester");
 		assertEquals(Strings.create(ALICE_DID + "/w/reports/"),
-			RT.getIn(token.getCapabilities().get(0), Capability.WITH),
-			"bare offered resources canonicalise to the responder's namespace at issuance");
+			RT.getIn(token.getCapabilities().get(0), Capability.WITH));
 	}
 
 	// ========== Cross-user delivery ==========
@@ -239,8 +231,8 @@ public class HITLAdapterTest {
 	@Test
 	public void testCrossUserDelivery() {
 		// ADVERSARIAL: no delegation → delivery denied, job FAILED, no record.
-		Job blocked = request(BOB, Maps.of("user", ALICE_DID,
-			"title", "gimme", "asks", approvalAsk("ok", null)));
+		Job blocked = request(BOB, Hitl.request("gimme").to(ALICE_DID.toString())
+			.ask(Hitl.approval("ok", "OK?")).build());
 		assertEquals(Status.FAILED, blocked.getStatus());
 		assertTrue(blocked.getErrorMessage().contains("hitl/request"));
 		assertNull(readRecord(ALICE, blocked.getID().toHexString()),
@@ -252,28 +244,29 @@ public class HITLAdapterTest {
 			Vectors.of(Capability.create(
 				Strings.create(ALICE_DID + "/h/"), HITLAdapter.ABILITY_HITL_REQUEST)),
 			Vectors.empty());
-		ACell offered = Vectors.of((ACell) Capability.create(
-			Strings.create("w/reports/"), Capability.CRUD_READ));
 		Job job = request(BOB.withProofs(Vectors.of(delegation.toMap())),
-			Maps.of("user", ALICE_DID, "title", "Report access",
-				"asks", approvalAsk("access", offered)));
+			Hitl.request("Report access").to(ALICE_DID.toString())
+				.ask(Hitl.approval("access", "Grant report access?")
+					.grant("w/reports/", "crud/read"))
+				.build());
 		assertEquals(Status.INPUT_REQUIRED, job.getStatus());
 		String id = job.getID().toHexString();
 
 		AMap<AString, ACell> record = readRecord(ALICE, id);
-		assertEquals(BOB_DID, record.get(HITLAdapter.K_FROM),
+		assertEquals(BOB_DID, record.get(Hitl.FROM),
 			"from is Bob — the verified requester, not the inbox owner");
 
 		// ADVERSARIAL: the requester cannot respond — the record is not in HIS inbox.
 		assertThrows(Exception.class, () -> respond(BOB,
-			Maps.of("id", id, "outcome", "answer", "answers", Maps.of("access", CVMBool.TRUE))));
-		assertEquals(HITLAdapter.S_OPEN, readRecord(ALICE, id).get(HITLAdapter.K_STATUS));
+			Hitl.answer(id).answer("access", true).build()));
+		assertEquals(Hitl.OPEN, readRecord(ALICE, id).get(Hitl.STATUS));
 
 		// Alice answers, approving and echoing the grant: Bob's job completes
 		// with a token audienced to BOB over ALICE's resource.
-		respond(ALICE, Maps.of("id", id, "outcome", "answer",
-			"answers", Maps.of("access", CVMBool.TRUE),
-			"grants", offered));
+		respond(ALICE, Hitl.answer(id)
+			.answer("access", true)
+			.echo("w/reports/", "crud/read")
+			.build());
 		assertEquals(Status.COMPLETE, job.getStatus());
 		UCAN token = UCAN.fromJWT(RT.ensureString(RT.getIn(job.getOutput(), "token")));
 		assertEquals(BOB_DID, token.getAudience());
@@ -285,9 +278,8 @@ public class HITLAdapterTest {
 
 	@Test
 	public void testExpiry() {
-		Job job = request(ALICE, Maps.of("title", "quick",
-			"asks", approvalAsk("ok", null),
-			"timeout", CVMLong.create(1)));
+		Job job = request(ALICE, Hitl.request("quick")
+			.ask(Hitl.approval("ok", "OK?")).timeout(1).build());
 		String id = job.getID().toHexString();
 		assertEquals(Status.INPUT_REQUIRED, job.getStatus());
 
@@ -295,23 +287,24 @@ public class HITLAdapterTest {
 		assertThrows(JobFailedException.class, () -> job.awaitResult(15000));
 		assertEquals(Status.FAILED, job.getStatus());
 		assertTrue(job.getErrorMessage().contains("expired"));
-		assertEquals(HITLAdapter.S_EXPIRED, readRecord(ALICE, id).get(HITLAdapter.K_STATUS));
+		assertEquals(Hitl.EXPIRED, readRecord(ALICE, id).get(Hitl.STATUS));
 
 		// ADVERSARIAL: responding to an expired request must fail.
 		assertThrows(Exception.class, () -> respond(ALICE,
-			Maps.of("id", id, "outcome", "answer", "answers", Maps.of("ok", CVMBool.TRUE))));
+			Hitl.answer(id).answer("ok", true).build()));
 	}
 
 	@Test
 	public void testCancelMarksRecordCancelled() {
-		Job job = request(ALICE, Maps.of("title", "c", "asks", approvalAsk("ok", null)));
+		Job job = request(ALICE, Hitl.request("c")
+			.ask(Hitl.approval("ok", "OK?")).build());
 		String id = job.getID().toHexString();
 
 		engine.jobs().cancelJob(job.getID(), ALICE);
 		assertEquals(Status.CANCELLED, job.getStatus());
-		assertEquals(HITLAdapter.S_CANCELLED, readRecord(ALICE, id).get(HITLAdapter.K_STATUS),
+		assertEquals(Hitl.CANCELLED, readRecord(ALICE, id).get(Hitl.STATUS),
 			"the cancel hook marks the inbox record cancelled");
 		assertThrows(Exception.class, () -> respond(ALICE,
-			Maps.of("id", id, "outcome", "answer", "answers", Maps.of("ok", CVMBool.TRUE))));
+			Hitl.answer(id).answer("ok", true).build()));
 	}
 }

--- a/venue/src/test/java/covia/adapter/hitl/HitlValidationTest.java
+++ b/venue/src/test/java/covia/adapter/hitl/HitlValidationTest.java
@@ -1,0 +1,179 @@
+package covia.adapter.hitl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import convex.core.data.ACell;
+import convex.core.data.AMap;
+import convex.core.data.AString;
+import convex.core.data.AVector;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+import convex.core.data.prim.CVMBool;
+import convex.core.data.prim.CVMLong;
+import convex.core.lang.RT;
+import covia.grid.hitl.Hitl;
+
+/**
+ * Pure unit tests for the HITL domain rules — no engine, no lattice, no IO.
+ * Every COG-16 validation rule and the echo-consent intersection, driven
+ * through the {@link Hitl} builders (which doubles as builder shape coverage).
+ */
+public class HitlValidationTest {
+
+	// ========== validateAsks ==========
+
+	@Test
+	public void testValidAsksPass() {
+		AVector<ACell> asks = (AVector<ACell>) RT.getIn(
+			Hitl.request("t")
+				.ask(Hitl.text("notes", "Anything?"))
+				.ask(Hitl.approval("pay", "Pay?").required().grant("w/reports/", "crud/read"))
+				.ask(Hitl.choice("tier", "Tier?").option("fast", "Fast").option("best", "Best"))
+				.ask(Hitl.checkboxes("scopes", "Scopes?")
+					.option("r", "Read", Hitl.grant("w/data/", "crud/read")))
+				.build(),
+			Hitl.ASKS);
+		assertEquals(4, HitlValidation.validateAsks(asks).count());
+	}
+
+	@Test
+	public void testAsksStructuralViolations() {
+		// Empty / non-vector
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.empty()));
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Strings.create("x")));
+		// Duplicate ask ids
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.of(
+			Hitl.text("a", "p").build(), Hitl.text("a", "p2").build())));
+		// Unknown type
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.of(
+			(ACell) Maps.of(Hitl.ID, Strings.create("a"), Hitl.TYPE, Strings.create("essay"),
+				Hitl.PROMPT, Strings.create("p")))));
+		// Missing prompt
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.of(
+			(ACell) Maps.of(Hitl.ID, Strings.create("a"), Hitl.TYPE, Hitl.TEXT))));
+		// choice without options
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.of(
+			Hitl.choice("a", "p").build())));
+		// Duplicate option ids
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.of(
+			Hitl.choice("a", "p").option("x", "X").option("x", "X2").build())));
+		// Options on a non-option type
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.of(
+			(ACell) Hitl.text("a", "p").build().assoc(Hitl.OPTIONS,
+				Vectors.of((ACell) Maps.of(Hitl.ID, Strings.create("x"), Hitl.LABEL, Strings.create("X")))))));
+	}
+
+	@Test
+	public void testGrantPlacementRules() {
+		// Grants ride explicit choices ONLY: approval asks and options.
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.of(
+			(ACell) Hitl.text("a", "p").build().assoc(Hitl.GRANTS,
+				Vectors.of((ACell) Hitl.grant("w/x", "crud/read"))))));
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.of(
+			(ACell) Hitl.choice("a", "p").option("x", "X").build().assoc(Hitl.GRANTS,
+				Vectors.of((ACell) Hitl.grant("w/x", "crud/read"))))));
+		// Malformed grant entries
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAsks(Vectors.of(
+			(ACell) Hitl.approval("a", "p").build().assoc(Hitl.GRANTS,
+				Vectors.of((ACell) Maps.of(Hitl.WITH, Strings.create("w/x"))))))); // no can
+		// Approval-ask and option grants are the permitted placements.
+		assertEquals(1, HitlValidation.validateAsks(Vectors.of(
+			Hitl.approval("a", "p").grant("w/x", "crud/read").build())).count());
+		assertEquals(1, HitlValidation.validateAsks(Vectors.of(
+			Hitl.checkboxes("a", "p").option("x", "X", Hitl.grant("w/x", "crud/read")).build())).count());
+	}
+
+	// ========== validateAnswers ==========
+
+	private static AVector<ACell> sampleAsks() {
+		return HitlValidation.validateAsks(Vectors.of(
+			Hitl.approval("pay", "Pay?").required().grant("w/reports/", "crud/read").build(),
+			Hitl.choice("tier", "Tier?").option("fast", "Fast")
+				.option("best", "Best", Hitl.grant("w/best/", "crud/read")).build(),
+			Hitl.checkboxes("scopes", "Scopes?")
+				.option("r", "Read", Hitl.grant("w/data/", "crud/read"))
+				.option("w", "Write", Hitl.grant("w/data/", "crud/write")).build(),
+			Hitl.text("notes", "Notes?").build()));
+	}
+
+	private static AMap<AString, ACell> answers(ACell... kv) {
+		AMap<AString, ACell> m = Maps.empty();
+		for (int i = 0; i < kv.length; i += 2) m = m.assoc((AString) kv[i], kv[i + 1]);
+		return m;
+	}
+
+	@Test
+	public void testAnswerShapes() {
+		AVector<ACell> asks = sampleAsks();
+		// Required unanswered
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAnswers(asks,
+			answers(Strings.create("tier"), Strings.create("fast"))));
+		// Approval must be boolean
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAnswers(asks,
+			answers(Strings.create("pay"), Strings.create("yes"))));
+		// Text must be a string
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAnswers(asks,
+			answers(Strings.create("pay"), CVMBool.TRUE, Strings.create("notes"), CVMLong.create(1))));
+		// Choice must name a known option
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAnswers(asks,
+			answers(Strings.create("pay"), CVMBool.TRUE, Strings.create("tier"), Strings.create("zzz"))));
+		// Checkboxes must be a vector of known, non-duplicate option ids
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAnswers(asks,
+			answers(Strings.create("pay"), CVMBool.TRUE, Strings.create("scopes"), Strings.create("r"))));
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAnswers(asks,
+			answers(Strings.create("pay"), CVMBool.TRUE,
+				Strings.create("scopes"), Vectors.of(Strings.create("r"), Strings.create("r")))));
+		// Unknown ask id
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.validateAnswers(asks,
+			answers(Strings.create("pay"), CVMBool.TRUE, Strings.create("bogus"), Strings.create("x"))));
+	}
+
+	@Test
+	public void testTriggeredOffers() {
+		AVector<ACell> asks = sampleAsks();
+		// Approval TRUE + option selections trigger exactly their grants.
+		AVector<ACell> triggered = HitlValidation.validateAnswers(asks, answers(
+			Strings.create("pay"), CVMBool.TRUE,
+			Strings.create("tier"), Strings.create("best"),
+			Strings.create("scopes"), Vectors.of(Strings.create("r"))));
+		assertEquals(3, triggered.count(), "approval grant + best-option grant + r-option grant");
+
+		// Approval FALSE and unselected options trigger nothing.
+		AVector<ACell> none = HitlValidation.validateAnswers(asks, answers(
+			Strings.create("pay"), CVMBool.FALSE,
+			Strings.create("tier"), Strings.create("fast")));
+		assertEquals(0, none.count());
+	}
+
+	// ========== intersectEchoedGrants (echo-consent) ==========
+
+	@Test
+	public void testEchoConsentIntersection() {
+		AVector<ACell> triggered = Vectors.of(
+			(ACell) Hitl.grant("w/reports/", "crud/read", 1795000000L));
+
+		// No echo → nothing conferred, always valid.
+		assertEquals(0, HitlValidation.intersectEchoedGrants(null, triggered).count());
+
+		// Echo of a triggered offer → approved, carrying the OFFER's map
+		// (including its exp) even when the echo omits it.
+		AVector<ACell> approved = HitlValidation.intersectEchoedGrants(
+			Vectors.of((ACell) Hitl.grant("w/reports/", "crud/read")), triggered);
+		assertEquals(1, approved.count());
+		assertEquals(CVMLong.create(1795000000L), RT.getIn(approved.get(0), Hitl.EXP),
+			"the issued capability is the offer's own map, never the echo's");
+
+		// ADVERSARIAL: echo of a never-offered grant fails the response.
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.intersectEchoedGrants(
+			Vectors.of((ACell) Hitl.grant("w/private/", "crud")), triggered));
+		// ADVERSARIAL: echo of an offered-but-untriggered grant fails too.
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.intersectEchoedGrants(
+			Vectors.of((ACell) Hitl.grant("w/reports/", "crud/read")), Vectors.empty()));
+		// ADVERSARIAL: an echo widening the ability is not a match.
+		assertThrows(IllegalArgumentException.class, () -> HitlValidation.intersectEchoedGrants(
+			Vectors.of((ACell) Hitl.grant("w/reports/", "crud")), triggered));
+	}
+}


### PR DESCRIPTION
HITL cleanliness/testability pass — the flow drives as `Hitl.request(...)` → `Hitl.answer(...)`/`Hitl.reject(...)` → job completion.

- **`covia.grid.hitl.Hitl`** (covia-core) — shared field vocabulary + fluent `RequestBuilder`/`AskBuilder`/`ResponseBuilder`. Shape construction only (validation stays venue-side); transport-portable, so the same builders drive a remote venue over the Grid API.
- **`covia.adapter.hitl.HitlValidation`** (venue) — the pure domain rules extracted whole: ask validation, answer validation → triggered offers, echo-consent intersection. No engine dependencies.
- **`HITLAdapter`** — plumbing only: authorise (`requireDeliverable`) → persist → park/resolve job (`resolveReject`/`resolveAnswer`); duplicated constants removed.
- **Tests at two speeds**: `HitlValidationTest` (6 pure unit tests, engine-free — every COG-16 rule plus the echo-widening adversarial case) and `HITLAdapterTest` (8 integration tests rewritten through the builders, each demonstrating the clean drive).

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
