### PR TITLE
Cross-venue HITL test + ucans proof header for job observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 ### Added
 - HITL requests (COG-16) — `hitl:request`/`respond`/`list` over the per-user `h/` inbox, typed asks, choice-bound grants with echo-consent, restart-safe expiry; `hitl` skill
 - `Hitl` builders (covia-core) — fluent, transport-portable construction of HITL requests, asks and responses
+- Federated job observation carries caller proofs — `X-Covia-Ucans` header on body-less job reads; cross-venue HITL verified end-to-end
 - `ucan:issue` is a granting surface — mints over another principal's resource under a presented `grant/<ability>` right, expiry-capped by the right's validity
 
 ### Changed

--- a/covia-core/src/main/java/covia/grid/client/VenueHTTP.java
+++ b/covia-core/src/main/java/covia/grid/client/VenueHTTP.java
@@ -185,6 +185,14 @@ public class VenueHTTP extends Venue {
 	 * @param uri The request URI
 	 * @return Pre-authenticated request builder
 	 */
+	/**
+	 * Header carrying the caller's UCAN proofs on body-less requests (job
+	 * observation GETs): comma-separated JWTs, verified at venue ingress
+	 * exactly like the request-body {@code ucans} array. Commas cannot occur
+	 * inside a JWT, so the encoding is unambiguous.
+	 */
+	public static final String UCANS_HEADER = "X-Covia-Ucans";
+
 	private HttpRequest.Builder requestBuilder(URI uri) {
 		HttpRequest.Builder builder = HttpRequest.newBuilder().uri(uri);
 		// Per-request total deadline. connectTimeout only bounds establishing the
@@ -195,6 +203,19 @@ public class VenueHTTP extends Venue {
 		// complete; grows with the caller's configured job-wait timeout.
 		builder.timeout(Duration.ofMillis(Math.max(timeout, 120_000L)));
 		auth.apply(builder);
+		// Proofs also ride a header so body-less requests (GET /jobs/{id} and
+		// friends) carry the caller's authority — without this, a federated
+		// hop can invoke a remote job but never observe it (identity tokens
+		// and delegations only travelled in the invoke body).
+		AVector<ACell> proofTokens = this.ucans;
+		if (proofTokens != null) {
+			StringBuilder sb = new StringBuilder();
+			for (long i = 0; i < proofTokens.count(); i++) {
+				if (i > 0) sb.append(',');
+				sb.append(proofTokens.get(i).toString());
+			}
+			builder.header(UCANS_HEADER, sb.toString());
+		}
 		return builder;
 	}
 

--- a/venue/docs/UCAN.md
+++ b/venue/docs/UCAN.md
@@ -255,6 +255,14 @@ The audience presents UCAN tokens in the `RequestContext` on a
 **per-request basis**. Each request carries its own proof set — there is
 no server-side token store and no session-level capability state.
 
+Enveloped requests carry proofs in the body `ucans` array; **body-less
+requests** (job observation GETs) carry the same JWTs comma-separated in
+the `X-Covia-Ucans` header (`VenueHTTP.UCANS_HEADER`), explicitly attached
+by the sender and verified identically at ingress
+(`AuthMiddleware.headerUcans`). This is what lets a federated hop observe
+the remote job it created — the identity token authenticates the caller on
+the read exactly as on the invoke.
+
 ```
 RequestContext:
   callerDID: "did:key:zBob..."

--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -718,6 +718,14 @@ public class CoviaAPI extends ACoviaAPI {
 			return;
 		}
 		RequestContext rctx = AuthMiddleware.callerContext(ctx);
+		// Job reads are delegable and federated observation must carry the
+		// caller's authority: attach transport proofs from the bearer and the
+		// X-Covia-Ucans header (a GET has no body for the ucans array). With
+		// venueDID set, an identity token authenticates a relayed caller —
+		// this is how a grid hop observes the remote job it created.
+		AString bearer = ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR);
+		rctx = AuthMiddleware.withTransportAuth(rctx, bearer,
+			AuthMiddleware.headerUcans(ctx), engine().getDIDString());
 
 		try {
 			AMap<AString,ACell> status=engine().jobs().getJobData(id, rctx);

--- a/venue/src/main/java/covia/venue/server/AuthMiddleware.java
+++ b/venue/src/main/java/covia/venue/server/AuthMiddleware.java
@@ -498,6 +498,25 @@ public class AuthMiddleware {
 	}
 
 	/**
+	 * Raw JWT strings from the {@code X-Covia-Ucans} header (comma-separated),
+	 * in the same vector shape as the request-body {@code ucans} array —
+	 * verified downstream by {@link #withTransportAuth} exactly like body
+	 * proofs. The header channel exists for body-less requests (job
+	 * observation GETs): without it a federated hop can invoke a remote job
+	 * but never observe it. Returns null when the header is absent or empty.
+	 */
+	public static AVector<ACell> headerUcans(Context ctx) {
+		String h = ctx.header(covia.grid.client.VenueHTTP.UCANS_HEADER);
+		if (h == null || h.isBlank()) return null;
+		AVector<ACell> v = convex.core.data.Vectors.empty();
+		for (String part : h.split(",")) {
+			String t = part.trim();
+			if (!t.isEmpty()) v = v.conj(Strings.create(t));
+		}
+		return v.isEmpty() ? null : v;
+	}
+
+	/**
 	 * As {@link #withTransportAuth(RequestContext, AString, AVector)}, and — when
 	 * {@code venueDID} is supplied and the transport is unauthenticated — derives
 	 * the caller's identity from a presented <b>identity token</b>: a verified

--- a/venue/src/test/java/covia/venue/grid/HitlFederationTest.java
+++ b/venue/src/test/java/covia/venue/grid/HitlFederationTest.java
@@ -1,0 +1,209 @@
+package covia.venue.grid;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+import convex.auth.ucan.Capability;
+import convex.auth.ucan.UCAN;
+import convex.core.crypto.AKeyPair;
+import convex.core.data.ACell;
+import convex.core.data.AMap;
+import convex.core.data.AString;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+import convex.core.lang.RT;
+import covia.adapter.HITLAdapter;
+import covia.api.Fields;
+import covia.grid.Job;
+import covia.grid.Status;
+import covia.grid.auth.VenueAuth;
+import covia.grid.client.VenueHTTP;
+import covia.grid.hitl.Hitl;
+import covia.venue.TwoVenueTestServer;
+
+/**
+ * Cross-venue HITL (COG-16 §Cross-Venue Requests): the requester on venue A
+ * asks a user whose inbox lives on venue B, via the standard federation
+ * surfaces (COG-15) — no HITL-specific federation machinery exists, which is
+ * the point:
+ *
+ * <ul>
+ *   <li><b>Caller identity</b> crosses the hop as an audience-bound identity
+ *       token; B attributes the request to the requester's own DID.</li>
+ *   <li><b>Delivery authority</b> crosses in the proof channel: the target
+ *       user's {@code hitl/request} delegation, forwarded by A, enforced by
+ *       B at delivery exactly as in the local case.</li>
+ *   <li><b>The Job lives on B</b> (it carries the request); the requester
+ *       observes it through the federation job surfaces and receives any
+ *       granted token in its output.</li>
+ * </ul>
+ *
+ * <p>Uses the shared {@link TwoVenueTestServer} venues — nothing is spun up
+ * per test; identities are fresh per test method.</p>
+ */
+public class HitlFederationTest {
+
+	private static final AString OP_GRID_INVOKE = Strings.create("v/ops/grid/invoke");
+	private static final AString OP_GRID_JOB_STATUS = Strings.create("v/ops/grid/job-status");
+
+	/** Identity token: empty att, audienced to {@code venueDID} — pure proof
+	 *  of the caller's identity at that venue, unusable anywhere else. */
+	private static String identityToken(AKeyPair kp, String venueDID) {
+		long exp = (System.currentTimeMillis() / 1000) + 300;
+		return UCAN.create(kp, UCAN.fromDIDKey(Strings.create(venueDID)), exp,
+			Vectors.empty(), Vectors.empty()).toJWT(kp).toString();
+	}
+
+	/** Polls the remote job through venue A until it reaches {@code wanted}
+	 *  (or times out); returns the last status map seen. */
+	private static AMap<AString, ACell> awaitRemoteStatus(VenueHTTP viaA, String remoteId,
+			AString wanted, long timeoutMs) throws Exception {
+		long deadline = System.currentTimeMillis() + timeoutMs;
+		ACell lastSeen = null;
+		while (System.currentTimeMillis() < deadline) {
+			Job probe = viaA.invokeAndWait(OP_GRID_JOB_STATUS, Maps.of(
+				Fields.VENUE, TwoVenueTestServer.BASE_URL_B,
+				"id", remoteId));
+			lastSeen = probe.getData();
+			if (Status.COMPLETE.equals(probe.getStatus())) {
+				AMap<AString, ACell> status = RT.castMap(probe.getOutput());
+				if (status != null && wanted.equals(RT.ensureString(status.get(Fields.STATUS)))) return status;
+			}
+			Thread.sleep(100);
+		}
+		throw new AssertionError("remote job did not reach " + wanted + " within " + timeoutMs
+			+ "ms; last probe: " + lastSeen);
+	}
+
+	private static String bare(String id) {
+		return (id != null && id.startsWith("0x")) ? id.substring(2) : id;
+	}
+
+	/**
+	 * The full COG-16 cross-venue flow: delegated delivery, remote park,
+	 * response on B, completion observed (with the granted token) through A.
+	 */
+	@Test
+	public void hitlRequestAcrossVenues() throws Exception {
+		// Alice: inbox on venue B. Bob: requester, calling via venue A.
+		AKeyPair aliceKP = AKeyPair.generate();
+		AString aliceDID = UCAN.toDIDKey(aliceKP.getAccountKey());
+		AKeyPair bobKP = AKeyPair.generate();
+		AString bobDID = UCAN.toDIDKey(bobKP.getAccountKey());
+
+		// Alice delegates hitl/request over her inbox to Bob (self-sovereign).
+		long exp = (System.currentTimeMillis() / 1000) + 3600;
+		String hitlGrant = UCAN.create(aliceKP, UCAN.fromDIDKey(bobDID), exp,
+			Vectors.of(Capability.create(
+				Strings.create(aliceDID + "/h/"), HITLAdapter.ABILITY_HITL_REQUEST)),
+			Vectors.empty()).toJWT(aliceKP).toString();
+
+		// Bob calls VENUE A; his ucans carry the delegation plus his identity
+		// token for venue B. The grid op input carries data only (COG-15).
+		VenueHTTP bobOnA = VenueHTTP.create(
+			URI.create(TwoVenueTestServer.BASE_URL_A), VenueAuth.keyPair(bobKP));
+		bobOnA.setUcans(java.util.List.of(
+			hitlGrant, identityToken(bobKP, TwoVenueTestServer.DID_B)));
+
+		Job hop = bobOnA.invokeAndWait(OP_GRID_INVOKE, Maps.of(
+			Fields.VENUE, TwoVenueTestServer.BASE_URL_B,
+			Fields.OPERATION, "v/ops/hitl/request",
+			Fields.INPUT, Hitl.request("Report access")
+				.to(aliceDID.toString())
+				.description("Bob needs read access to your reports")
+				.ask(Hitl.approval("access", "Grant report access?").required()
+					.grant("w/reports/", "crud/read"))
+				.build()));
+		assertEquals(Status.COMPLETE, hop.getStatus(),
+			"grid:invoke should return the remote job's status: "
+				+ RT.getIn(hop.getData(), Fields.ERROR));
+		AMap<AString, ACell> remote = RT.castMap(hop.getOutput());
+		String remoteId = RT.ensureString(remote.get(Strings.intern("id"))).toString();
+		assertEquals(Status.INPUT_REQUIRED, RT.ensureString(remote.get(Fields.STATUS)),
+			"the remote HITL job parks INPUT_REQUIRED awaiting Alice");
+
+		// The record landed in Alice's inbox ON VENUE B, attributed to Bob.
+		AMap<AString, ACell> record = TwoVenueTestServer.ENGINE_B.getVenueState()
+			.users().ensure(aliceDID).getHitlRequest(Strings.create(bare(remoteId)));
+		assertNotNull(record, "delivery must land in Alice's inbox on venue B");
+		assertEquals(bobDID, record.get(Hitl.FROM),
+			"from is the requester's verified cross-venue identity");
+		assertEquals(Hitl.OPEN, record.get(Hitl.STATUS));
+
+		// Alice answers ON VENUE B, approving and echoing the offered grant.
+		VenueHTTP aliceOnB = VenueHTTP.create(
+			URI.create(TwoVenueTestServer.BASE_URL_B), VenueAuth.keyPair(aliceKP));
+		Job respond = aliceOnB.invokeAndWait(Strings.create("v/ops/hitl/respond"),
+			Hitl.answer(remoteId)
+				.answer("access", true)
+				.echo("w/reports/", "crud/read")
+				.comment("approved from venue B")
+				.build());
+		assertEquals(Status.COMPLETE, respond.getStatus(),
+			"Alice's respond on B should complete: " + RT.getIn(respond.getData(), Fields.ERROR));
+
+		// Bob observes completion through venue A's federation job surface and
+		// receives the granted token in the output.
+		AMap<AString, ACell> done = awaitRemoteStatus(bobOnA, remoteId, Status.COMPLETE, 10_000);
+		assertNotNull(done, "remote job status must be observable through venue A");
+		assertEquals(Status.COMPLETE, RT.ensureString(done.get(Fields.STATUS)));
+		AMap<AString, ACell> output = RT.castMap(done.get(Fields.OUTPUT));
+		assertEquals(convex.core.data.prim.CVMBool.TRUE, RT.getIn(output, "answers", "access"));
+
+		AString jwt = RT.ensureString(output.get(Hitl.TOKEN));
+		assertNotNull(jwt, "the granted token flows back in the job output");
+		UCAN token = UCAN.fromJWT(jwt);
+		assertEquals(bobDID, token.getAudience(), "token is audienced to the requester");
+		assertEquals(Strings.create(aliceDID + "/w/reports/"),
+			RT.getIn(token.getCapabilities().get(0), Capability.WITH),
+			"the grant covers Alice's resource, canonicalised at issuance on B");
+	}
+
+	/**
+	 * ADVERSARIAL: without the target's {@code hitl/request} delegation the
+	 * remote delivery is refused — the job on B fails and nothing lands in
+	 * Alice's inbox. Federation changes where the ask comes from, not what it
+	 * is allowed to do.
+	 */
+	@Test
+	public void hitlRequestAcrossVenuesDeniedWithoutDelegation() throws Exception {
+		AKeyPair aliceKP = AKeyPair.generate();
+		AString aliceDID = UCAN.toDIDKey(aliceKP.getAccountKey());
+		AKeyPair bobKP = AKeyPair.generate();
+
+		// Bob presents ONLY his identity token — no delegation from Alice.
+		VenueHTTP bobOnA = VenueHTTP.create(
+			URI.create(TwoVenueTestServer.BASE_URL_A), VenueAuth.keyPair(bobKP));
+		bobOnA.setUcans(java.util.List.of(
+			identityToken(bobKP, TwoVenueTestServer.DID_B)));
+
+		Job hop = bobOnA.invokeAndWait(OP_GRID_INVOKE, Maps.of(
+			Fields.VENUE, TwoVenueTestServer.BASE_URL_B,
+			Fields.OPERATION, "v/ops/hitl/request",
+			Fields.INPUT, Hitl.request("gimme")
+				.to(aliceDID.toString())
+				.ask(Hitl.approval("ok", "OK?"))
+				.build()));
+		assertEquals(Status.COMPLETE, hop.getStatus(),
+			"grid:invoke itself succeeds — the DENIAL is the remote job's state");
+		AMap<AString, ACell> remote = RT.castMap(hop.getOutput());
+		String remoteId = RT.ensureString(remote.get(Strings.intern("id"))).toString();
+
+		AMap<AString, ACell> failed = awaitRemoteStatus(bobOnA, remoteId, Status.FAILED, 10_000);
+		assertNotNull(failed);
+		assertEquals(Status.FAILED, RT.ensureString(failed.get(Fields.STATUS)),
+			"delivery without the hitl/request delegation must fail the remote job");
+		AString err = RT.ensureString(failed.get(Fields.ERROR));
+		assertTrue(err != null && err.toString().contains("hitl/request"),
+			"the denial names the missing ability: " + err);
+
+		// And nothing landed in Alice's inbox on B.
+		assertNull(TwoVenueTestServer.ENGINE_B.getVenueState()
+			.users().ensure(aliceDID).getHitlRequest(Strings.create(bare(remoteId))),
+			"a denied delivery must leave no record");
+	}
+}


### PR DESCRIPTION
- **`HitlFederationTest`** (shared `TwoVenueTestServer`, per-test identities — no per-test venues): the full COG-16 cross-venue flow (Bob on A → grid:invoke → delivery into Alice`s inbox on B under her forwarded `hitl/request` delegation → Alice responds on B → Bob observes COMPLETE and receives the granted token through A`s `grid:job-status`), plus the adversarial no-delegation case (remote job FAILED naming the ability, no record created).
- **Genuine gap found and fixed**: proofs only travelled in the invoke body, so a federated hop could create a remote job but never observe it (GET has no body → anonymous → existence-hiding 404). Proofs now also ride the `X-Covia-Ucans` header — explicitly attached by `VenueHTTP` from its own proof state, verified identically at ingress (`AuthMiddleware.headerUcans`), wired into `GET /jobs/{id}` with identity-from-proofs. COG-15/UCAN.md updated to refine the "never in headers" rationale (the invariant is *explicit* attachment + ingress verification, never passive propagation).

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)