### PR TITLE
Authenticated access to the public user (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - HITL requests (COG-16) — `hitl:request`/`respond`/`list` over the per-user `h/` inbox, typed asks, choice-bound grants with echo-consent, restart-safe expiry; `hitl` skill
 - `Hitl` builders (covia-core) — fluent, transport-portable construction of HITL requests, asks and responses
 - Federated job observation carries caller proofs — `X-Covia-Ucans` header on body-less job reads; cross-venue HITL verified end-to-end
+- Authenticated callers get public-user access per the public ceiling (#254) — reads, public jobs, DLFS, and secret resolution fallback (use-only, never extraction)
 - `ucan:issue` is a granting surface — mints over another principal's resource under a presented `grant/<ability>` right, expiry-capped by the right's validity
 
 ### Changed

--- a/venue/src/main/java/covia/adapter/CoviaAdapter.java
+++ b/venue/src/main/java/covia/adapter/CoviaAdapter.java
@@ -1929,12 +1929,11 @@ public class CoviaAdapter extends AAdapter {
 	@SuppressWarnings("unchecked")
 	private boolean verifyProofs(RequestContext ctx,
 			String requestedResource, String requestedAbility) {
-		// Single cross-user grant check, shared with job-read authorisation
-		// (covia#102) so the lattice-read path and the job path enforce the
-		// same right. Signature + chain already verified at transport ingress.
-		return CapabilityChecker.proofsCover(ctx.getProofs(), ctx.getCallerDID(),
-			engine.getDIDString(), Strings.create(requestedResource),
-			Strings.create(requestedAbility), System.currentTimeMillis() / 1000);
+		// Single cross-user gate (covia#102), shared with job-read
+		// authorisation — public-owned resources and presented proofs are
+		// both decided there. Signatures verified at transport ingress.
+		return engine.crossUserAllows(ctx, Strings.create(requestedResource),
+			Strings.create(requestedAbility));
 	}
 
 }

--- a/venue/src/main/java/covia/adapter/DLFSAdapter.java
+++ b/venue/src/main/java/covia/adapter/DLFSAdapter.java
@@ -359,10 +359,7 @@ public class DLFSAdapter extends AAdapter implements covia.venue.storage.Content
 		if (cross) {
 			String resource = dlfsResource(fr.ownerDID(), Strings.create(fr.drive()),
 				Strings.create(fr.path()));
-			boolean ok = CapabilityChecker.proofsCover(
-				ctx.getProofs(), ctx.getCallerDID(), engine.getDIDString(),
-				Strings.create(resource), ability,
-				System.currentTimeMillis() / 1000);
+			boolean ok = engine.crossUserAllows(ctx, Strings.create(resource), ability);
 			if (!ok) throw new IllegalStateException(
 				"Access denied: no " + ability + " capability for " + resource);
 			driveCtx = RequestContext.of(fr.ownerDID());
@@ -472,10 +469,7 @@ public class DLFSAdapter extends AAdapter implements covia.venue.storage.Content
 		}
 		AString pathCell = RT.ensureString(RT.getIn(input, FIELD_PATH));
 		String resource = dlfsResource(target.ownerDID(), Strings.create(target.driveName()), pathCell);
-		boolean ok = CapabilityChecker.proofsCover(
-			ctx.getProofs(), ctx.getCallerDID(), engine.getDIDString(),
-			Strings.create(resource), ability,
-			System.currentTimeMillis() / 1000);
+		boolean ok = engine.crossUserAllows(ctx, Strings.create(resource), ability);
 		if (!ok) throw new IllegalStateException(
 			"Access denied: no " + ability + " capability for " + resource);
 	}

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -2098,6 +2098,43 @@ public class Engine {
 		}
 	}
 
