### PR TITLE
hitl:respond accepts 0x-prefixed job ids

### DIFF
--- a/skills/hitl/SKILL.md
+++ b/skills/hitl/SKILL.md
@@ -127,4 +127,5 @@ Run these in order against a dev venue; each step states its expected outcome. (
 | "echoed grant ... was not offered" | The echo doesn't match an offer your choices triggered — echo exactly the offered `{with, can}`, only for choices you made |
 | "HITL request ... is not open" | Already answered/rejected/expired/cancelled — check `covia_read path=h/<id>` status |
 | Tool call timed out | Normal for long asks — the job id is in the result; poll `covia_read path=j/<id>` |
+| Record not found at `h/<id>` | Record ids are bare hex; strip a leading `0x` from a job id for `covia_read` paths (`hitl_respond` accepts both forms) |
 | Job stuck `INPUT_REQUIRED` after venue restart | Expected — open asks survive restarts (expiry timers re-arm at boot); just respond normally |

--- a/venue/src/main/java/covia/adapter/HITLAdapter.java
+++ b/venue/src/main/java/covia/adapter/HITLAdapter.java
@@ -205,6 +205,12 @@ public class HITLAdapter extends AAdapter {
 		if (caller == null) throw new AuthException("Authentication required");
 		AString id = RT.ensureString(RT.getIn(input, Hitl.ID));
 		if (id == null) throw new IllegalArgumentException("id is required");
+		// Records key on bare hex, but REST renders job ids 0x-prefixed —
+		// accept both, so a pasted job id just works.
+		String idStr = id.toString();
+		if (idStr.startsWith("0x") || idStr.startsWith("0X")) {
+			id = Strings.create(idStr.substring(2));
+		}
 
 		// Structural authorisation: respond reads the CALLER's own inbox only.
 		User user = engine.getVenueState().users().ensure(caller);

--- a/venue/src/test/java/covia/adapter/HITLAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/HITLAdapterTest.java
@@ -131,6 +131,15 @@ public class HITLAdapterTest {
 		assertEquals(Hitl.REJECTED, readRecord(ALICE, id).get(Hitl.STATUS));
 	}
 
+	@Test
+	public void testRespondAcceptsPrefixedJobId() {
+		// REST renders job ids 0x-prefixed; records key on bare hex. A pasted
+		// job id must work for respond (live smoke-test finding).
+		Job job = request(ALICE, Hitl.request("x").ask(Hitl.approval("ok", "OK?")).build());
+		respond(ALICE, Hitl.answer("0x" + job.getID().toHexString()).answer("ok", true).build());
+		assertEquals(Status.COMPLETE, job.getStatus());
+	}
+
 	// ========== Validation at the adapter boundary (adversarial) ==========
 
 	@Test


### PR DESCRIPTION
Live REST smoke test of the full HITL loop (boot → catalog/skill materialisation → request parks INPUT_REQUIRED → inbox list → record read → answer → job COMPLETE; reject and expiry flows verified) surfaced one wart: REST renders job ids `0x`-prefixed while records key on bare hex, so a pasted job id failed the respond lookup. `hitl:respond` now accepts both; regression test added; /hitl skill troubleshooting updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)