### PR TITLE
Prompt-cache-friendly context assembly + Anthropic caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - Agent LLM calls are time-bounded (`llmTimeoutMs`) and interrupt the provider on cancel
 - Default agent tool pack trimmed to read-only — skills add tools on demand (#60)
 - Bare UCAN grant resources mean the issuer's own namespace — canonicalised at issuance (custodial) and evaluation (self-sovereign)
+- Agent context assembly is prompt-cache-friendly — volatile values (date, budget map) moved to the tail; Anthropic system/tools caching enabled
 
 ### Fixed
 - `a/<hash>` references resolve without a leading slash

--- a/venue/src/main/java/covia/adapter/LangChainAdapter.java
+++ b/venue/src/main/java/covia/adapter/LangChainAdapter.java
@@ -469,7 +469,13 @@ public class LangChainAdapter extends AAdapter {
 			.logRequests(false)
 			.logResponses(false)
 			.modelName(model)
-			.timeout(timeout);
+			.timeout(timeout)
+			// Anthropic prompt caching is explicit opt-in: mark the system
+			// prompt and tool definitions with cache_control. ContextBuilder
+			// keeps both stable across calls (no changing values in the early
+			// context), so agent loops reuse the cached prefix every iteration.
+			.cacheSystemMessages(true)
+			.cacheTools(true);
 		// Anthropic's API requires max_tokens on every request; when the caller
 		// doesn't bound it, langchain4j's model default applies (covia#198).
 		if (tuning.maxTokens() != null) builder = builder.maxTokens(tuning.maxTokens());

--- a/venue/src/main/java/covia/adapter/agent/ContextBuilder.java
+++ b/venue/src/main/java/covia/adapter/agent/ContextBuilder.java
@@ -261,12 +261,12 @@ public class ContextBuilder {
 		if (identity == null) identity = DEFAULT_IDENTITY_PROMPT;
 		StringBuilder sb = new StringBuilder(identity.toString());
 
-		// Session context: date/time and venue identity. Always included —
-		// agents that write timestamps, evaluate dates, or need to refer
-		// to their venue have no other way to get this information.
-		sb.append("\n\nCurrent date: ")
-		  .append(java.time.LocalDate.now().toString())
-		  .append(". Venue: ").append(engine.getName());
+		// Session context: venue identity and stable ids ONLY. The current
+		// date is deliberately NOT here — the system prompt is the head of
+		// every provider's cached prefix (OpenAI automatic prefix caching,
+		// Anthropic cache_control on system+tools), so it must contain no
+		// changing values. The date rides withCurrentDate() at the TAIL.
+		sb.append("\n\nVenue: ").append(engine.getName());
 		// Model name, if configured — helps the LLM self-calibrate
 		AString model = getConfigValue(config, Strings.intern("model"), null);
 		if (model != null) sb.append(". Model: ").append(model);
@@ -641,7 +641,25 @@ public class ContextBuilder {
 	}
 
 	/**
+	 * Appends the current date as a small tail message. Kept OUT of the system
+	 * prompt so the cacheable prefix (system + reference + history) contains no
+	 * changing values — this message busts only itself, once a day.
+	 */
+	public ContextBuilder withCurrentDate() {
+		ACell msg = Maps.of(K_ROLE, ROLE_SYSTEM, K_CONTENT,
+			Strings.create("Current date: " + java.time.LocalDate.now() + "."));
+		messages = messages.conj(msg);
+		trackMessage(msg);
+		return this;
+	}
+
+	/**
 	 * Appends a compact context map showing budget status and loaded paths.
+	 *
+	 * <p><b>Call this LAST among message sections</b>: the budget numbers
+	 * change on every build, so anything after this message is uncacheable by
+	 * prefix-cached providers. At the tail it busts only itself — and reports
+	 * the most accurate totals.</p>
 	 */
 	@SuppressWarnings("unchecked")
 	public ContextBuilder withContextMap(AMap<AString, ACell> loads) {

--- a/venue/src/main/java/covia/adapter/agent/GoalTreeAdapter.java
+++ b/venue/src/main/java/covia/adapter/agent/GoalTreeAdapter.java
@@ -374,6 +374,7 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 			builder = builder.withFrameStack(sessionFrames);
 		}
 		ContextBuilder.ContextResult context = builder
+			.withCurrentDate()                    // volatile (daily) → tail, cache-stable prefix
 			.withTools()
 			.build();
 
@@ -636,6 +637,7 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 			.withFrameStack(frames)
 			.withContextEntries()
 			.withSkillsIndex(indexLoads)
+			.withCurrentDate()                    // volatile (daily) → tail, cache-stable prefix
 			.withTools()
 			.build();
 

--- a/venue/src/main/java/covia/adapter/agent/LLMAgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/agent/LLMAgentAdapter.java
@@ -320,15 +320,16 @@ public class LLMAgentAdapter extends AbstractLLMAdapter {
 		ContextBuilder.ContextResult context = builder
 			.withConfig(recordConfig)
 			.withSessionId(RT.getIn(input, Fields.SESSION, Fields.ID))
-			.withSystemPrompt()                   // always fresh
-			.withContextEntries()                 // ephemeral (config.context)
-			.withSkillsIndex(effectiveLoads)      // ephemeral (config.skills index)
-			.withLoadedPaths(effectiveLoads)      // ephemeral (scope-chain view)
-			.withContextMap(effectiveLoads)       // ephemeral
-			.withFrameStack(sessionFrames)        // session.frames → LLM messages
-			.withPendingResults(pending)          // ephemeral (this turn)
+			.withSystemPrompt()                   // stable — head of the cached prefix
+			.withContextEntries()                 // stable while config.context unchanged
+			.withSkillsIndex(effectiveLoads)      // stable while loads unchanged
+			.withLoadedPaths(effectiveLoads)      // stable while loads unchanged
+			.withFrameStack(sessionFrames)        // session history — append-only
+			.withPendingResults(pending)          // this turn
 			.withInboxMessages(messages)          // this turn's user input
 			.withEmptyStateSignal(hasInput)
+			.withCurrentDate()                    // volatile (daily) → tail, after the prefix
+			.withContextMap(effectiveLoads)       // volatile (every build) → LAST message
 			.withTools()
 			.build();
 

--- a/venue/src/test/java/covia/adapter/agent/ContextBuilderTest.java
+++ b/venue/src/test/java/covia/adapter/agent/ContextBuilderTest.java
@@ -628,18 +628,55 @@ public class ContextBuilderTest {
 
 	@Test
 	public void testSystemPromptIncludesSessionContext() {
-		// Every agent should see current date and venue name.
+		// Venue name in the system prompt; the current date rides a TAIL
+		// message (withCurrentDate) so the cacheable prefix stays stable.
 		ContextBuilder.ContextResult result = new ContextBuilder(engine, ctx)
 			.withConfig(null)
 			.withSystemPrompt()
+			.withCurrentDate()
 			.build();
 		AString sys = extractSystemContent(result.history());
 		assertNotNull(sys);
 		String content = sys.toString();
-		assertTrue(content.contains("Current date:"),
-			"System prompt should include current date: " + content);
 		assertTrue(content.contains("Venue:"),
 			"System prompt should include venue name: " + content);
+		// CACHE GUARD: no changing values in the system prompt — the date
+		// must never creep back into the head of the cached prefix.
+		assertFalse(content.contains(java.time.LocalDate.now().toString()),
+			"system prompt must not contain the current date (cache buster): " + content);
+		// The date is present, as the last message.
+		AString tail = RT.ensureString(RT.getIn(
+			result.history().get(result.history().count() - 1), K_CONTENT));
+		assertTrue(tail.toString().contains(java.time.LocalDate.now().toString()),
+			"the date rides the tail message: " + tail);
+	}
+
+	@Test
+	public void testCachePrefixStability() {
+		// Two identical builds must produce IDENTICAL message sequences —
+		// prefix-cached providers (OpenAI automatic, Anthropic cache_control)
+		// only reuse a byte-stable prefix. Any per-build variation here is a
+		// cache buster and a regression.
+		AMap<AString, ACell> config = Maps.of(Strings.intern("defaultTools"), CVMBool.TRUE);
+		ContextBuilder.ContextResult r1 = new ContextBuilder(engine, ctx)
+			.withConfig(config).withSystemPrompt().withContextEntries()
+			.withCurrentDate().withTools().build();
+		ContextBuilder.ContextResult r2 = new ContextBuilder(engine, ctx)
+			.withConfig(config).withSystemPrompt().withContextEntries()
+			.withCurrentDate().withTools().build();
+		assertEquals(r1.history(), r2.history(),
+			"identical inputs must assemble identical messages (cache-stable)");
+		assertEquals(r1.tools(), r2.tools(),
+			"tool definitions must be build-stable (part of the cached prefix)");
+
+		// The volatile context map must be the LAST message when present.
+		ContextBuilder.ContextResult mapped = new ContextBuilder(engine, ctx)
+			.withConfig(config).withSystemPrompt().withCurrentDate()
+			.withContextMap(null).withTools().build();
+		AString last = RT.ensureString(RT.getIn(
+			mapped.history().get(mapped.history().count() - 1), K_CONTENT));
+		assertTrue(last.toString().startsWith("[Context Map]"),
+			"the per-build-volatile context map must sit at the tail: " + last);
 	}
 
 	@Test


### PR DESCRIPTION
Audit of agent context assembly for provider prompt caching (OpenAI automatic prefix, Anthropic explicit cache_control, DeepSeek prefix):

- **`withContextMap` (per-build budget numbers) sat BEFORE the conversation history** — every turn invalidated the whole history for every provider. Now the LAST message (busts only itself; reports truer totals).
- **Current date sat in the system prompt** (head of the cached prefix, daily churn). Now a tiny `withCurrentDate()` tail message in all three builder chains; the system prompt carries only stable values.
- **Anthropic caching enabled** — `cacheSystemMessages(true)` + `cacheTools(true)` (explicit opt-in; previously zero caching on Anthropic regardless of stability).
- `testCachePrefixStability`: identical builds must assemble identical message sequences + tool vectors; context map must be tail; date can never creep back into the prefix head.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)