+	// ========== Cross-user authorisation ==========
+
+	/**
+	 * The single cross-user authorisation gate (covia#102): may this caller
+	 * act on a resource belonging to another user?
+	 *
+	 * <p>Two rights compose, checked in order:</p>
+	 * <ol>
+	 *   <li><b>Ambient public access</b> (covia#254) — a resource owned by the
+	 *       venue's PUBLIC identity follows the public capability ceiling for
+	 *       ANY caller: an authenticated caller is at least as privileged as
+	 *       the anonymous one. Checked only when the resource is actually
+	 *       public-owned; tracks operator policy ({@code auth.public.caps} —
+	 *       default read-only, widened at the operator's own risk).</li>
+	 *   <li><b>Presented UCAN proofs</b> — the pure fail-closed delegation
+	 *       check ({@link covia.lattice.CapabilityChecker#proofsCover}).</li>
+	 * </ol>
+	 */
+	public boolean crossUserAllows(RequestContext ctx, AString resource, AString ability) {
+		if (ctx == null || resource == null || ability == null) return false;
+		if (auth.isPublicAccessEnabled()) {
+			String publicDIDStr = getDIDString().toString() + ":public";
+			String r = resource.toString();
+			if (r.equals(publicDIDStr) || r.startsWith(publicDIDStr + "/")) {
+				AString publicDID = Strings.create(publicDIDStr);
+				convex.core.data.AVector<ACell> ceiling = auth.getPublicCeiling(publicDID);
+				// null ceiling = operator-configured unrestricted public access
+				if (ceiling == null || covia.lattice.CapabilityChecker.allows(
+						ceiling, resource, ability, publicDID) == null) {
+					return true;
+				}
+			}
+		}
+		return covia.lattice.CapabilityChecker.proofsCover(ctx.getProofs(), ctx.getCallerDID(),
+			getDIDString(), resource, ability, System.currentTimeMillis() / 1000);
+	}
+
 	// ========== Secret resolution ==========
 
 	/**
@@ -2123,12 +2160,28 @@ public class Engine {
 		if (name.isEmpty()) return null;
 
 		User user = venueState.users().get(callerDID);
-		if (user == null) return null;   // identity has no store — genuinely absent
 
-		AString value;
+		AString value = null;
 		try {
 			byte[] encKey = SecretStore.deriveKey(keyPair);
-			value = user.secrets().decrypt(Strings.create(name), encKey);
+			if (user != null) {
+				value = user.secrets().decrypt(Strings.create(name), encKey);
+			}
+			// covia#254: fall back to the PUBLIC user's store — the anonymous
+			// public caller resolves these as their own, and an authenticated
+			// caller is at least as privileged. RESOLUTION-ONLY: the value flows
+			// into operations (secretFields-redacted in records); secret:extract
+			// remains gated separately, so this never enables disclosure. The
+			// caller's own secret of the same name always shadows the public one.
+			if (value == null) {
+				String publicDIDStr = getDIDString().toString() + ":public";
+				if (!publicDIDStr.equals(callerDID.toString())) {
+					User publicUser = venueState.users().get(Strings.create(publicDIDStr));
+					if (publicUser != null) {
+						value = publicUser.secrets().decrypt(Strings.create(name), encKey);
+					}
+				}
+			}
 		} catch (Exception e) {
 			// A decrypt/key failure is NOT the same as "secret not set".
 			// Collapsing both to null (the old behaviour) masked real errors as

--- a/venue/src/main/java/covia/venue/JobManager.java
+++ b/venue/src/main/java/covia/venue/JobManager.java
@@ -641,9 +641,7 @@ public class JobManager {
 		AString owner = RT.ensureString(data.get(Fields.CALLER));
 		if (owner == null) return false; // venue-internal job — owner/internal only
 		AString resource = owner.append("/j/" + jobID.toHexString());
-		return CapabilityChecker.proofsCover(ctx.getProofs(), ctx.getCallerDID(),
-			engine.getDIDString(), resource, Capability.CRUD_READ,
-			System.currentTimeMillis() / 1000);
+		return engine.crossUserAllows(ctx, resource, Capability.CRUD_READ);
 	}
 
 	/**

--- a/venue/src/test/java/covia/venue/AuthenticatedPublicAccessTest.java
+++ b/venue/src/test/java/covia/venue/AuthenticatedPublicAccessTest.java
@@ -1,0 +1,169 @@
+package covia.venue;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import convex.core.data.ACell;
+import convex.core.data.AMap;
+import convex.core.data.AString;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import convex.core.data.prim.CVMBool;
+import convex.core.lang.RT;
+import covia.api.Fields;
+import covia.exception.AuthException;
+import covia.grid.Job;
+import covia.grid.Status;
+
+/**
+ * covia#254: an authenticated caller is at least as privileged as the
+ * anonymous public caller — access to the PUBLIC user's resources follows
+ * the public capability ceiling (default read-only), for any caller.
+ *
+ * <p>Parity is ceiling-governed, never hard-coded: what these tests assert
+ * under the default ceiling widens automatically (and deliberately —
+ * caveat emptor) when an operator widens {@code auth.public.caps}.</p>
+ */
+public class AuthenticatedPublicAccessTest {
+
+	private final Engine engine = TestEngine.ENGINE;
+
+	private AString PUBLIC_DID;
+	private RequestContext PUBLIC;
+	private AString ALICE_DID;
+	private RequestContext ALICE;
+	private AString BOB_DID;
+	private RequestContext BOB;
+
+	@BeforeEach
+	public void setup(TestInfo info) {
+		PUBLIC_DID = Strings.create(engine.getDIDString().toString() + ":public");
+		PUBLIC = RequestContext.of(PUBLIC_DID);
+		ALICE_DID = TestEngine.uniqueDID(info);
+		ALICE = RequestContext.of(ALICE_DID);
+		BOB_DID = TestEngine.uniqueDID(info + "-bob");
+		BOB = RequestContext.of(BOB_DID);
+	}
+
+	// ========== Lattice reads ==========
+
+	@Test
+	public void testAuthenticatedReadsPublicWorkspace() {
+		// Anonymous callers write public data as their own namespace.
+		engine.jobs().invokeOperation("v/ops/covia/write",
+			Maps.of(Fields.PATH, "w/pub-doc", Fields.VALUE, Strings.create("public content")),
+			PUBLIC).awaitResult(5000);
+
+		// An authenticated caller reads it via the DID-URL path — no proof needed.
+		ACell result = engine.jobs().invokeOperation("v/ops/covia/read",
+			Maps.of(Fields.PATH, PUBLIC_DID + "/w/pub-doc"), ALICE).awaitResult(5000);
+		assertEquals(CVMBool.TRUE, RT.getIn(result, "exists"));
+		assertEquals(Strings.create("public content"), RT.getIn(result, "value"));
+
+		// Parity, not blanket cross-user access: Bob's data stays protected.
+		engine.jobs().invokeOperation("v/ops/covia/write",
+			Maps.of(Fields.PATH, "w/private-doc", Fields.VALUE, Strings.create("bob content")),
+			BOB).awaitResult(5000);
+		assertThrows(Exception.class, () -> engine.jobs().invokeOperation("v/ops/covia/read",
+			Maps.of(Fields.PATH, BOB_DID + "/w/private-doc"), ALICE).awaitResult(5000),
+			"non-public cross-user reads still require a delegation proof");
+	}
+
+	@Test
+	public void testPublicWriteParityDeniedByDefault() {
+		// The default public ceiling is read-only, and cross-user DID-URL
+		// writes remain blocked — write parity arrives only if/when the write
+		// path supports public-targeted cursors under a widened ceiling.
+		assertThrows(Exception.class, () -> engine.jobs().invokeOperation("v/ops/covia/write",
+			Maps.of(Fields.PATH, PUBLIC_DID + "/w/x", Fields.VALUE, Strings.create("nope")),
+			ALICE).awaitResult(5000));
+	}
+
+	// ========== Job reads ==========
+
+	@Test
+	public void testAuthenticatedReadsPublicJob() {
+		// ACTIVE public job — readable via the job surface (hot-cache path,
+		// canReadJob's public-ceiling fallback).
+		Job activeJob = engine.jobs().invokeOperation("v/test/ops/never", Maps.empty(), PUBLIC);
+		try {
+			AMap<AString, ACell> viaAlice = engine.jobs().getJobData(activeJob.getID(), ALICE);
+			assertNotNull(viaAlice, "active public-owned jobs are readable per the public ceiling");
+			assertEquals(PUBLIC_DID, viaAlice.get(Fields.CALLER));
+
+			// Parity, not blanket access: Bob's active job stays owner-only.
+			Job bobJob = engine.jobs().invokeOperation("v/test/ops/never", Maps.empty(), BOB);
+			try {
+				assertThrows(AuthException.class,
+					() -> engine.jobs().getJobData(bobJob.getID(), ALICE),
+					"another user's job must stay unreadable without a proof");
+			} finally {
+				engine.jobs().cancelJob(bobJob.getID(), BOB);
+			}
+		} finally {
+			engine.jobs().cancelJob(activeJob.getID(), PUBLIC);
+		}
+
+		// TERMINAL public job — cross-user terminal reads go via the DID-URL
+		// lattice path (same rule as delegated reads), hitting the
+		// verifyProofs public-ceiling fallback.
+		Job doneJob = engine.jobs().invokeOperation("v/test/ops/echo",
+			Maps.of("text", "hello"), PUBLIC);
+		doneJob.awaitResult(5000);
+		ACell read = engine.jobs().invokeOperation("v/ops/covia/read",
+			Maps.of(Fields.PATH, PUBLIC_DID + "/j/" + doneJob.getID().toHexString()),
+			ALICE).awaitResult(5000);
+		assertEquals(CVMBool.TRUE, RT.getIn(read, "exists"),
+			"terminal public-owned jobs are readable via the DID-URL path");
+		assertEquals(PUBLIC_DID, RT.getIn(read, "value", Fields.CALLER.toString()));
+	}
+
+	// ========== Secret resolution fallback (use-only, never disclosure) ==========
+
+	@Test
+	public void testSecretResolutionFallsBackToPublicStore() {
+		// Operator-style provisioning into the public store.
+		engine.jobs().invokeOperation("v/ops/secret/set",
+			Maps.of("name", "PUB_FALLBACK_KEY", "value", "public-value"),
+			PUBLIC).awaitResult(5000);
+
+		// Authenticated resolution falls back to the public store...
+		assertEquals("public-value", engine.resolveSecret("s/PUB_FALLBACK_KEY", ALICE));
+		// ...and the public caller still resolves its own store directly.
+		assertEquals("public-value", engine.resolveSecret("s/PUB_FALLBACK_KEY", PUBLIC));
+
+		// The caller's OWN secret of the same name always shadows the public one.
+		engine.jobs().invokeOperation("v/ops/secret/set",
+			Maps.of("name", "PUB_FALLBACK_KEY", "value", "alice-own"),
+			ALICE).awaitResult(5000);
+		assertEquals("alice-own", engine.resolveSecret("s/PUB_FALLBACK_KEY", ALICE));
+	}
+
+	@Test
+	public void testSecretExtractionRemainsClosed() {
+		// covia#254 ruling: extraction is CEILING-governed, not hard-coded —
+		// today it is universally denied (gated implementation pending). When
+		// implemented it must require secret/decrypt, which the DEFAULT public
+		// ceiling withholds; an operator widening auth.public.caps to include
+		// it gets exactly what they asked for (caveat emptor). This test pins
+		// the closed state so that change is a conscious decision.
+		engine.jobs().invokeOperation("v/ops/secret/set",
+			Maps.of("name", "NO_EXTRACT", "value", "sensitive"),
+			PUBLIC).awaitResult(5000);
+
+		Job asPublic = engine.jobs().invokeOperation("v/ops/secret/extract",
+			Maps.of("name", "NO_EXTRACT"), PUBLIC);
+		assertThrows(Exception.class, () -> asPublic.awaitResult(5000));
+		assertEquals(Status.FAILED, asPublic.getStatus(),
+			"the shared public identity must not extract stored secret values");
+
+		Job asAlice = engine.jobs().invokeOperation("v/ops/secret/extract",
+			Maps.of("name", "NO_EXTRACT"), ALICE);
+		assertThrows(Exception.class, () -> asAlice.awaitResult(5000));
+		assertEquals(Status.FAILED, asAlice.getStatus(),
+			"the resolution fallback must never become a disclosure channel");
+	}
+}


### PR DESCRIPTION
`Engine.crossUserAllows(ctx, resource, ability)` is now the single cross-user gate (covia#102 shape): a public-identity-owned resource follows the **public capability ceiling** for any caller — checked only where relevant, at the venue-policy layer — else the untouched pure `CapabilityChecker.proofsCover`. Call sites (lattice reads, job reads, DLFS ×2) are one-liners.

- Default read-only ceiling → read parity for authenticated callers (public workspace, public jobs active + terminal, public drives); widened `auth.public.caps` widens parity identically (caveat emptor).
- `resolveSecret` falls back to the public store (own secrets shadow) — **use-only**: `secret:extract` remains universally closed, pinned by test with the ruling recorded (ceiling-governed via `secret/decrypt` when implemented; defaults withhold).
- Known limitation: write parity on widened venues additionally needs public-targeted write cursors — follow-up if wanted.
- 5 parity tests incl. adversarial (other users` data/jobs stay protected; extraction closed for everyone).

Closes #254. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)