### PR TITLE
Authority: single authorization seam + immutable Authority value (grants-not-ceiling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - Bare UCAN grant resources mean the issuer's own namespace — canonicalised at issuance (custodial) and evaluation (self-sovereign)
 - Agent context assembly is prompt-cache-friendly — volatile values (date, budget map) moved to the tail; Anthropic system/tools caching enabled
 
+### Removed
+- Wire self-attenuation on `/invoke` (#131) — presented proofs are additive-only; reduce authority via a narrower `Authority`, not subtractive tokens
+
 ### Fixed
 - `a/<hash>` references resolve without a leading slash
 - Store unlocked when engine construction fails

--- a/covia-core/src/main/java/covia/api/Abilities.java
+++ b/covia-core/src/main/java/covia/api/Abilities.java
@@ -21,6 +21,8 @@ public final class Abilities {
 	public static final AString SECRET_WRITE  = Strings.intern("secret/write");
 	public static final AString MCP_MANAGE    = Strings.intern("mcp/manage");
 	public static final AString HITL_REQUEST  = Strings.intern("hitl/request");
+	public static final AString AGENT_CREATE  = Strings.intern("agent/create");
+	public static final AString AGENT_REQUEST = Strings.intern("agent/request");
 	public static final AString AGENT_MESSAGE = Strings.intern("agent/message");
 	public static final AString AGENT_WRITE   = Strings.intern("agent/write");
 

--- a/covia-core/src/main/java/covia/api/Abilities.java
+++ b/covia-core/src/main/java/covia/api/Abilities.java
@@ -1,0 +1,29 @@
+package covia.api;
+
+import convex.core.data.AString;
+import convex.core.data.Strings;
+
+/**
+ * Shared covia capability abilities — the {@code can} of a UCAN grant.
+ *
+ * <p>One home for the covia-specific ability strings so they are never
+ * inline-interned or duplicated per adapter. The generic CRUD abilities
+ * ({@code crud/read}, {@code crud/write}, {@code crud/delete}) and {@code invoke}
+ * live on {@link convex.auth.ucan.Capability}; these are the covia-domain
+ * additions on top.</p>
+ */
+public final class Abilities {
+
+	private Abilities() {}
+
+	public static final AString ASSET_READ    = Strings.intern("asset/read");
+	public static final AString ASSET_STORE   = Strings.intern("asset/store");
+	public static final AString SECRET_WRITE  = Strings.intern("secret/write");
+	public static final AString MCP_MANAGE    = Strings.intern("mcp/manage");
+	public static final AString HITL_REQUEST  = Strings.intern("hitl/request");
+	public static final AString AGENT_MESSAGE = Strings.intern("agent/message");
+	public static final AString AGENT_WRITE   = Strings.intern("agent/write");
+
+	/** The venue-scoped MCP management resource guarded by {@link #MCP_MANAGE}. */
+	public static final AString V_MCP = Strings.intern("v/mcp");
+}

--- a/covia-core/src/main/java/covia/grid/Authority.java
+++ b/covia-core/src/main/java/covia/grid/Authority.java
@@ -18,10 +18,10 @@ import convex.core.data.Vectors;
  * job id).</p>
  *
  * <p><b>Grants are additive.</b> An {@code Authority} can be augmented with
- * further delegations (e.g. a short-lived, audience-bound UCAN handed to an
- * agent for a specific task) via {@link #withProof}/{@link #withProofs}. There is
- * no ceiling here: attenuation is a property of each individual delegation (you
- * can only delegate what you hold, and you mint it narrow), not of the
+ * further delegations (e.g. a short-lived, audience-bound UCAN handed to an agent
+ * for a specific task) via {@link #withGrant}/{@link #withGrants}. There is no
+ * ceiling here: attenuation is a property of each individual delegation (you can
+ * only delegate what you hold, and you mint it narrow), not of the
  * {@code Authority} as a whole.</p>
  *
  * <p>Immutable and thread-safe: every {@code with*} method returns a new
@@ -32,15 +32,15 @@ public final class Authority {
 	/** Caller identity (DID), or {@code null} for anonymous. */
 	private final AString did;
 
-	/** Verified UCAN delegation tokens this authority carries. Never null. */
-	private final AVector<ACell> proofs;
+	/** Verified UCAN delegation grants this authority carries. Never null. */
+	private final AVector<ACell> grants;
 
 	/** The anonymous authority: no identity, no grants. */
 	public static final Authority ANONYMOUS = new Authority(null, Vectors.empty());
 
-	private Authority(AString did, AVector<ACell> proofs) {
+	private Authority(AString did, AVector<ACell> grants) {
 		this.did = did;
-		this.proofs = (proofs != null) ? proofs : Vectors.empty();
+		this.grants = (grants != null) ? grants : Vectors.empty();
 	}
 
 	/**
@@ -54,10 +54,10 @@ public final class Authority {
 	/**
 	 * An authority for the given identity carrying the given verified grants.
 	 * @param did Caller DID, or null for anonymous
-	 * @param proofs Verified UCAN delegation tokens (null treated as none)
+	 * @param grants Verified UCAN delegation tokens (null treated as none)
 	 */
-	public static Authority of(AString did, AVector<ACell> proofs) {
-		return new Authority(did, proofs);
+	public static Authority of(AString did, AVector<ACell> grants) {
+		return new Authority(did, grants);
 	}
 
 	/** The caller identity, or null if anonymous. */
@@ -66,8 +66,8 @@ public final class Authority {
 	}
 
 	/** The grants (verified UCAN delegations) this authority carries; never null. */
-	public AVector<ACell> getProofs() {
-		return proofs;
+	public AVector<ACell> getGrants() {
+		return grants;
 	}
 
 	/** True if this authority carries no identity. */
@@ -76,42 +76,44 @@ public final class Authority {
 	}
 
 	/** True if this authority carries at least one grant. */
-	public boolean hasProofs() {
-		return !proofs.isEmpty();
+	public boolean hasGrants() {
+		return !grants.isEmpty();
 	}
 
 	/**
-	 * Returns a copy of this authority augmented with one additional grant.
-	 * @param proof a verified UCAN delegation token (ignored if null)
+	 * Returns a copy of this authority augmented with one additional grant — the
+	 * primary way an authority acquires extra authority (e.g. a time-limited,
+	 * audience-bound UCAN handed to an agent for a task).
+	 * @param grant a verified UCAN delegation token (ignored if null)
 	 */
-	public Authority withProof(ACell proof) {
-		if (proof == null) return this;
-		return new Authority(did, proofs.concat(Vectors.of(proof)));
+	public Authority withGrant(ACell grant) {
+		if (grant == null) return this;
+		return new Authority(did, grants.concat(Vectors.of(grant)));
 	}
 
 	/**
 	 * Returns a copy of this authority augmented with additional grants.
 	 * @param more verified UCAN delegation tokens (null/empty is a no-op)
 	 */
-	public Authority withProofs(AVector<ACell> more) {
+	public Authority withGrants(AVector<ACell> more) {
 		if (more == null || more.isEmpty()) return this;
-		return new Authority(did, proofs.concat(more));
+		return new Authority(did, grants.concat(more));
 	}
 
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (!(o instanceof Authority a)) return false;
-		return Objects.equals(did, a.did) && proofs.equals(a.proofs);
+		return Objects.equals(did, a.did) && grants.equals(a.grants);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(did, proofs);
+		return Objects.hash(did, grants);
 	}
 
 	@Override
 	public String toString() {
-		return "Authority[" + (did != null ? did : "anonymous") + ", grants=" + proofs.count() + "]";
+		return "Authority[" + (did != null ? did : "anonymous") + ", grants=" + grants.count() + "]";
 	}
 }

--- a/covia-core/src/main/java/covia/grid/Authority.java
+++ b/covia-core/src/main/java/covia/grid/Authority.java
@@ -8,56 +8,70 @@ import convex.core.data.AVector;
 import convex.core.data.Vectors;
 
 /**
- * An immutable credential of authority: the identity (a DID) a caller presents,
- * plus the set of <b>grants</b> (verified UCAN delegation tokens) it carries.
+ * An immutable credential of authority: <b>who</b> a caller is (a DID) plus
+ * <b>what they may do</b> — the grants they hold. It is the portable "identity
+ * plus authorisation" a request or handle acts under; a venue's
+ * {@code RequestContext} wraps an {@code Authority} and adds only per-execution
+ * state (execution scopes, job id).
  *
- * <p>This is the portable "who, plus what has been delegated to them" that a
- * request or a handle acts under — the authority a caller <em>brings</em>. It is
- * distinct from a venue's evaluated {@code RequestContext}, which wraps an
- * {@code Authority} and adds venue-local, per-execution state (execution scopes,
- * job id).</p>
+ * <p><b>Two grant sources, one rule.</b> An action is authorised iff a grant
+ * covers it — <em>either you have the right or you don't</em>. There is no
+ * ceiling: nothing here subtracts. Grants arrive two ways, both additive:</p>
+ * <ul>
+ *   <li><b>{@code grants}</b> — the caller's own held capability scope (an
+ *       agent's {@code config.caps}). {@code null} means an <em>unrestricted</em>
+ *       principal (the owner/venue) — not "a grant of everything" but "no
+ *       explicit scope, so inherent authority stands"; it is the efficient
+ *       fast-path. A non-null scope binds the principal to exactly those
+ *       capabilities.</li>
+ *   <li><b>{@code proofs}</b> — presented, verified UCAN delegation tokens, the
+ *       additive cross-user reach a caller <em>brings</em> to a request.</li>
+ * </ul>
  *
- * <p><b>Grants are additive.</b> An {@code Authority} can be augmented with
- * further delegations (e.g. a short-lived, audience-bound UCAN handed to an agent
- * for a specific task) via {@link #withGrant}/{@link #withGrants}. There is no
- * ceiling here: attenuation is a property of each individual delegation (you can
- * only delegate what you hold, and you mint it narrow), not of the
- * {@code Authority} as a whole.</p>
- *
- * <p>Immutable and thread-safe: every {@code with*} method returns a new
- * instance. Equality is by value (identity + grants).</p>
+ * <p>An {@code Authority} can be augmented — a short-lived, audience-bound UCAN
+ * handed to an agent widens what it may do without ever narrowing it
+ * ({@link #withGrant}/{@link #withGrants} on the scope; {@link #withProofs} for
+ * presented delegations). Immutable and thread-safe: every {@code with*} returns
+ * a new instance. Equality is by value.</p>
  */
 public final class Authority {
 
 	/** Caller identity (DID), or {@code null} for anonymous. */
 	private final AString did;
 
-	/** Verified UCAN delegation grants this authority carries. Never null. */
+	/** The caller's own held capability scope. {@code null} = unrestricted. */
 	private final AVector<ACell> grants;
 
-	/** The anonymous authority: no identity, no grants. */
-	public static final Authority ANONYMOUS = new Authority(null, Vectors.empty());
+	/** Presented, verified UCAN delegation tokens, or {@code null} if none. */
+	private final AVector<ACell> proofs;
 
-	private Authority(AString did, AVector<ACell> grants) {
+	/** The anonymous authority: no identity, unrestricted-irrelevant, no proofs. */
+	public static final Authority ANONYMOUS = new Authority(null, null, null);
+
+	private Authority(AString did, AVector<ACell> grants, AVector<ACell> proofs) {
 		this.did = did;
-		this.grants = (grants != null) ? grants : Vectors.empty();
+		this.grants = grants;
+		this.proofs = proofs;
 	}
 
 	/**
-	 * An authority for the given identity, carrying no grants.
+	 * An authority for the given identity, unrestricted ({@code null} scope) and
+	 * carrying no presented proofs.
 	 * @param did Caller DID, or null for anonymous
 	 */
 	public static Authority of(AString did) {
-		return (did == null) ? ANONYMOUS : new Authority(did, Vectors.empty());
+		return (did == null) ? ANONYMOUS : new Authority(did, null, null);
 	}
 
 	/**
-	 * An authority for the given identity carrying the given verified grants.
+	 * An authority for the given identity bound to the given capability scope.
+	 * A {@code null} scope is unrestricted; a non-null scope binds the principal
+	 * to exactly those capabilities (an agent's {@code config.caps}).
 	 * @param did Caller DID, or null for anonymous
-	 * @param grants Verified UCAN delegation tokens (null treated as none)
+	 * @param grants the held capability scope, or null for unrestricted
 	 */
 	public static Authority of(AString did, AVector<ACell> grants) {
-		return new Authority(did, grants);
+		return (did == null && grants == null) ? ANONYMOUS : new Authority(did, grants, null);
 	}
 
 	/** The caller identity, or null if anonymous. */
@@ -65,9 +79,14 @@ public final class Authority {
 		return did;
 	}
 
-	/** The grants (verified UCAN delegations) this authority carries; never null. */
+	/** The held capability scope; {@code null} = unrestricted (the fast path). */
 	public AVector<ACell> getGrants() {
 		return grants;
+	}
+
+	/** The presented, verified UCAN delegations, or null if none. */
+	public AVector<ACell> getProofs() {
+		return proofs;
 	}
 
 	/** True if this authority carries no identity. */
@@ -75,45 +94,76 @@ public final class Authority {
 		return did == null;
 	}
 
-	/** True if this authority carries at least one grant. */
+	/** True if this authority is bound to an explicit (non-null, non-empty) scope. */
 	public boolean hasGrants() {
-		return !grants.isEmpty();
+		return grants != null && !grants.isEmpty();
+	}
+
+	/** True if this authority carries at least one presented proof. */
+	public boolean hasProofs() {
+		return proofs != null && !proofs.isEmpty();
 	}
 
 	/**
-	 * Returns a copy of this authority augmented with one additional grant — the
-	 * primary way an authority acquires extra authority (e.g. a time-limited,
-	 * audience-bound UCAN handed to an agent for a task).
-	 * @param grant a verified UCAN delegation token (ignored if null)
+	 * Returns a copy augmented with one additional capability in its scope — the
+	 * additive way an authority acquires more authority. A no-op on an
+	 * unrestricted authority (a {@code null} scope already covers everything).
+	 * @param grant a capability (ignored if null)
 	 */
 	public Authority withGrant(ACell grant) {
-		if (grant == null) return this;
-		return new Authority(did, grants.concat(Vectors.of(grant)));
+		if (grant == null || grants == null) return this;
+		return new Authority(did, grants.concat(Vectors.of(grant)), proofs);
 	}
 
 	/**
-	 * Returns a copy of this authority augmented with additional grants.
-	 * @param more verified UCAN delegation tokens (null/empty is a no-op)
+	 * Returns a copy augmented with additional capabilities in its scope. A no-op
+	 * on an unrestricted authority ({@code null} scope) or an empty argument.
+	 * @param more capabilities (null/empty is a no-op)
 	 */
 	public Authority withGrants(AVector<ACell> more) {
-		if (more == null || more.isEmpty()) return this;
-		return new Authority(did, grants.concat(more));
+		if (more == null || more.isEmpty() || grants == null) return this;
+		return new Authority(did, grants.concat(more), proofs);
+	}
+
+	/**
+	 * Returns a copy with its capability scope replaced. {@code null} = make the
+	 * authority unrestricted; a vector binds it to exactly those capabilities.
+	 * Identity and presented proofs are preserved.
+	 */
+	public Authority withGrantScope(AVector<ACell> grants) {
+		return new Authority(did, grants, proofs);
+	}
+
+	/**
+	 * Returns a copy carrying the given presented, verified UCAN delegations,
+	 * replacing any already attached. Identity and scope are preserved.
+	 *
+	 * <p><b>Trust contract:</b> every token must already be cryptographically
+	 * verified (signature, expiry-at-verification, chain integrity) — downstream
+	 * authorisation re-checks only temporal bounds and policy, never signatures.</p>
+	 */
+	public Authority withProofs(AVector<ACell> proofs) {
+		return new Authority(did, grants, proofs);
 	}
 
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (!(o instanceof Authority a)) return false;
-		return Objects.equals(did, a.did) && grants.equals(a.grants);
+		return Objects.equals(did, a.did)
+			&& Objects.equals(grants, a.grants)
+			&& Objects.equals(proofs, a.proofs);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(did, grants);
+		return Objects.hash(did, grants, proofs);
 	}
 
 	@Override
 	public String toString() {
-		return "Authority[" + (did != null ? did : "anonymous") + ", grants=" + grants.count() + "]";
+		return "Authority[" + (did != null ? did : "anonymous")
+			+ ", grants=" + (grants != null ? grants.count() : "unrestricted")
+			+ ", proofs=" + (proofs != null ? proofs.count() : 0) + "]";
 	}
 }

--- a/covia-core/src/main/java/covia/grid/Authority.java
+++ b/covia-core/src/main/java/covia/grid/Authority.java
@@ -1,0 +1,117 @@
+package covia.grid;
+
+import java.util.Objects;
+
+import convex.core.data.ACell;
+import convex.core.data.AString;
+import convex.core.data.AVector;
+import convex.core.data.Vectors;
+
+/**
+ * An immutable credential of authority: the identity (a DID) a caller presents,
+ * plus the set of <b>grants</b> (verified UCAN delegation tokens) it carries.
+ *
+ * <p>This is the portable "who, plus what has been delegated to them" that a
+ * request or a handle acts under — the authority a caller <em>brings</em>. It is
+ * distinct from a venue's evaluated {@code RequestContext}, which wraps an
+ * {@code Authority} and adds venue-local, per-execution state (execution scopes,
+ * job id).</p>
+ *
+ * <p><b>Grants are additive.</b> An {@code Authority} can be augmented with
+ * further delegations (e.g. a short-lived, audience-bound UCAN handed to an
+ * agent for a specific task) via {@link #withProof}/{@link #withProofs}. There is
+ * no ceiling here: attenuation is a property of each individual delegation (you
+ * can only delegate what you hold, and you mint it narrow), not of the
+ * {@code Authority} as a whole.</p>
+ *
+ * <p>Immutable and thread-safe: every {@code with*} method returns a new
+ * instance. Equality is by value (identity + grants).</p>
+ */
+public final class Authority {
+
+	/** Caller identity (DID), or {@code null} for anonymous. */
+	private final AString did;
+
+	/** Verified UCAN delegation tokens this authority carries. Never null. */
+	private final AVector<ACell> proofs;
+
+	/** The anonymous authority: no identity, no grants. */
+	public static final Authority ANONYMOUS = new Authority(null, Vectors.empty());
+
+	private Authority(AString did, AVector<ACell> proofs) {
+		this.did = did;
+		this.proofs = (proofs != null) ? proofs : Vectors.empty();
+	}
+
+	/**
+	 * An authority for the given identity, carrying no grants.
+	 * @param did Caller DID, or null for anonymous
+	 */
+	public static Authority of(AString did) {
+		return (did == null) ? ANONYMOUS : new Authority(did, Vectors.empty());
+	}
+
+	/**
+	 * An authority for the given identity carrying the given verified grants.
+	 * @param did Caller DID, or null for anonymous
+	 * @param proofs Verified UCAN delegation tokens (null treated as none)
+	 */
+	public static Authority of(AString did, AVector<ACell> proofs) {
+		return new Authority(did, proofs);
+	}
+
+	/** The caller identity, or null if anonymous. */
+	public AString getDID() {
+		return did;
+	}
+
+	/** The grants (verified UCAN delegations) this authority carries; never null. */
+	public AVector<ACell> getProofs() {
+		return proofs;
+	}
+
+	/** True if this authority carries no identity. */
+	public boolean isAnonymous() {
+		return did == null;
+	}
+
+	/** True if this authority carries at least one grant. */
+	public boolean hasProofs() {
+		return !proofs.isEmpty();
+	}
+
+	/**
+	 * Returns a copy of this authority augmented with one additional grant.
+	 * @param proof a verified UCAN delegation token (ignored if null)
+	 */
+	public Authority withProof(ACell proof) {
+		if (proof == null) return this;
+		return new Authority(did, proofs.concat(Vectors.of(proof)));
+	}
+
+	/**
+	 * Returns a copy of this authority augmented with additional grants.
+	 * @param more verified UCAN delegation tokens (null/empty is a no-op)
+	 */
+	public Authority withProofs(AVector<ACell> more) {
+		if (more == null || more.isEmpty()) return this;
+		return new Authority(did, proofs.concat(more));
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof Authority a)) return false;
+		return Objects.equals(did, a.did) && proofs.equals(a.proofs);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(did, proofs);
+	}
+
+	@Override
+	public String toString() {
+		return "Authority[" + (did != null ? did : "anonymous") + ", grants=" + proofs.count() + "]";
+	}
+}

--- a/covia-core/src/test/java/covia/grid/AuthorityTest.java
+++ b/covia-core/src/test/java/covia/grid/AuthorityTest.java
@@ -21,14 +21,17 @@ public class AuthorityTest {
 	private static final AString BOB = Strings.create("did:key:zBob");
 	private static final ACell GRANT_A = Strings.create("grant-a");
 	private static final ACell GRANT_B = Strings.create("grant-b");
+	private static final ACell PROOF = Strings.create("proof-1");
 
 	@Test
-	public void testIdentityOnly() {
+	public void testIdentityOnlyIsUnrestricted() {
+		// Identity with no explicit scope = unrestricted (null grants), no proofs.
 		Authority a = Authority.of(ALICE);
 		assertEquals(ALICE, a.getDID());
 		assertFalse(a.isAnonymous());
 		assertFalse(a.hasGrants());
-		assertTrue(a.getGrants().isEmpty());
+		assertNull(a.getGrants());   // null scope = unrestricted, the fast path
+		assertNull(a.getProofs());
 	}
 
 	@Test
@@ -41,54 +44,91 @@ public class AuthorityTest {
 	}
 
 	@Test
-	public void testNullProofsNormalised() {
-		Authority a = Authority.of(ALICE, null);
-		assertTrue(a.getGrants().isEmpty());
-		assertFalse(a.hasGrants());
+	public void testScopedConstruction() {
+		Authority a = Authority.of(ALICE, Vectors.of(GRANT_A));
+		assertEquals(1, a.getGrants().count());
+		assertTrue(a.hasGrants());
+		// a null scope is unrestricted, not a bound
+		assertNull(Authority.of(ALICE, null).getGrants());
 	}
 
 	@Test
-	public void testWithGrantsAreAdditiveAndImmutable() {
-		Authority base = Authority.of(ALICE);
-		Authority one = base.withGrant(GRANT_A);
-		Authority two = one.withGrant(GRANT_B);
+	public void testWithGrantIsAdditiveOnAScopedAuthority() {
+		Authority base = Authority.of(ALICE, Vectors.of(GRANT_A));  // scoped
+		Authority two = base.withGrant(GRANT_B);
 
 		// base is unchanged — immutability
-		assertFalse(base.hasGrants());
-		assertEquals(1, one.getGrants().count());
+		assertEquals(1, base.getGrants().count());
 		assertEquals(2, two.getGrants().count());
 		assertTrue(two.hasGrants());
 		assertEquals(ALICE, two.getDID());
 	}
 
 	@Test
-	public void testWithProofsBulk() {
-		AVector<ACell> more = Vectors.of(GRANT_A, GRANT_B);
-		Authority a = Authority.of(BOB).withGrants(more);
+	public void testWithGrantsBulk() {
+		Authority a = Authority.of(BOB, Vectors.of(GRANT_A)).withGrants(Vectors.of(GRANT_B));
 		assertEquals(2, a.getGrants().count());
 
-		// null / empty augmentation is a no-op that returns an equal authority
-		assertEquals(a, a.withGrants(null));
-		assertEquals(a, a.withGrants(Vectors.empty()));
+		// null / empty augmentation is a no-op
+		assertSame(a, a.withGrants(null));
+		assertSame(a, a.withGrants(Vectors.empty()));
+	}
+
+	@Test
+	public void testAugmentingUnrestrictedIsANoOp() {
+		// A null scope already covers everything — adding a grant cannot widen it,
+		// and must never accidentally narrow an unrestricted principal to a scope.
+		Authority unrestricted = Authority.of(ALICE);
+		assertSame(unrestricted, unrestricted.withGrant(GRANT_A));
+		assertSame(unrestricted, unrestricted.withGrants(Vectors.of(GRANT_A)));
+		assertNull(unrestricted.withGrant(GRANT_A).getGrants());
 	}
 
 	@Test
 	public void testNullGrantIgnored() {
-		Authority a = Authority.of(ALICE);
+		Authority a = Authority.of(ALICE, Vectors.of(GRANT_A));
 		assertSame(a, a.withGrant(null));
 	}
 
 	@Test
+	public void testWithGrantScopeReplaces() {
+		Authority unrestricted = Authority.of(ALICE);
+		Authority scoped = unrestricted.withGrantScope(Vectors.of(GRANT_A));
+		assertEquals(1, scoped.getGrants().count());
+		// replacing back to null restores unrestricted
+		assertNull(scoped.withGrantScope(null).getGrants());
+		// identity preserved
+		assertEquals(ALICE, scoped.getDID());
+	}
+
+	@Test
+	public void testWithProofsCarriesAndPreservesScope() {
+		Authority scoped = Authority.of(ALICE, Vectors.of(GRANT_A));
+		Authority withProof = scoped.withProofs(Vectors.of(PROOF));
+		assertEquals(1, withProof.getProofs().count());
+		assertTrue(withProof.hasProofs());
+		// scope and identity survive attaching proofs
+		assertEquals(1, withProof.getGrants().count());
+		assertEquals(ALICE, withProof.getDID());
+		// no proofs by default
+		assertFalse(scoped.hasProofs());
+	}
+
+	@Test
 	public void testEquality() {
-		Authority a1 = Authority.of(ALICE).withGrant(GRANT_A);
-		Authority a2 = Authority.of(ALICE).withGrant(GRANT_A);
-		Authority differentGrant = Authority.of(ALICE).withGrant(GRANT_B);
-		Authority differentDid = Authority.of(BOB).withGrant(GRANT_A);
+		Authority a1 = Authority.of(ALICE, Vectors.of(GRANT_A));
+		Authority a2 = Authority.of(ALICE, Vectors.of(GRANT_A));
+		Authority differentGrant = Authority.of(ALICE, Vectors.of(GRANT_B));
+		Authority differentDid = Authority.of(BOB, Vectors.of(GRANT_A));
+		Authority withProof = a1.withProofs(Vectors.of(PROOF));
 
 		assertEquals(a1, a2);
 		assertEquals(a1.hashCode(), a2.hashCode());
 		assertNotEquals(a1, differentGrant);
 		assertNotEquals(a1, differentDid);
+		assertNotEquals(a1, withProof);                       // proofs count in equality
 		assertNotEquals(Authority.of(ALICE), Authority.ANONYMOUS);
+		// unrestricted (null scope) != empty scope
+		assertNotEquals(Authority.of(ALICE), Authority.of(ALICE, Vectors.empty()));
 	}
 }

--- a/covia-core/src/test/java/covia/grid/AuthorityTest.java
+++ b/covia-core/src/test/java/covia/grid/AuthorityTest.java
@@ -27,15 +27,15 @@ public class AuthorityTest {
 		Authority a = Authority.of(ALICE);
 		assertEquals(ALICE, a.getDID());
 		assertFalse(a.isAnonymous());
-		assertFalse(a.hasProofs());
-		assertTrue(a.getProofs().isEmpty());
+		assertFalse(a.hasGrants());
+		assertTrue(a.getGrants().isEmpty());
 	}
 
 	@Test
 	public void testAnonymous() {
 		assertTrue(Authority.ANONYMOUS.isAnonymous());
 		assertNull(Authority.ANONYMOUS.getDID());
-		assertFalse(Authority.ANONYMOUS.hasProofs());
+		assertFalse(Authority.ANONYMOUS.hasGrants());
 		// of(null) collapses to the shared ANONYMOUS instance
 		assertSame(Authority.ANONYMOUS, Authority.of(null));
 	}
@@ -43,47 +43,47 @@ public class AuthorityTest {
 	@Test
 	public void testNullProofsNormalised() {
 		Authority a = Authority.of(ALICE, null);
-		assertTrue(a.getProofs().isEmpty());
-		assertFalse(a.hasProofs());
+		assertTrue(a.getGrants().isEmpty());
+		assertFalse(a.hasGrants());
 	}
 
 	@Test
 	public void testWithGrantsAreAdditiveAndImmutable() {
 		Authority base = Authority.of(ALICE);
-		Authority one = base.withProof(GRANT_A);
-		Authority two = one.withProof(GRANT_B);
+		Authority one = base.withGrant(GRANT_A);
+		Authority two = one.withGrant(GRANT_B);
 
 		// base is unchanged — immutability
-		assertFalse(base.hasProofs());
-		assertEquals(1, one.getProofs().count());
-		assertEquals(2, two.getProofs().count());
-		assertTrue(two.hasProofs());
+		assertFalse(base.hasGrants());
+		assertEquals(1, one.getGrants().count());
+		assertEquals(2, two.getGrants().count());
+		assertTrue(two.hasGrants());
 		assertEquals(ALICE, two.getDID());
 	}
 
 	@Test
 	public void testWithProofsBulk() {
 		AVector<ACell> more = Vectors.of(GRANT_A, GRANT_B);
-		Authority a = Authority.of(BOB).withProofs(more);
-		assertEquals(2, a.getProofs().count());
+		Authority a = Authority.of(BOB).withGrants(more);
+		assertEquals(2, a.getGrants().count());
 
 		// null / empty augmentation is a no-op that returns an equal authority
-		assertEquals(a, a.withProofs(null));
-		assertEquals(a, a.withProofs(Vectors.empty()));
+		assertEquals(a, a.withGrants(null));
+		assertEquals(a, a.withGrants(Vectors.empty()));
 	}
 
 	@Test
 	public void testNullGrantIgnored() {
 		Authority a = Authority.of(ALICE);
-		assertSame(a, a.withProof(null));
+		assertSame(a, a.withGrant(null));
 	}
 
 	@Test
 	public void testEquality() {
-		Authority a1 = Authority.of(ALICE).withProof(GRANT_A);
-		Authority a2 = Authority.of(ALICE).withProof(GRANT_A);
-		Authority differentGrant = Authority.of(ALICE).withProof(GRANT_B);
-		Authority differentDid = Authority.of(BOB).withProof(GRANT_A);
+		Authority a1 = Authority.of(ALICE).withGrant(GRANT_A);
+		Authority a2 = Authority.of(ALICE).withGrant(GRANT_A);
+		Authority differentGrant = Authority.of(ALICE).withGrant(GRANT_B);
+		Authority differentDid = Authority.of(BOB).withGrant(GRANT_A);
 
 		assertEquals(a1, a2);
 		assertEquals(a1.hashCode(), a2.hashCode());

--- a/covia-core/src/test/java/covia/grid/AuthorityTest.java
+++ b/covia-core/src/test/java/covia/grid/AuthorityTest.java
@@ -1,0 +1,94 @@
+package covia.grid;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import convex.core.data.ACell;
+import convex.core.data.AString;
+import convex.core.data.AVector;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+
+public class AuthorityTest {
+
+	private static final AString ALICE = Strings.create("did:key:zAlice");
+	private static final AString BOB = Strings.create("did:key:zBob");
+	private static final ACell GRANT_A = Strings.create("grant-a");
+	private static final ACell GRANT_B = Strings.create("grant-b");
+
+	@Test
+	public void testIdentityOnly() {
+		Authority a = Authority.of(ALICE);
+		assertEquals(ALICE, a.getDID());
+		assertFalse(a.isAnonymous());
+		assertFalse(a.hasProofs());
+		assertTrue(a.getProofs().isEmpty());
+	}
+
+	@Test
+	public void testAnonymous() {
+		assertTrue(Authority.ANONYMOUS.isAnonymous());
+		assertNull(Authority.ANONYMOUS.getDID());
+		assertFalse(Authority.ANONYMOUS.hasProofs());
+		// of(null) collapses to the shared ANONYMOUS instance
+		assertSame(Authority.ANONYMOUS, Authority.of(null));
+	}
+
+	@Test
+	public void testNullProofsNormalised() {
+		Authority a = Authority.of(ALICE, null);
+		assertTrue(a.getProofs().isEmpty());
+		assertFalse(a.hasProofs());
+	}
+
+	@Test
+	public void testWithGrantsAreAdditiveAndImmutable() {
+		Authority base = Authority.of(ALICE);
+		Authority one = base.withProof(GRANT_A);
+		Authority two = one.withProof(GRANT_B);
+
+		// base is unchanged — immutability
+		assertFalse(base.hasProofs());
+		assertEquals(1, one.getProofs().count());
+		assertEquals(2, two.getProofs().count());
+		assertTrue(two.hasProofs());
+		assertEquals(ALICE, two.getDID());
+	}
+
+	@Test
+	public void testWithProofsBulk() {
+		AVector<ACell> more = Vectors.of(GRANT_A, GRANT_B);
+		Authority a = Authority.of(BOB).withProofs(more);
+		assertEquals(2, a.getProofs().count());
+
+		// null / empty augmentation is a no-op that returns an equal authority
+		assertEquals(a, a.withProofs(null));
+		assertEquals(a, a.withProofs(Vectors.empty()));
+	}
+
+	@Test
+	public void testNullGrantIgnored() {
+		Authority a = Authority.of(ALICE);
+		assertSame(a, a.withProof(null));
+	}
+
+	@Test
+	public void testEquality() {
+		Authority a1 = Authority.of(ALICE).withProof(GRANT_A);
+		Authority a2 = Authority.of(ALICE).withProof(GRANT_A);
+		Authority differentGrant = Authority.of(ALICE).withProof(GRANT_B);
+		Authority differentDid = Authority.of(BOB).withProof(GRANT_A);
+
+		assertEquals(a1, a2);
+		assertEquals(a1.hashCode(), a2.hashCode());
+		assertNotEquals(a1, differentGrant);
+		assertNotEquals(a1, differentDid);
+		assertNotEquals(Authority.of(ALICE), Authority.ANONYMOUS);
+	}
+}

--- a/covia-sql/src/test/java/covia/adapter/sql/SQLAdapterTest.java
+++ b/covia-sql/src/test/java/covia/adapter/sql/SQLAdapterTest.java
@@ -184,8 +184,8 @@ public class SQLAdapterTest {
 	// ========== Capabilities ==========
 
 	@Test
-	public void testCapabilityDeniedUnderPublicCeiling() {
-		RequestContext capped = ctx.withCaps(CapabilityChecker.readOnlyCeiling(did));
+	public void testCapabilityDeniedUnderPublicScope() {
+		RequestContext capped = ctx.withCaps(CapabilityChecker.readOnlyScope(did));
 		Job denied = engine.jobs().invokeOperation("v/ops/sql/query",
 			Maps.of(Strings.create("db"), Strings.create("db4"),
 				Strings.create("statement"), Strings.create("SELECT 1")),

--- a/venue/docs/UCAN.md
+++ b/venue/docs/UCAN.md
@@ -111,7 +111,7 @@ This aligns with `DIDURL` from convex-core — the DID is the authority, the pat
 
 **Canonical vs. shorthand.** A canonical `with` is absolute (owner-named) as above; a **bare** lattice path is shorthand whose owner is implied by context, always the same principal: **the authority whose grant it is**.
 
-- **Agent caps / self-attenuation ceilings**: a bare `w/projects/foo` is the *caller's own* resource; enforcement canonicalises it to `<callerDID>/w/projects/foo` before matching, so bare and DID-URL grants compare identically. The same applies to bare `dlfs/<drive>/…` paths.
+- **Agent caps (config ceilings)**: a bare `w/projects/foo` is the *caller's own* resource; enforcement canonicalises it to `<callerDID>/w/projects/foo` before matching, so bare and DID-URL grants compare identically. The same applies to bare `dlfs/<drive>/…` paths.
 - **Signed UCAN tokens**: a bare `with` means the **token issuer's own** namespace, resolved at evaluation against the token's signed `iss` (`CapabilityChecker.normaliseProofs`, applied inside `proofsCover` recursively per chain hop — a bare path in a re-delegation binds to the re-delegator). A self-sovereign owner can therefore sign bare paths naturally; they can never be reinterpreted against the presenter or the target.
 - **Custodial issuance** (`ucan:issue`): the venue signs, so its `iss` is not the caller — bare paths are absolutised to the *caller's* DID before signing (§4.1). Tokens minted by the venue always carry the canonical form.
 
@@ -457,23 +457,18 @@ This is the "resource owner" root of every delegation chain. The venue
 recognises the caller's DID as owning their namespace without requiring
 a token.
 
-**Narrowing the implicit grant (self-attenuation).** The full grant is the
-default. A caller may *narrow* it for a session by presenting an
-**owner-authored** attenuation — a UCAN the owner signed over its own
-resources (`iss == aud == caller`). The venue takes the union of those caps
-and applies it as a ceiling through the standard enforcement path, so the
-session can do only what the attenuation allows. Because the owner is the
-authority over its own namespace and a ceiling can only *narrow* the implicit
-grant — never widen it — this is escalation-safe: the venue merely enforces
-the restriction the owner chose. With no token presented, the full implicit
-grant stands.
+**Reducing authority.** The full implicit grant is the default, and presented
+proofs are **additive** — a UCAN only ever *adds* a grant, it never subtracts
+from the caller's own authority. There is therefore no wire-level
+self-attenuation: a caller never sends "everything" and then narrows it. To act
+with reduced authority:
 
-A self-attenuation is **owner-signed** — mint it by signing a UCAN with the
-owner's own key (in the embedded/desktop case, the local owner key signs a
-per-launch token that locks the app's session to a subset of the namespace).
-This is distinct from `ucan:issue`, which mints *venue-signed* tokens for
-**cross-user** grants (§5.2); a venue-signed token is not the owner's own
-authority and forms no self-ceiling.
+- **Within a venue** — hand the callee a narrower `Authority`
+  (`Authority.of(did, grants)`). An owner spawning an agent gives it exactly the
+  caps it should start with (its `config.caps`), which the agent may later
+  *augment* with additional grants — e.g. a time-limited token (§5.2).
+- **Externally** — present only the UCANs the request actually needs, never the
+  caller's whole authority.
 
 ### 5.2 Cross-User Access
 
@@ -532,16 +527,15 @@ naturally:
 Granting `crud` (without a verb suffix) covers read+write+delete uniformly;
 trailing-slash on the resource is the conventional way to cover a subtree.
 
-**Own-namespace enforcement (self-ceiling).** The points above are the
-cross-user checks (a *grant* of access to someone else's resource). When a
-caller presents a self-attenuation (§5.1), the same capability check is also
-applied to the caller's **own** operations as a *ceiling*: the op's resource
-and each presented capability's `with` are canonicalised to absolute
-owner-scoped form (a bare `w/health/bp` → `<callerDID>/w/health/bp`; DID-URL
-and `file://`/`dlfs://` left as-is), then matched with `Capability.covers`.
-Own and cross-user resources thus match by one rule. With no token presented,
-the implicit grant stands and no ceiling applies — so token-less callers are
-unaffected.
+**Own-namespace enforcement (ceiling).** The points above are the cross-user
+checks (a *grant* of access to someone else's resource). A caller running under
+a **narrower Authority** — an agent started with `config.caps` (§5.4) — has the
+same capability check applied to its **own** operations as a *ceiling*: the op's
+resource and each grant's `with` are canonicalised to absolute owner-scoped form
+(a bare `w/health/bp` → `<callerDID>/w/health/bp`; DID-URL and `file://`/`dlfs://`
+left as-is), then matched with `Capability.covers`. Own and cross-user resources
+thus match by one rule. A caller with no ceiling (the null-caps fast path) holds
+the full implicit grant and is unaffected.
 
 ### 5.4 Agent Identity Models
 
@@ -706,8 +700,8 @@ Two complementary checks apply, both built on the same `Capability.covers`
 matcher over canonical owner-scoped resources (§3.1):
 
 - **`CapabilityChecker`** enforces a *ceiling* — the agent's config `caps`
-  and any presented self-attenuation (§5.1) — on every operation (`enforceCaps`
-  at job dispatch, and before each tool call). A ceiling can only narrow.
+  (§5.4) — on every operation (`enforceCaps` at job dispatch, and before each
+  tool call). A ceiling can only narrow.
 - **`CoviaAdapter.verifyProofs()`** authorises *cross-user* access against
   presented proofs (§5.2). A proof grants reach into another namespace.
 
@@ -918,19 +912,6 @@ so there are no mode flags or auth fields anywhere:
 - `ucan:verify` canonicalises bare queried resources against the audience
   so diagnostics match enforcement
 - Verification remains grant-agnostic — `grant/…` binds production only
-
-### Phase C1b: Self-attenuation on the direct invoke path ✓ (#131)
-
-- A presented owner-authored UCAN narrows the caller's own implicit grant (§5.1)
-- `enforceCaps` matches caps against **canonical owner-scoped resources** —
-  bare own-paths resolve to `<callerDID>/…`, the same convention as cross-user
-  (§3.1, §5.3); config caps and token caps interoperate
-- Selection reuses `UCANValidator.capabilitiesFor` (convex-core);
-  `CapabilityChecker.selfCapabilities` delegates to it and adds only the
-  self-attenuation narrow-only guard (drop empty-`with`)
-- Escalation-safe: a ceiling can only narrow, never widen
-- Both invoke transports (REST, MCP) attach it via one seam,
-  `AuthMiddleware.withTransportAuth`
 
 ### Phase C2: Delegation Chains
 

--- a/venue/src/main/java/covia/adapter/AAdapter.java
+++ b/venue/src/main/java/covia/adapter/AAdapter.java
@@ -329,9 +329,9 @@ public abstract class AAdapter {
     /**
      * Asserts the baseline {@link #INVOKE} capability at the adapter's enforcement
      * point. An invoke-class adapter calls this at the top of its dispatch — before
-     * any side effect — so the capability ceiling is checked where the op actually
-     * runs, with no central name-keyed mapping. A {@code null} ceiling
-     * (authenticated/internal) is unrestricted (no-op); a restricted ceiling
+     * any side effect — so the capability check happens where the op actually
+     * runs, with no central name-keyed mapping. A {@code null} grant scope
+     * (authenticated/internal) is unrestricted (no-op); a restricted scope
      * (e.g. the public read-only profile, which withholds {@code invoke}) denies.
      *
      * <p>The checked resource is the caller-supplied operation reference from
@@ -348,7 +348,7 @@ public abstract class AAdapter {
         // ctx only occurs in direct unit-test calls that bypass dispatch — treat
         // as no enforcement context. Route through the single authority seam so an
         // invoke grant may be satisfied by a config grant OR a presented proof
-        // (additive); fall back to the ceiling-only check when no engine is wired
+        // (additive); fall back to the scope-only check when no engine is wired
         // (adapters constructed directly in unit tests).
         if (ctx == null) return;
         if (engine != null) engine.requireAuthority(ctx, ctx.getOp(), INVOKE);

--- a/venue/src/main/java/covia/adapter/AAdapter.java
+++ b/venue/src/main/java/covia/adapter/AAdapter.java
@@ -343,11 +343,16 @@ public abstract class AAdapter {
      * invocations where no reference path is available ({@code getOp() == null}
      * → resource-less check, coverable only by the wildcard).</p>
      */
-    protected static void requireInvoke(RequestContext ctx) {
+    protected void requireInvoke(RequestContext ctx) {
         // The framework always supplies a context (at minimum ANONYMOUS); a null
         // ctx only occurs in direct unit-test calls that bypass dispatch — treat
-        // as no enforcement context.
-        if (ctx != null) ctx.requireCapability(ctx.getOp(), INVOKE);
+        // as no enforcement context. Route through the single authority seam so an
+        // invoke grant may be satisfied by a config grant OR a presented proof
+        // (additive); fall back to the ceiling-only check when no engine is wired
+        // (adapters constructed directly in unit tests).
+        if (ctx == null) return;
+        if (engine != null) engine.requireAuthority(ctx, ctx.getOp(), INVOKE);
+        else ctx.requireCapability(ctx.getOp(), INVOKE);
     }
 
     /**

--- a/venue/src/main/java/covia/adapter/AgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/AgentAdapter.java
@@ -32,6 +32,7 @@ import covia.api.Fields;
 import covia.grid.Job;
 import covia.grid.Status;
 import covia.venue.AgentState;
+import covia.api.Abilities;
 import covia.venue.RequestContext;
 import covia.venue.Scheduler;
 import covia.venue.User;
@@ -362,16 +363,16 @@ public class AgentAdapter extends AAdapter {
 	 * config ceiling can still complete its own tasks during a transition.
 	 */
 	private void requireAgentCap(RequestContext ctx, ACell input, String subOp) {
-		String ability = switch (subOp) {
-			case "create", "fork" -> "agent/create";
-			case "request"        -> "agent/request";
-			case "message", "chat" -> "agent/message";
-			case "delete", "suspend", "resume", "update", "cancelTask", "deleteSession" -> "agent/write";
+		AString ability = switch (subOp) {
+			case "create", "fork" -> Abilities.AGENT_CREATE;
+			case "request"        -> Abilities.AGENT_REQUEST;
+			case "message", "chat" -> Abilities.AGENT_MESSAGE;
+			case "delete", "suspend", "resume", "update", "cancelTask", "deleteSession" -> Abilities.AGENT_WRITE;
 			default -> null; // info/list/context (reads), trigger, completeTask/failTask
 		};
 		if (ability == null) return;
 		AString agentId = RT.ensureString(RT.getIn(input, Fields.AGENT_ID));
-		engine.requireAuthority(ctx,agentId != null ? "g/" + agentId : null, ability);
+		engine.requireAuthority(ctx, agentId != null ? Strings.create("g/" + agentId) : null, ability);
 	}
 
 	@Override

--- a/venue/src/main/java/covia/adapter/AgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/AgentAdapter.java
@@ -361,7 +361,7 @@ public class AgentAdapter extends AAdapter {
 	 * gated here — they fall to the boundary net — so an agent with a restricted
 	 * config ceiling can still complete its own tasks during a transition.
 	 */
-	private static void requireAgentCap(RequestContext ctx, ACell input, String subOp) {
+	private void requireAgentCap(RequestContext ctx, ACell input, String subOp) {
 		String ability = switch (subOp) {
 			case "create", "fork" -> "agent/create";
 			case "request"        -> "agent/request";
@@ -371,7 +371,7 @@ public class AgentAdapter extends AAdapter {
 		};
 		if (ability == null) return;
 		AString agentId = RT.ensureString(RT.getIn(input, Fields.AGENT_ID));
-		ctx.requireCapability(agentId != null ? "g/" + agentId : null, ability);
+		engine.requireAuthority(ctx,agentId != null ? "g/" + agentId : null, ability);
 	}
 
 	@Override

--- a/venue/src/main/java/covia/adapter/AgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/AgentAdapter.java
@@ -207,7 +207,7 @@ public class AgentAdapter extends AAdapter {
 		String subOp = getSubOperation(meta);
 		// The task-lifecycle ops are self-scoped — agentId/taskId come from the
 		// RequestContext, never the input — and must stay callable under a
-		// restricted transition ceiling (the requireAgentCap contract): a capped
+		// restricted transition scope (the requireAgentCap contract): a scoped
 		// agent that cannot complete/fail its own task is trapped in the tool
 		// loop until the iteration limit. The invoke gate covers everything else.
 		if (!"completeTask".equals(subOp) && !"failTask".equals(subOp)) requireInvoke(ctx);
@@ -256,7 +256,7 @@ public class AgentAdapter extends AAdapter {
 					// system-of-record action, so the internal path (LLM tool
 					// loop, context assemble ops) delegates to the Job-aware
 					// dispatch and gets a real, owner-attributed Job — same
-					// RequestContext, same capability ceiling. This is the
+					// RequestContext, same grant scope. This is the
 					// delegation pattern `request` established above; the
 					// internal path previously rejected these outright (#85
 					// fall-out), breaking agent ops as LLM tools.
@@ -356,11 +356,11 @@ public class AgentAdapter extends AAdapter {
 	/**
 	 * Capability enforcement co-located with the agent op dispatch: each
 	 * user-facing op pins the exact ability it needs on the agent resource
-	 * ({@code g/<agentId>}). A null ceiling (authenticated/internal) is
+	 * ({@code g/<agentId>}). A null grant scope (authenticated/internal) is
 	 * unrestricted (no-op). The internal task-lifecycle ops
 	 * ({@code completeTask}/{@code failTask}) and {@code trigger}/reads are not
 	 * gated here — they fall to the boundary net — so an agent with a restricted
-	 * config ceiling can still complete its own tasks during a transition.
+	 * config scope can still complete its own tasks during a transition.
 	 */
 	private void requireAgentCap(RequestContext ctx, ACell input, String subOp) {
 		AString ability = switch (subOp) {

--- a/venue/src/main/java/covia/adapter/AssetAdapter.java
+++ b/venue/src/main/java/covia/adapter/AssetAdapter.java
@@ -75,7 +75,7 @@ public class AssetAdapter extends AAdapter {
 
 	@SuppressWarnings("unchecked")
 	private ACell handleStore(ACell input, RequestContext ctx) {
-		ctx.requireCapability(Strings.create(""), Strings.intern("asset/store"));
+		engine.requireAuthority(ctx,Strings.create(""), Strings.intern("asset/store"));
 		ACell metaCell = RT.getIn(input, Fields.METADATA);
 		// Accept metadata as a JSON object or a JSON string (parsed on the fly).
 		// NB: instanceof check on the parsed value is required because RT.castMap(null)
@@ -219,7 +219,7 @@ public class AssetAdapter extends AAdapter {
 	@SuppressWarnings("unchecked")
 	private ACell handleGet(ACell input, RequestContext ctx) {
 		AString idStr = RT.ensureString(RT.getIn(input, Fields.ID));
-		ctx.requireCapability(idStr, Strings.intern("asset/read"));
+		engine.requireAuthority(ctx,idStr, Strings.intern("asset/read"));
 		if (idStr == null) throw new IllegalArgumentException("id is required");
 
 		// Hash-form refs go through the CAS record (preserves the canonical
@@ -249,7 +249,7 @@ public class AssetAdapter extends AAdapter {
 	@SuppressWarnings("unchecked")
 	private ACell handleContent(ACell input, RequestContext ctx) {
 		AString idStr = RT.ensureString(RT.getIn(input, Fields.ID));
-		ctx.requireCapability(idStr, Strings.intern("asset/read"));
+		engine.requireAuthority(ctx,idStr, Strings.intern("asset/read"));
 		if (idStr == null) throw new IllegalArgumentException("id is required");
 
 		// Unified reference-addressed resolution first: DLFS is an alternative
@@ -325,7 +325,7 @@ public class AssetAdapter extends AAdapter {
 
 	@SuppressWarnings("unchecked")
 	private ACell handleList(ACell input, RequestContext ctx) {
-		ctx.requireCapability(Strings.create(""), Strings.intern("asset/read"));
+		engine.requireAuthority(ctx,Strings.create(""), Strings.intern("asset/read"));
 		long offset = 0, limit = 100;
 		ACell offsetCell = RT.getIn(input, Fields.OFFSET);
 		if (offsetCell instanceof CVMLong l) offset = Math.max(0, l.longValue());
@@ -396,7 +396,7 @@ public class AssetAdapter extends AAdapter {
 		AString pathStr = RT.ensureString(RT.getIn(input, Fields.PATH));
 		if (pathStr == null) pathStr = RT.ensureString(RT.getIn(input, Fields.ID));
 		if (pathStr == null) throw new IllegalArgumentException("path is required");
-		ctx.requireCapability(pathStr, Strings.intern("asset/store"));
+		engine.requireAuthority(ctx,pathStr, Strings.intern("asset/store"));
 
 		AString metaString;
 		ACell content = null;

--- a/venue/src/main/java/covia/adapter/AssetAdapter.java
+++ b/venue/src/main/java/covia/adapter/AssetAdapter.java
@@ -17,6 +17,7 @@ import convex.core.data.prim.CVMBool;
 import convex.core.data.prim.CVMLong;
 import convex.core.lang.RT;
 import convex.core.util.JSON;
+import covia.api.Abilities;
 import covia.api.Fields;
 import covia.grid.Asset;
 import covia.venue.AssetStore;
@@ -75,7 +76,7 @@ public class AssetAdapter extends AAdapter {
 
 	@SuppressWarnings("unchecked")
 	private ACell handleStore(ACell input, RequestContext ctx) {
-		engine.requireAuthority(ctx,Strings.create(""), Strings.intern("asset/store"));
+		engine.requireAuthority(ctx,Strings.create(""), Abilities.ASSET_STORE);
 		ACell metaCell = RT.getIn(input, Fields.METADATA);
 		// Accept metadata as a JSON object or a JSON string (parsed on the fly).
 		// NB: instanceof check on the parsed value is required because RT.castMap(null)
@@ -219,7 +220,7 @@ public class AssetAdapter extends AAdapter {
 	@SuppressWarnings("unchecked")
 	private ACell handleGet(ACell input, RequestContext ctx) {
 		AString idStr = RT.ensureString(RT.getIn(input, Fields.ID));
-		engine.requireAuthority(ctx,idStr, Strings.intern("asset/read"));
+		engine.requireAuthority(ctx,idStr, Abilities.ASSET_READ);
 		if (idStr == null) throw new IllegalArgumentException("id is required");
 
 		// Hash-form refs go through the CAS record (preserves the canonical
@@ -249,7 +250,7 @@ public class AssetAdapter extends AAdapter {
 	@SuppressWarnings("unchecked")
 	private ACell handleContent(ACell input, RequestContext ctx) {
 		AString idStr = RT.ensureString(RT.getIn(input, Fields.ID));
-		engine.requireAuthority(ctx,idStr, Strings.intern("asset/read"));
+		engine.requireAuthority(ctx,idStr, Abilities.ASSET_READ);
 		if (idStr == null) throw new IllegalArgumentException("id is required");
 
 		// Unified reference-addressed resolution first: DLFS is an alternative
@@ -325,7 +326,7 @@ public class AssetAdapter extends AAdapter {
 
 	@SuppressWarnings("unchecked")
 	private ACell handleList(ACell input, RequestContext ctx) {
-		engine.requireAuthority(ctx,Strings.create(""), Strings.intern("asset/read"));
+		engine.requireAuthority(ctx,Strings.create(""), Abilities.ASSET_READ);
 		long offset = 0, limit = 100;
 		ACell offsetCell = RT.getIn(input, Fields.OFFSET);
 		if (offsetCell instanceof CVMLong l) offset = Math.max(0, l.longValue());
@@ -396,7 +397,7 @@ public class AssetAdapter extends AAdapter {
 		AString pathStr = RT.ensureString(RT.getIn(input, Fields.PATH));
 		if (pathStr == null) pathStr = RT.ensureString(RT.getIn(input, Fields.ID));
 		if (pathStr == null) throw new IllegalArgumentException("path is required");
-		engine.requireAuthority(ctx,pathStr, Strings.intern("asset/store"));
+		engine.requireAuthority(ctx,pathStr, Abilities.ASSET_STORE);
 
 		AString metaString;
 		ACell content = null;

--- a/venue/src/main/java/covia/adapter/CoviaAdapter.java
+++ b/venue/src/main/java/covia/adapter/CoviaAdapter.java
@@ -449,7 +449,7 @@ public class CoviaAdapter extends AAdapter {
 	 * Resolves a single path and renders the value via CellExplorer.
 	 */
 	private String explorePath(RequestContext ctx, String pathStr, int budget, boolean compact) {
-		ctx.requireCapability(Strings.create(pathStr), Capability.CRUD_READ);
+		engine.requireAuthority(ctx,Strings.create(pathStr), Capability.CRUD_READ);
 		ACell[] pathKeys = parseStringPath(pathStr);
 
 		// Check job-scoped virtual namespace (t/)
@@ -655,7 +655,7 @@ public class CoviaAdapter extends AAdapter {
 		if (to == null) throw new IllegalArgumentException("'to' is required");
 
 		// Reads the source (handleWrite enforces crud/write on the destination).
-		ctx.requireCapability(from, Capability.CRUD_READ);
+		engine.requireAuthority(ctx,from, Capability.CRUD_READ);
 
 		// Read from source via the canonical universal resolver. Caps
 		// enforcement happens inside resolvePath via the cursor it returns.

--- a/venue/src/main/java/covia/adapter/CoviaAdapter.java
+++ b/venue/src/main/java/covia/adapter/CoviaAdapter.java
@@ -674,9 +674,9 @@ public class CoviaAdapter extends AAdapter {
 	/**
 	 * Enforces the capability for a path-targeted lattice mutation at the point
 	 * it executes — the adapter pins the exact resource (the path) and ability,
-	 * so the enforced cap cannot drift from the implementation. A null ceiling
+	 * so the enforced cap cannot drift from the implementation. A null grant scope
 	 * (internal/authenticated callers) is unrestricted, so this is a no-op for
-	 * them; a restricted ceiling (e.g. the public read-only profile) is gated.
+	 * them; a restricted scope (e.g. the public read-only profile) is gated.
 	 */
 	private void requireCap(RequestContext ctx, ACell input, AString ability) {
 		AString p = RT.ensureString(RT.getIn(input, Fields.PATH));

--- a/venue/src/main/java/covia/adapter/CoviaAdapter.java
+++ b/venue/src/main/java/covia/adapter/CoviaAdapter.java
@@ -678,20 +678,19 @@ public class CoviaAdapter extends AAdapter {
 	 * (internal/authenticated callers) is unrestricted, so this is a no-op for
 	 * them; a restricted ceiling (e.g. the public read-only profile) is gated.
 	 */
-	private static void requireCap(RequestContext ctx, ACell input, AString ability) {
+	private void requireCap(RequestContext ctx, ACell input, AString ability) {
 		AString p = RT.ensureString(RT.getIn(input, Fields.PATH));
 		// MUTATIONS target the caller's OWN namespace via bare paths (w/…, o/…).
-		// Cross-user access via a DID-URL path is supported for READS only (gated
-		// by a presented delegation proof in resolveDIDURL); there is no cross-user
-		// write path. Reject a DID-URL mutation target explicitly and early rather
-		// than relying on the downstream writable-namespace check — defence-in-depth
-		// that survives refactors and gives a clear error. Reads fall through to the
-		// proof-gated resolver.
+		// Cross-user access via a DID-URL path is supported for READS only (a
+		// presented delegation proof authorises it through the authority seam);
+		// there is no cross-user write path. Reject a DID-URL mutation target
+		// explicitly and early — defence-in-depth that survives refactors and gives
+		// a clear error. Reads fall through to the proof-gated seam.
 		if (p != null && !Capability.CRUD_READ.equals(ability) && p.toString().startsWith("did:")) {
 			throw new AuthException("Cross-user / DID-URL write paths are not supported: " + p
 				+ " — write to your own namespace via a bare path (e.g. w/…).");
 		}
-		ctx.requireCapability(p, ability);
+		engine.requireAuthority(ctx, p, ability);
 	}
 
 	/**

--- a/venue/src/main/java/covia/adapter/DLFSAdapter.java
+++ b/venue/src/main/java/covia/adapter/DLFSAdapter.java
@@ -275,7 +275,7 @@ public class DLFSAdapter extends AAdapter implements covia.venue.storage.Content
 	 * Builds a DLFS capability resource in plain DID-URL path form:
 	 * {@code [<ownerDID>/]dlfs/<drive>[/<path>]}. A null {@code ownerDID} yields the
 	 * bare own form ({@code dlfs/<drive>/…}, canonicalised to the caller by the
-	 * ceiling check); a non-null owner yields the cross-user form. This is a single
+	 * grant-scope check); a non-null owner yields the cross-user form. This is a single
 	 * well-formed DID URL (CAD038 DID-scoped path) — {@code /dlfs/} is a namespace
 	 * segment alongside {@code /w/} and {@code /j/} — so {@code RootAuthorityPolicy}
 	 * derives the owner with no special cases, unlike the old {@code dlfs://} scheme
@@ -298,7 +298,7 @@ public class DLFSAdapter extends AAdapter implements covia.venue.storage.Content
 	 * Own-namespace capability enforcement co-located with the DLFS op dispatch.
 	 * The resource is the {@code dlfs/<drive>/<path>} path form (drive named via
 	 * {@code drive}, or {@code name} for drive-level ops), canonicalised to the
-	 * caller by the ceiling check; a null ceiling (authenticated/internal) is
+	 * caller by the grant-scope check; a null grant scope (authenticated/internal) is
 	 * unrestricted (no-op).
 	 */
 	private void requireDlfsCap(RequestContext ctx, String subOp, AMap<AString, ACell> input) {
@@ -344,7 +344,7 @@ public class DLFSAdapter extends AAdapter implements covia.venue.storage.Content
 	/**
 	 * Resolves a DID-scoped DLFS file reference to a drive {@link Path},
 	 * enforcing exactly the checks the corresponding op enforces for
-	 * {@code ability}: the caller's own ceiling for an own drive; the
+	 * {@code ability}: the caller's own grant scope for an own drive; the
 	 * cross-user proof gate ({@link CapabilityChecker#proofsCover} on
 	 * {@code <owner>/dlfs/<drive>/<path>}) for another user's drive. Returns
 	 * null when {@code ref} is not DLFS-shaped; throws (never degrades) on
@@ -400,7 +400,7 @@ public class DLFSAdapter extends AAdapter implements covia.venue.storage.Content
 	/**
 	 * {@link covia.venue.storage.ContentProvider} write: stores bytes at a
 	 * DID-scoped DLFS path under the same checks as {@code dlfs:write} — the
-	 * caller's own ceiling ({@code crud/write}) for an own drive, the
+	 * caller's own grant scope ({@code crud/write}) for an own drive, the
 	 * cross-user proof gate for another user's (the mutation lands under the
 	 * owner's key, custodial). False for non-DLFS reference shapes.
 	 */
@@ -488,7 +488,7 @@ public class DLFSAdapter extends AAdapter implements covia.venue.storage.Content
 				authorizeCrossUser(ctx, subOp, target, input);
 				driveCtx = RequestContext.of(target.ownerDID());
 			} else {
-				// Own drive addressed explicitly by DID — normal own-ceiling check.
+				// Own drive addressed explicitly by DID — normal own-scope check.
 				requireDlfsCap(ctx, subOp, input);
 			}
 		} else {

--- a/venue/src/main/java/covia/adapter/DLFSAdapter.java
+++ b/venue/src/main/java/covia/adapter/DLFSAdapter.java
@@ -301,13 +301,13 @@ public class DLFSAdapter extends AAdapter implements covia.venue.storage.Content
 	 * caller by the ceiling check; a null ceiling (authenticated/internal) is
 	 * unrestricted (no-op).
 	 */
-	private static void requireDlfsCap(RequestContext ctx, String subOp, AMap<AString, ACell> input) {
+	private void requireDlfsCap(RequestContext ctx, String subOp, AMap<AString, ACell> input) {
 		AString ability = abilityFor(subOp);
 		if (ability == null) return;
 		AString drive = RT.ensureString(RT.getIn(input, FIELD_DRIVE));
 		if (drive == null) drive = RT.ensureString(RT.getIn(input, FIELD_NAME));
 		String resource = dlfsResource(null, drive, RT.ensureString(RT.getIn(input, FIELD_PATH)));
-		ctx.requireCapability(Strings.create(resource), ability);
+		engine.requireAuthority(ctx, Strings.create(resource), ability);
 	}
 
 	/**
@@ -364,7 +364,7 @@ public class DLFSAdapter extends AAdapter implements covia.venue.storage.Content
 				"Access denied: no " + ability + " capability for " + resource);
 			driveCtx = RequestContext.of(fr.ownerDID());
 		} else {
-			ctx.requireCapability(Strings.create(
+			engine.requireAuthority(ctx, Strings.create(
 				dlfsResource(null, Strings.create(fr.drive()), Strings.create(fr.path()))),
 				ability);
 		}

--- a/venue/src/main/java/covia/adapter/FileAdapter.java
+++ b/venue/src/main/java/covia/adapter/FileAdapter.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import convex.core.data.ACell;
 import convex.core.data.AMap;
+import convex.auth.ucan.Capability;
 import convex.core.data.AString;
 import convex.core.data.AVector;
 import convex.core.data.Maps;
@@ -460,17 +461,17 @@ public class FileAdapter extends AAdapter {
 	 * and deletes pin {@code crud/read}/{@code crud/write}/{@code crud/delete}.
 	 */
 	private void requireFileCap(RequestContext ctx, String subOp, AMap<AString, ACell> input) {
-		String ability = switch (subOp) {
-			case "list", "tree", "read", "stat", "roots" -> "crud/read";
-			case "write", "append", "mkdir" -> "crud/write";
-			case "delete" -> "crud/delete";
+		AString ability = switch (subOp) {
+			case "list", "tree", "read", "stat", "roots" -> Capability.CRUD_READ;
+			case "write", "append", "mkdir" -> Capability.CRUD_WRITE;
+			case "delete" -> Capability.CRUD_DELETE;
 			default -> null;
 		};
 		if (ability == null) return;
 		String resource = schemeResource("file",
 			RT.ensureString(RT.getIn(input, FIELD_ROOT)),
 			RT.ensureString(RT.getIn(input, FIELD_PATH)));
-		engine.requireAuthority(ctx,resource, ability);
+		engine.requireAuthority(ctx, Strings.create(resource), ability);
 	}
 
 	// ==================== Handlers ====================

--- a/venue/src/main/java/covia/adapter/FileAdapter.java
+++ b/venue/src/main/java/covia/adapter/FileAdapter.java
@@ -457,7 +457,7 @@ public class FileAdapter extends AAdapter {
 	/**
 	 * Capability enforcement co-located with the file op dispatch. The resource
 	 * is the {@code file://<root>/<path>} form the grant taxonomy uses; a null
-	 * ceiling (authenticated/internal) is unrestricted (no-op). Reads, writes,
+	 * grant scope (authenticated/internal) is unrestricted (no-op). Reads, writes,
 	 * and deletes pin {@code crud/read}/{@code crud/write}/{@code crud/delete}.
 	 */
 	private void requireFileCap(RequestContext ctx, String subOp, AMap<AString, ACell> input) {

--- a/venue/src/main/java/covia/adapter/FileAdapter.java
+++ b/venue/src/main/java/covia/adapter/FileAdapter.java
@@ -459,7 +459,7 @@ public class FileAdapter extends AAdapter {
 	 * ceiling (authenticated/internal) is unrestricted (no-op). Reads, writes,
 	 * and deletes pin {@code crud/read}/{@code crud/write}/{@code crud/delete}.
 	 */
-	private static void requireFileCap(RequestContext ctx, String subOp, AMap<AString, ACell> input) {
+	private void requireFileCap(RequestContext ctx, String subOp, AMap<AString, ACell> input) {
 		String ability = switch (subOp) {
 			case "list", "tree", "read", "stat", "roots" -> "crud/read";
 			case "write", "append", "mkdir" -> "crud/write";
@@ -470,7 +470,7 @@ public class FileAdapter extends AAdapter {
 		String resource = schemeResource("file",
 			RT.ensureString(RT.getIn(input, FIELD_ROOT)),
 			RT.ensureString(RT.getIn(input, FIELD_PATH)));
-		ctx.requireCapability(resource, ability);
+		engine.requireAuthority(ctx,resource, ability);
 	}
 
 	// ==================== Handlers ====================

--- a/venue/src/main/java/covia/adapter/HITLAdapter.java
+++ b/venue/src/main/java/covia/adapter/HITLAdapter.java
@@ -163,7 +163,7 @@ public class HITLAdapter extends AAdapter {
 	private void requireDeliverable(RequestContext ctx, AString caller, AString target) {
 		if (target.equals(caller)) return;
 		AString resource = Strings.create(target + "/h/");
-		ctx.requireCapability(resource, ABILITY_HITL_REQUEST);
+		engine.requireAuthority(ctx,resource, ABILITY_HITL_REQUEST);
 		long now = System.currentTimeMillis() / 1000;
 		if (!CapabilityChecker.proofsCover(ctx.getProofs(), caller, engine.getDIDString(),
 				resource, ABILITY_HITL_REQUEST, now)) {

--- a/venue/src/main/java/covia/adapter/HITLAdapter.java
+++ b/venue/src/main/java/covia/adapter/HITLAdapter.java
@@ -19,6 +19,7 @@ import convex.core.data.Vectors;
 import convex.core.data.prim.CVMLong;
 import convex.core.lang.RT;
 import covia.adapter.hitl.HitlValidation;
+import covia.api.Abilities;
 import covia.exception.AuthException;
 import covia.grid.Job;
 import covia.grid.Status;
@@ -59,7 +60,7 @@ public class HITLAdapter extends AAdapter {
 	private static final Logger log = LoggerFactory.getLogger(HITLAdapter.class);
 
 	/** Delivery ability for cross-user asks: {@code hitl/request} on {@code <target>/h/}. */
-	public static final AString ABILITY_HITL_REQUEST = Strings.intern("hitl/request");
+	public static final AString ABILITY_HITL_REQUEST = Abilities.HITL_REQUEST;
 
 	/** Default lifetime for grants offered without an explicit {@code exp} (7 days). */
 	static final long DEFAULT_GRANT_LIFETIME_SECS = 7 * 24 * 3600L;

--- a/venue/src/main/java/covia/adapter/HITLAdapter.java
+++ b/venue/src/main/java/covia/adapter/HITLAdapter.java
@@ -160,7 +160,7 @@ public class HITLAdapter extends AAdapter {
 
 	/** A self-ask is always permitted; delivering into ANOTHER user's inbox
 	 *  requires hitl/request on {@code <target>/h/} — checked against the
-	 *  caller's ceiling AND (cross-user) their presented proofs. */
+	 *  caller's grant scope AND (cross-user) their presented proofs. */
 	private void requireDeliverable(RequestContext ctx, AString caller, AString target) {
 		if (target.equals(caller)) return;
 		AString resource = Strings.create(target + "/h/");

--- a/venue/src/main/java/covia/adapter/MCPAdapter.java
+++ b/venue/src/main/java/covia/adapter/MCPAdapter.java
@@ -1026,7 +1026,7 @@ public class MCPAdapter extends AAdapter {
 	}
 
 	/** Venue scope requires the {@code mcp/manage} ability on {@code v/mcp} —
-	 *  denied under the public ceiling, grantable by cap. User scope is the
+	 *  denied under the public grant scope, grantable by cap. User scope is the
 	 *  default and needs nothing beyond invoking the op. */
 	private boolean isVenueScope(RequestContext ctx, ACell input) {
 		boolean venueScope = SCOPE_VENUE.equals(RT.ensureString(RT.getIn(input, K_SCOPE)));

--- a/venue/src/main/java/covia/adapter/MCPAdapter.java
+++ b/venue/src/main/java/covia/adapter/MCPAdapter.java
@@ -618,7 +618,7 @@ public class MCPAdapter extends AAdapter {
 		}
 		String path = requireToolPath(input);
 		boolean venuePath = path.startsWith("v/");
-		if (venuePath) ctx.requireCapability("v/mcp", "mcp/manage");
+		if (venuePath) engine.requireAuthority(ctx,"v/mcp", "mcp/manage");
 
 		// SSRF guard — shared with the http adapter, including its allowlist.
 		((HTTPAdapter) engine.getAdapter("http")).requireSafeUrl(url.toString());
@@ -779,7 +779,7 @@ public class MCPAdapter extends AAdapter {
 	@SuppressWarnings("unchecked")
 	ACell refreshPath(RequestContext ctx, String path) {
 		boolean venuePath = path.startsWith("v/");
-		if (venuePath) ctx.requireCapability("v/mcp", "mcp/manage");
+		if (venuePath) engine.requireAuthority(ctx,"v/mcp", "mcp/manage");
 		RequestContext writeCtx = venuePath ? engine.venueContext() : ctx;
 
 		ACell root = readLattice(writeCtx, path);
@@ -1027,9 +1027,9 @@ public class MCPAdapter extends AAdapter {
 	/** Venue scope requires the {@code mcp/manage} ability on {@code v/mcp} —
 	 *  denied under the public ceiling, grantable by cap. User scope is the
 	 *  default and needs nothing beyond invoking the op. */
-	private static boolean isVenueScope(RequestContext ctx, ACell input) {
+	private boolean isVenueScope(RequestContext ctx, ACell input) {
 		boolean venueScope = SCOPE_VENUE.equals(RT.ensureString(RT.getIn(input, K_SCOPE)));
-		if (venueScope) ctx.requireCapability("v/mcp", "mcp/manage");
+		if (venueScope) engine.requireAuthority(ctx,"v/mcp", "mcp/manage");
 		return venueScope;
 	}
 

--- a/venue/src/main/java/covia/adapter/MCPAdapter.java
+++ b/venue/src/main/java/covia/adapter/MCPAdapter.java
@@ -21,6 +21,7 @@ import convex.core.lang.RT;
 import convex.core.util.JSON;
 import covia.api.Fields;
 import covia.exception.JobFailedException;
+import covia.api.Abilities;
 import covia.venue.RequestContext;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
@@ -618,7 +619,7 @@ public class MCPAdapter extends AAdapter {
 		}
 		String path = requireToolPath(input);
 		boolean venuePath = path.startsWith("v/");
-		if (venuePath) engine.requireAuthority(ctx,"v/mcp", "mcp/manage");
+		if (venuePath) engine.requireAuthority(ctx, Abilities.V_MCP, Abilities.MCP_MANAGE);
 
 		// SSRF guard — shared with the http adapter, including its allowlist.
 		((HTTPAdapter) engine.getAdapter("http")).requireSafeUrl(url.toString());
@@ -779,7 +780,7 @@ public class MCPAdapter extends AAdapter {
 	@SuppressWarnings("unchecked")
 	ACell refreshPath(RequestContext ctx, String path) {
 		boolean venuePath = path.startsWith("v/");
-		if (venuePath) engine.requireAuthority(ctx,"v/mcp", "mcp/manage");
+		if (venuePath) engine.requireAuthority(ctx, Abilities.V_MCP, Abilities.MCP_MANAGE);
 		RequestContext writeCtx = venuePath ? engine.venueContext() : ctx;
 
 		ACell root = readLattice(writeCtx, path);
@@ -1029,7 +1030,7 @@ public class MCPAdapter extends AAdapter {
 	 *  default and needs nothing beyond invoking the op. */
 	private boolean isVenueScope(RequestContext ctx, ACell input) {
 		boolean venueScope = SCOPE_VENUE.equals(RT.ensureString(RT.getIn(input, K_SCOPE)));
-		if (venueScope) engine.requireAuthority(ctx,"v/mcp", "mcp/manage");
+		if (venueScope) engine.requireAuthority(ctx, Abilities.V_MCP, Abilities.MCP_MANAGE);
 		return venueScope;
 	}
 

--- a/venue/src/main/java/covia/adapter/Orchestrator.java
+++ b/venue/src/main/java/covia/adapter/Orchestrator.java
@@ -50,7 +50,7 @@ public class Orchestrator extends AAdapter {
 		// sub-jobs per step. The internal path (LLM tool loop, context
 		// assemble ops — e.g. a skills-bundled pipeline invoked as a tool)
 		// delegates to the Job-aware dispatch — same RequestContext, same
-		// capability ceiling — instead of rejecting the call (#85 fall-out).
+		// grant scope — instead of rejecting the call (#85 fall-out).
 		Job job = engine.jobs().invokeOperation(meta, input, ctx);
 		return job.future().thenApply(x -> x);
 	}

--- a/venue/src/main/java/covia/adapter/SecretAdapter.java
+++ b/venue/src/main/java/covia/adapter/SecretAdapter.java
@@ -77,8 +77,8 @@ public class SecretAdapter extends AAdapter {
 		if (value == null) throw new IllegalArgumentException("value is required");
 
 		// Pin the capability to the action: writing a secret requires
-		// secret/write on the secret resource. A null ceiling (authenticated /
-		// internal) is unrestricted; a read-only ceiling (the public profile)
+		// secret/write on the secret resource. A null grant scope (authenticated /
+		// internal) is unrestricted; a read-only scope (the public profile)
 		// is denied here — closing the unauthenticated secret-write gap (#148).
 		engine.requireAuthority(ctx, Strings.create("s/" + name), Abilities.SECRET_WRITE);
 

--- a/venue/src/main/java/covia/adapter/SecretAdapter.java
+++ b/venue/src/main/java/covia/adapter/SecretAdapter.java
@@ -11,6 +11,7 @@ import convex.core.data.prim.CVMBool;
 import convex.core.lang.RT;
 import covia.api.Fields;
 import covia.exception.AuthException;
+import covia.api.Abilities;
 import covia.venue.RequestContext;
 import covia.venue.SecretStore;
 import covia.venue.User;
@@ -79,7 +80,7 @@ public class SecretAdapter extends AAdapter {
 		// secret/write on the secret resource. A null ceiling (authenticated /
 		// internal) is unrestricted; a read-only ceiling (the public profile)
 		// is denied here — closing the unauthenticated secret-write gap (#148).
-		engine.requireAuthority(ctx,"s/" + name, "secret/write");
+		engine.requireAuthority(ctx, Strings.create("s/" + name), Abilities.SECRET_WRITE);
 
 		User user = engine.getVenueState().users().ensure(ctx.getCallerDID());
 		byte[] encKey = SecretStore.deriveKey(engine.getKeyPair());

--- a/venue/src/main/java/covia/adapter/SecretAdapter.java
+++ b/venue/src/main/java/covia/adapter/SecretAdapter.java
@@ -79,7 +79,7 @@ public class SecretAdapter extends AAdapter {
 		// secret/write on the secret resource. A null ceiling (authenticated /
 		// internal) is unrestricted; a read-only ceiling (the public profile)
 		// is denied here — closing the unauthenticated secret-write gap (#148).
-		ctx.requireCapability("s/" + name, "secret/write");
+		engine.requireAuthority(ctx,"s/" + name, "secret/write");
 
 		User user = engine.getVenueState().users().ensure(ctx.getCallerDID());
 		byte[] encKey = SecretStore.deriveKey(engine.getKeyPair());

--- a/venue/src/main/java/covia/adapter/SkillsAdapter.java
+++ b/venue/src/main/java/covia/adapter/SkillsAdapter.java
@@ -162,7 +162,7 @@ public class SkillsAdapter extends AAdapter {
 		return sources;
 	}
 
-	private static void requireReadCaps(RequestContext ctx, AVector<ACell> sources) {
+	private void requireReadCaps(RequestContext ctx, AVector<ACell> sources) {
 		for (long i = 0; i < sources.count(); i++) {
 			AString source = RT.ensureString(sources.get(i));
 			if (source == null) throw new IllegalArgumentException(
@@ -174,11 +174,11 @@ public class SkillsAdapter extends AAdapter {
 	/** Pins the read capability for one source: {@code asset/read} for
 	 *  content-addressed refs, {@code crud/read} for paths — mirroring
 	 *  AssetAdapter and CoviaAdapter's read pins exactly. */
-	private static void requireReadCap(RequestContext ctx, AString source) {
+	private void requireReadCap(RequestContext ctx, AString source) {
 		if (AssetAdapter.parseAssetId(source) != null) {
-			ctx.requireCapability(source, ASSET_READ);
+			engine.requireAuthority(ctx,source, ASSET_READ);
 		} else {
-			ctx.requireCapability(source, Capability.CRUD_READ);
+			engine.requireAuthority(ctx,source, Capability.CRUD_READ);
 		}
 	}
 

--- a/venue/src/main/java/covia/adapter/SkillsAdapter.java
+++ b/venue/src/main/java/covia/adapter/SkillsAdapter.java
@@ -30,7 +30,7 @@ import covia.venue.RequestContext;
  * the existing {@code covia:write} (workspace) and {@code asset:store}
  * (immutable assets). Reads pin {@code crud/read} on path sources and
  * {@code asset/read} on content-addressed refs — both inside the anonymous
- * read-only ceiling, so venue skills are publicly discoverable.</p>
+ * read-only grant scope, so venue skills are publicly discoverable.</p>
  */
 public class SkillsAdapter extends AAdapter {
 
@@ -93,7 +93,7 @@ public class SkillsAdapter extends AAdapter {
 	public CompletableFuture<ACell> invokeFuture(RequestContext ctx, AMap<AString, ACell> meta, ACell input) {
 		// No authentication precondition: v/skills is publicly discoverable.
 		// The per-source capability pins below do the gating (an anonymous
-		// caller's read-only ceiling covers own-namespace reads + asset/read).
+		// caller's read-only grant scope covers own-namespace reads + asset/read).
 		String command = strInput(input, "command");
 		try {
 			return switch (command) {

--- a/venue/src/main/java/covia/adapter/SkillsAdapter.java
+++ b/venue/src/main/java/covia/adapter/SkillsAdapter.java
@@ -12,6 +12,7 @@ import convex.core.data.Strings;
 import convex.core.data.Vectors;
 import convex.core.lang.RT;
 import covia.adapter.agent.Skills;
+import covia.api.Abilities;
 import covia.api.Fields;
 import covia.venue.RequestContext;
 
@@ -37,7 +38,7 @@ public class SkillsAdapter extends AAdapter {
 	static final AVector<ACell> DEFAULT_SOURCES = Vectors.of(
 		Strings.intern("w/skills"), Strings.intern("v/skills"));
 
-	private static final AString ASSET_READ = Strings.intern("asset/read");
+	private static final AString ASSET_READ = Abilities.ASSET_READ;
 	private static final AString K_SOURCES  = Strings.intern("sources");
 	private static final AString K_REF      = Strings.intern("ref");
 	private static final AString K_BODY     = Strings.intern("body");

--- a/venue/src/main/java/covia/adapter/agent/AbstractLLMAdapter.java
+++ b/venue/src/main/java/covia/adapter/agent/AbstractLLMAdapter.java
@@ -422,7 +422,7 @@ public abstract class AbstractLLMAdapter extends AAdapter implements ContextInsp
 	 * @param input the tool call arguments
 	 * @param configToolMap mapping of LLM tool names to operation names
 	 * @param ctx request context for the tool dispatch — carries the agent's
-	 *        capability ceiling ({@link RequestContext#getCaps()})
+	 *        grant scope ({@link RequestContext#getCaps()})
 	 * @param timeoutMs per-tool-call wall-clock budget; {@link TimeoutException}
 	 *        is converted to an "Error: tool call timed out" string result so
 	 *        the agent loop can continue
@@ -435,7 +435,7 @@ public abstract class AbstractLLMAdapter extends AAdapter implements ContextInsp
 		// ref, otherwise the tool name is dispatched as a grid op. Capability
 		// enforcement happens at the dispatched op's OWN enforcement point
 		// (invokeInternal → the adapter's requireCapability / requireInvoke),
-		// under the agent's ceiling carried on ctx — no name-keyed pre-check here.
+		// under the agent's grant scope carried on ctx — no name-keyed pre-check here.
 		AString operation = (configToolMap != null) ? configToolMap.get(toolName) : null;
 
 		// Config tools — tool name maps to a resolved operation
@@ -500,7 +500,7 @@ public abstract class AbstractLLMAdapter extends AAdapter implements ContextInsp
 
 	/**
 	 * Invokes an operation with a per-call timeout, via the no-Job internal
-	 * dispatch path. {@code invokeInternal} enforces the ceiling carried by
+	 * dispatch path. {@code invokeInternal} enforces the grant scope carried by
 	 * {@code ctx} (today the agent cycle runs unrestricted at the context
 	 * level); {@link #dispatchTool} has additionally checked the call against
 	 * the agent's own config caps. Times out via

--- a/venue/src/main/java/covia/lattice/CapabilityChecker.java
+++ b/venue/src/main/java/covia/lattice/CapabilityChecker.java
@@ -11,6 +11,7 @@ import convex.core.data.AVector;
 import convex.core.data.Strings;
 import convex.core.data.Vectors;
 import convex.core.lang.RT;
+import covia.api.Abilities;
 
 /**
  * Checks agent tool calls against declared capability attenuations.
@@ -342,7 +343,7 @@ public class CapabilityChecker {
 	public static AVector<ACell> readOnlyCeiling(AString scopeDID) {
 		return Vectors.of(
 			Capability.create(scopeDID, Capability.CRUD_READ),
-			Capability.create(Strings.create(""), Strings.create("asset/read")));
+			Capability.create(Strings.create(""), Abilities.ASSET_READ));
 	}
 
 	/**

--- a/venue/src/main/java/covia/lattice/CapabilityChecker.java
+++ b/venue/src/main/java/covia/lattice/CapabilityChecker.java
@@ -153,9 +153,10 @@ public class CapabilityChecker {
 	}
 
 	/**
-	 * Checks whether a capability ceiling allows a specific {@code (resource,
-	 * ability)} pair supplied <em>directly</em> by the executing adapter — not
-	 * derived from an operation name.
+	 * Checks whether a capability scope — the grants a caller holds — covers a
+	 * specific {@code (resource, ability)} pair supplied <em>directly</em> by the
+	 * executing adapter, not derived from an operation name. Either a grant covers
+	 * it or you don't have the right; a {@code null} scope is unrestricted.
 	 *
 	 * <p>This is the enforcement primitive meant to be co-located with the code
 	 * that performs the action: the implementation names the exact resource and
@@ -167,7 +168,7 @@ public class CapabilityChecker {
 	 * form is the primary entry point; a {@link String} overload is provided for
 	 * literal arguments.</p>
 	 *
-	 * @param caps     the caller's granted capability ceiling; {@code null} = unrestricted
+	 * @param caps     the caller's held grant scope; {@code null} = unrestricted
 	 * @param resource the exact resource acted on — a bare lattice path
 	 *                 ({@code "w/x"}, owner-scoped), a DID URL, or a scheme URI;
 	 *                 {@code null}/empty means "no specific resource"
@@ -198,7 +199,7 @@ public class CapabilityChecker {
 	 */
 	public static String allows(AVector<ACell> caps, AString resource, AString ability, AString ownerDID,
 			AString opRef, ACell invocationInput, CapabilityGate gate) {
-		if (caps == null) return null;              // no ceiling = unrestricted
+		if (caps == null) return null;              // no scope = unrestricted (no bounding grants)
 		String canonResource = canonicalResource(resource != null ? resource.toString() : null, ownerDID);
 		if (canonResource == null) canonResource = "";
 		String ab = (ability != null) ? ability.toString() : "";

--- a/venue/src/main/java/covia/lattice/CapabilityChecker.java
+++ b/venue/src/main/java/covia/lattice/CapabilityChecker.java
@@ -279,7 +279,7 @@ public class CapabilityChecker {
 	 *                 non-null (e.g. the venue public DID, {@code "<venueDID>:public"});
 	 *                 a null scope would yield an unscoped, over-broad grant
 	 */
-	public static AVector<ACell> readOnlyCeiling(AString scopeDID) {
+	public static AVector<ACell> readOnlyScope(AString scopeDID) {
 		return Vectors.of(
 			Capability.create(scopeDID, Capability.CRUD_READ),
 			Capability.create(Strings.create(""), Abilities.ASSET_READ));

--- a/venue/src/main/java/covia/lattice/CapabilityChecker.java
+++ b/venue/src/main/java/covia/lattice/CapabilityChecker.java
@@ -29,68 +29,6 @@ import covia.api.Abilities;
  */
 public class CapabilityChecker {
 
-
-	/**
-	 * Derive the self-attenuation ceiling from presented proof tokens: the union
-	 * of capabilities the verified tokens grant to {@code caller} under the
-	 * authority {@code issuer}, with temporal bounds re-checked. The result is the
-	 * {@code caps} ceiling enforced by {@link #check}. The owner is the authority
-	 * over its own namespace, so for a self-ceiling {@code issuer == caller}.
-	 *
-	 * <p>Assumes signatures and chains were verified at the transport boundary
-	 * ({@code UCANValidator.parseTransportUCANs}); only temporal bounds are
-	 * re-checked. Fail-closed: null {@code proofs}/{@code caller}/{@code issuer}
-	 * → null (no ceiling), never a wildcard.</p>
-	 *
-	 * <p>A self-ceiling is genuinely <b>single-hop</b> and caller-rooted
-	 * ({@code iss == aud == caller}) — no delegation chain, no root-authority
-	 * policy — so it is derived by a local single-hop selection, kept isolated
-	 * from the cross-user proof path ({@link #proofsCover}). On top of the
-	 * selection this adds covia's self-attenuation guard: a self-ceiling may only
-	 * <b>narrow</b>, so a capability with an empty/absent {@code with} — a "match
-	 * any resource" wildcard that would broaden — is dropped from the ceiling.</p>
-	 *
-	 * <p><b>Scope of the wildcard-stripping (#211):</b> the guard above applies
-	 * only to ceilings derived here, from UCAN <em>proof tokens</em>. An agent's
-	 * {@code config.caps} array does not pass through this method — it reaches
-	 * the checker unmodified, where an empty-{@code with} grant such as
-	 * {@code {"with": "", "can": "invoke"}} acts as a match-any wildcard (see
-	 * {@link #covered}). That is the supported way to give a restricted agent
-	 * the {@code invoke} ability its tool calls need.</p>
-	 */
-	public static AVector<ACell> selfCapabilities(AVector<ACell> proofs,
-			AString caller, AString issuer, long now) {
-		if (proofs == null || caller == null || issuer == null) return null;
-		// Single-hop selection: union the attenuations of tokens audienced to the
-		// caller AND issued by `issuer` (== caller for a self-ceiling), still in-date.
-		// Uses the typed UCAN accessors (canonical DID comparison), not raw fields.
-		AVector<ACell> caps = Vectors.empty();
-		for (long i = 0; i < proofs.count(); i++) {
-			AMap<AString, ACell> tokenMap = RT.castMap(proofs.get(i));
-			if (tokenMap == null) continue;
-			UCAN token = UCAN.parse(tokenMap);
-			if (token == null) continue;
-			if (!UCANValidator.checkTemporalBounds(token, now)) continue;
-			if (!caller.equals(token.getAudience())) continue;
-			if (!issuer.equals(token.getIssuer())) continue;
-			caps = caps.concat(token.getCapabilities());
-		}
-		if (caps.isEmpty()) return null;
-		// Self-attenuation may only NARROW: drop empty/absent-`with` (match-any)
-		// caps that would broaden the owner's own authority.
-		AVector<ACell> narrowed = Vectors.empty();
-		for (long i = 0; i < caps.count(); i++) {
-			ACell c = caps.get(i);
-			if (c instanceof AMap<?, ?> m) {
-				@SuppressWarnings("unchecked")
-				AString w = RT.ensureString(((AMap<AString, ACell>) m).get(Capability.WITH));
-				if (w == null || w.count() == 0) continue;
-			}
-			narrowed = narrowed.conj(c);
-		}
-		return narrowed.isEmpty() ? null : narrowed;
-	}
-
 	/**
 	 * Cross-user proof check: do the caller's presented {@code proofs} authorise
 	 * {@code (resource, ability)}? Delegates to the convex-core authority layer

--- a/venue/src/main/java/covia/lattice/CapabilityChecker.java
+++ b/venue/src/main/java/covia/lattice/CapabilityChecker.java
@@ -245,7 +245,7 @@ public class CapabilityChecker {
 		appendCapsList(sb, caps);
 		// For the venue's public/anonymous identity, the remedy is an auth
 		// action — point to it (covia#206). Scoped to the public caller (DID
-		// ends ":public") so a capped agent's own-ceiling denial, which it is
+		// ends ":public") so a scoped agent's own-scope denial, which it is
 		// meant to just handle (#211), and cross-user denials stay clean.
 		if (ownerDID != null && ownerDID.toString().endsWith(":public")) {
 			sb.append(". Authenticate with a UCAN bearer token (Authorization: "
@@ -268,7 +268,7 @@ public class CapabilityChecker {
 	}
 
 	/**
-	 * The default read-only capability ceiling for an identity: read the
+	 * The default read-only capability grant scope for an identity: read the
 	 * identity's own (owner-scoped) lattice and venue paths, and read
 	 * content-addressed assets. It grants <em>no</em> write, delete, secret,
 	 * agent, asset-store, or invoke ability — so every mutating operation is
@@ -290,7 +290,7 @@ public class CapabilityChecker {
 	 * returns true iff some grant in {@code caps} covers the already-canonical
 	 * {@code (resourceStr, abilityStr)} request. Non-map and malformed entries
 	 * are skipped defensively (they grant nothing). An empty {@code caps}
-	 * vector therefore grants nothing — only a {@code null} ceiling is "full
+	 * vector therefore grants nothing — only a {@code null} scope is "full
 	 * access" (handled by the callers).
 	 */
 	private static boolean covered(AVector<ACell> caps, AString resourceStr, AString abilityStr,
@@ -324,8 +324,8 @@ public class CapabilityChecker {
 		AString grantCan = RT.ensureString(cap.get(Capability.CAN));
 
 		// A null/empty grant `with` is a "match any resource" wildcard — the
-		// venue's own asset/read ceiling ({with:""}) relies on it. This wildcard
-		// lives ONLY in the ceiling path, never in the fail-closed UCAN proof
+		// venue's own asset/read grant ({with:""}) relies on it. This wildcard
+		// lives ONLY in the grant-scope path, never in the fail-closed UCAN proof
 		// path (proofsCover). A concrete grant matches via the boundary-aware
 		// Capability.resourceCovers (Convex #585 fixed); ability via abilityCovers.
 		boolean resourceOK = (grantWith == null || grantWith.count() == 0)

--- a/venue/src/main/java/covia/venue/Auth.java
+++ b/venue/src/main/java/covia/venue/Auth.java
@@ -30,8 +30,8 @@ import covia.venue.auth.LoginProviders;
  * "auth": {
  *   "public": {
  *     "enabled": true,                // allow anonymous access (default: true)
- *     "caps": "unrestricted"          // public ceiling: absent = read-only default
- *   },                                //   (reads only); "unrestricted" = no ceiling;
+ *     "caps": "unrestricted"          // public grant scope: absent = read-only default
+ *   },                                //   (reads only); "unrestricted" = no scope;
  *                                     //   or an explicit capability array
  *   "tokenExpiry": 86400,             // JWT expiry in seconds (default 24h)
  *   "audience": "verify",             // JWT aud policy: "verify" (default — if
@@ -148,16 +148,16 @@ public class Auth extends ALatticeComponent<AMap<AString, AMap<AString, ACell>>>
 	}
 
 	/**
-	 * The capability ceiling applied to unauthenticated (public) callers,
+	 * The capability grant scope applied to unauthenticated (public) callers,
 	 * scoped to {@code publicDID}. Operator policy via {@code auth.public.caps}:
 	 * unconfigured → the secure read-only default
 	 * ({@link CapabilityChecker#readOnlyCeiling}); the literal
-	 * {@code "unrestricted"} → no ceiling (legacy full access); an explicit
-	 * capability vector → that ceiling. Malformed config fails safe to read-only.
+	 * {@code "unrestricted"} → no scope (legacy full access); an explicit
+	 * capability vector → that scope. Malformed config fails safe to read-only.
 	 *
 	 * @param publicDID the public caller's DID ({@code <venueDID>:public}),
 	 *                  used to scope the default read grant
-	 * @return the ceiling vector, or null for "unrestricted"
+	 * @return the grant-scope vector, or null for "unrestricted"
 	 */
 	public AVector<ACell> getPublicCeiling(AString publicDID) {
 		if (publicCapsConfig == null) return CapabilityChecker.readOnlyCeiling(publicDID);

--- a/venue/src/main/java/covia/venue/Auth.java
+++ b/venue/src/main/java/covia/venue/Auth.java
@@ -151,7 +151,7 @@ public class Auth extends ALatticeComponent<AMap<AString, AMap<AString, ACell>>>
 	 * The capability grant scope applied to unauthenticated (public) callers,
 	 * scoped to {@code publicDID}. Operator policy via {@code auth.public.caps}:
 	 * unconfigured → the secure read-only default
-	 * ({@link CapabilityChecker#readOnlyCeiling}); the literal
+	 * ({@link CapabilityChecker#readOnlyScope}); the literal
 	 * {@code "unrestricted"} → no scope (legacy full access); an explicit
 	 * capability vector → that scope. Malformed config fails safe to read-only.
 	 *
@@ -159,13 +159,13 @@ public class Auth extends ALatticeComponent<AMap<AString, AMap<AString, ACell>>>
 	 *                  used to scope the default read grant
 	 * @return the grant-scope vector, or null for "unrestricted"
 	 */
-	public AVector<ACell> getPublicCeiling(AString publicDID) {
-		if (publicCapsConfig == null) return CapabilityChecker.readOnlyCeiling(publicDID);
+	public AVector<ACell> getPublicScope(AString publicDID) {
+		if (publicCapsConfig == null) return CapabilityChecker.readOnlyScope(publicDID);
 		if (publicCapsConfig instanceof AString s && "unrestricted".equals(s.toString())) return null;
 		AVector<ACell> caps = RT.ensureVector(publicCapsConfig);
 		if (caps != null) return caps;
 		log.warn("auth.public.caps is malformed ({}); defaulting to read-only", publicCapsConfig);
-		return CapabilityChecker.readOnlyCeiling(publicDID);
+		return CapabilityChecker.readOnlyScope(publicDID);
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/Config.java
+++ b/venue/src/main/java/covia/venue/Config.java
@@ -206,9 +206,9 @@ public class Config {
 	/** Key for public (anonymous) access configuration */
 	public static final AString PUBLIC = Strings.intern("public");
 
-	/** Key for the public caller's capability ceiling, under {@code auth.public}.
-	 *  Absent → secure default (read-only); {@code "unrestricted"} → no ceiling
-	 *  (legacy permissive behaviour); an explicit cap array → that ceiling. */
+	/** Key for the public caller's capability grant scope, under {@code auth.public}.
+	 *  Absent → secure default (read-only); {@code "unrestricted"} → no scope
+	 *  (legacy permissive behaviour); an explicit cap array → that scope. */
 	public static final AString CAPS = Strings.intern("caps");
 
 	/** Key for the JWT audience policy, under {@code auth}: {@code "verify"}
@@ -738,10 +738,10 @@ public class Config {
 
 	/**
 	 * The raw {@code auth.public.caps} value, used to derive the capability
-	 * ceiling applied to unauthenticated (public) callers. Returns {@code null}
+	 * grant scope applied to unauthenticated (public) callers. Returns {@code null}
 	 * when unconfigured (the caller then applies the secure read-only default),
-	 * the literal string {@code "unrestricted"} to opt out of any ceiling, or an
-	 * explicit capability vector to use as the ceiling.
+	 * the literal string {@code "unrestricted"} to opt out of any scope, or an
+	 * explicit capability vector to use as the scope.
 	 *
 	 * @return the configured value, or null if {@code auth.public.caps} is absent
 	 */

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -2135,6 +2135,59 @@ public class Engine {
 			getDIDString(), resource, ability, System.currentTimeMillis() / 1000);
 	}
 
+	/**
+	 * The single authorisation seam. Does the caller's authority cover
+	 * {@code (resource, ability)}? Grants are <b>additive</b>: an inherent
+	 * (unrestricted, own-namespace) grant, an agent {@code config.caps} grant, or
+	 * a cross-user proof each independently authorise. Callers pass the credential
+	 * (the {@link RequestContext}) and the exact resource+ability they guard — all
+	 * the logic (the {@code null}-caps fast path, own-vs-cross-user routing, grant
+	 * coverage, and proof-chain validation) lives here, never at the call site.
+	 */
+	public boolean authorityCovers(RequestContext ctx, AString resource, AString ability) {
+		if (ctx == null) return false;
+		// A cross-user proof (or the public read ceiling) authorises independently
+		// of the caller's own ceiling — the additive cross-user grant.
+		if (crossUserAllows(ctx, resource, ability)) return true;
+		// Own-authority dimension. A null ceiling is unrestricted, but ONLY for
+		// own / unscoped resources — reaching another user's namespace always needs
+		// a proof (handled above), never the fast path.
+		if (ctx.getCaps() == null) {
+			return isOwnOrUnscoped(resource, ctx.getCallerDID());
+		}
+		return ctx.ceilingDenial(resource, ability) == null;
+	}
+
+	/**
+	 * Throwing form of {@link #authorityCovers}: enforces the authority at a point
+	 * of action, raising {@link covia.exception.AuthException} with an actionable
+	 * message when the caller's authority does not cover the request.
+	 */
+	public void requireAuthority(RequestContext ctx, AString resource, AString ability) {
+		if (authorityCovers(ctx, resource, ability)) return;
+		String denial = (ctx != null && ctx.getCaps() != null) ? ctx.ceilingDenial(resource, ability) : null;
+		throw new covia.exception.AuthException(denial != null ? denial
+			: "Capability denied: requires " + (ability != null ? ability : "(any ability)")
+				+ " on " + (resource != null ? resource : "(any)")
+				+ (ctx == null || ctx.getCallerDID() == null ? " (authenticate to act as an identity)" : ""));
+	}
+
+	/**
+	 * True when {@code resource} is the caller's own / an unscoped resource (a bare
+	 * lattice path, the caller's own DID-URL, a content-addressed asset, or a
+	 * scheme-qualified path) — i.e. NOT another user's DID-scoped namespace. Gates
+	 * the {@code null}-caps fast path so it can never authorise cross-user access.
+	 */
+	private static boolean isOwnOrUnscoped(AString resource, AString callerDID) {
+		String canon = covia.lattice.CapabilityChecker.canonicalResource(
+			resource != null ? resource.toString() : null, callerDID);
+		if (canon == null || canon.isEmpty()) return true;   // no specific / content-addressed
+		if (!canon.startsWith("did:")) return true;          // scheme-qualified (file://, …)
+		if (callerDID == null) return false;                 // anonymous cannot own a DID-scoped path
+		String c = callerDID.toString();
+		return canon.equals(c) || canon.startsWith(c + "/");
+	}
+
 	// ========== Secret resolution ==========
 
 	/**

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -2137,25 +2137,27 @@ public class Engine {
 
 	/**
 	 * The single authorisation seam. Does the caller's authority cover
-	 * {@code (resource, ability)}? Grants are <b>additive</b>: an inherent
-	 * (unrestricted, own-namespace) grant, an agent {@code config.caps} grant, or
-	 * a cross-user proof each independently authorise. Callers pass the credential
-	 * (the {@link RequestContext}) and the exact resource+ability they guard — all
-	 * the logic (the {@code null}-caps fast path, own-vs-cross-user routing, grant
-	 * coverage, and proof-chain validation) lives here, never at the call site.
+	 * {@code (resource, ability)}? Grants are <b>additive</b> — <em>either you
+	 * have the right or you don't</em>: an inherent (unrestricted, own-namespace)
+	 * grant, an agent {@code config.caps} grant, or a cross-user proof each
+	 * independently authorise; nothing subtracts. Callers pass the credential (the
+	 * {@link RequestContext}, wrapping an {@code Authority}) and the exact
+	 * resource+ability they guard — all the logic (the {@code null}-scope fast
+	 * path, own-vs-cross-user routing, grant coverage, and proof-chain validation)
+	 * lives here, never at the call site.
 	 */
 	public boolean authorityCovers(RequestContext ctx, AString resource, AString ability) {
 		if (ctx == null) return false;
-		// A cross-user proof (or the public read ceiling) authorises independently
-		// of the caller's own ceiling — the additive cross-user grant.
+		// A cross-user proof (or the public read grant) authorises independently of
+		// the caller's own scope — the additive cross-user grant.
 		if (crossUserAllows(ctx, resource, ability)) return true;
-		// Own-authority ceiling. A null ceiling is unrestricted (the fast path);
-		// otherwise the caller's config grants must cover the resource. An
+		// Own-authority scope. A null scope is unrestricted (the fast path);
+		// otherwise a grant in the caller's scope must cover the resource. An
 		// unrestricted caller's cross-user reach is still gated by the adapter's
 		// own cross-user resolver (which routes through crossUserAllows above) —
-		// the fast path bypasses the ceiling, never the proof requirement.
+		// the fast path skips the scope check, never the proof requirement.
 		if (ctx.getCaps() == null) return true;
-		return ctx.ceilingDenial(resource, ability) == null;
+		return ctx.grantsDenial(resource, ability) == null;
 	}
 
 	/**
@@ -2165,7 +2167,7 @@ public class Engine {
 	 */
 	public void requireAuthority(RequestContext ctx, AString resource, AString ability) {
 		if (authorityCovers(ctx, resource, ability)) return;
-		String denial = (ctx != null && ctx.getCaps() != null) ? ctx.ceilingDenial(resource, ability) : null;
+		String denial = (ctx != null && ctx.getCaps() != null) ? ctx.grantsDenial(resource, ability) : null;
 		throw new covia.exception.AuthException(denial != null ? denial
 			: "Capability denied: requires " + (ability != null ? ability : "(any ability)")
 				+ " on " + (resource != null ? resource : "(any)")

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -2172,6 +2172,18 @@ public class Engine {
 				+ (ctx == null || ctx.getCallerDID() == null ? " (authenticate to act as an identity)" : ""));
 	}
 
+	/**
+	 * {@link String}-literal convenience overload of
+	 * {@link #requireAuthority(RequestContext, AString, AString)} — mirrors
+	 * {@link RequestContext#requireCapability(String, String)}; the conversion to
+	 * {@link AString} happens here, not at the call site.
+	 */
+	public void requireAuthority(RequestContext ctx, String resource, String ability) {
+		requireAuthority(ctx,
+			resource != null ? Strings.create(resource) : null,
+			ability != null ? Strings.create(ability) : null);
+	}
+
 	// ========== Secret resolution ==========
 
 	/**

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -2123,7 +2123,7 @@ public class Engine {
 			String r = resource.toString();
 			if (r.equals(publicDIDStr) || r.startsWith(publicDIDStr + "/")) {
 				AString publicDID = Strings.create(publicDIDStr);
-				convex.core.data.AVector<ACell> publicScope = auth.getPublicCeiling(publicDID);
+				convex.core.data.AVector<ACell> publicScope = auth.getPublicScope(publicDID);
 				// null scope = operator-configured unrestricted public access
 				if (publicScope == null || covia.lattice.CapabilityChecker.allows(
 						publicScope, resource, ability, publicDID) == null) {

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -2107,7 +2107,7 @@ public class Engine {
 	 * <p>Two rights compose, checked in order:</p>
 	 * <ol>
 	 *   <li><b>Ambient public access</b> (covia#254) — a resource owned by the
-	 *       venue's PUBLIC identity follows the public capability ceiling for
+	 *       venue's PUBLIC identity follows the public capability grant scope for
 	 *       ANY caller: an authenticated caller is at least as privileged as
 	 *       the anonymous one. Checked only when the resource is actually
 	 *       public-owned; tracks operator policy ({@code auth.public.caps} —
@@ -2123,10 +2123,10 @@ public class Engine {
 			String r = resource.toString();
 			if (r.equals(publicDIDStr) || r.startsWith(publicDIDStr + "/")) {
 				AString publicDID = Strings.create(publicDIDStr);
-				convex.core.data.AVector<ACell> ceiling = auth.getPublicCeiling(publicDID);
-				// null ceiling = operator-configured unrestricted public access
-				if (ceiling == null || covia.lattice.CapabilityChecker.allows(
-						ceiling, resource, ability, publicDID) == null) {
+				convex.core.data.AVector<ACell> publicScope = auth.getPublicCeiling(publicDID);
+				// null scope = operator-configured unrestricted public access
+				if (publicScope == null || covia.lattice.CapabilityChecker.allows(
+						publicScope, resource, ability, publicDID) == null) {
 					return true;
 				}
 			}

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -2149,12 +2149,12 @@ public class Engine {
 		// A cross-user proof (or the public read ceiling) authorises independently
 		// of the caller's own ceiling — the additive cross-user grant.
 		if (crossUserAllows(ctx, resource, ability)) return true;
-		// Own-authority dimension. A null ceiling is unrestricted, but ONLY for
-		// own / unscoped resources — reaching another user's namespace always needs
-		// a proof (handled above), never the fast path.
-		if (ctx.getCaps() == null) {
-			return isOwnOrUnscoped(resource, ctx.getCallerDID());
-		}
+		// Own-authority ceiling. A null ceiling is unrestricted (the fast path);
+		// otherwise the caller's config grants must cover the resource. An
+		// unrestricted caller's cross-user reach is still gated by the adapter's
+		// own cross-user resolver (which routes through crossUserAllows above) —
+		// the fast path bypasses the ceiling, never the proof requirement.
+		if (ctx.getCaps() == null) return true;
 		return ctx.ceilingDenial(resource, ability) == null;
 	}
 
@@ -2170,22 +2170,6 @@ public class Engine {
 			: "Capability denied: requires " + (ability != null ? ability : "(any ability)")
 				+ " on " + (resource != null ? resource : "(any)")
 				+ (ctx == null || ctx.getCallerDID() == null ? " (authenticate to act as an identity)" : ""));
-	}
-
-	/**
-	 * True when {@code resource} is the caller's own / an unscoped resource (a bare
-	 * lattice path, the caller's own DID-URL, a content-addressed asset, or a
-	 * scheme-qualified path) — i.e. NOT another user's DID-scoped namespace. Gates
-	 * the {@code null}-caps fast path so it can never authorise cross-user access.
-	 */
-	private static boolean isOwnOrUnscoped(AString resource, AString callerDID) {
-		String canon = covia.lattice.CapabilityChecker.canonicalResource(
-			resource != null ? resource.toString() : null, callerDID);
-		if (canon == null || canon.isEmpty()) return true;   // no specific / content-addressed
-		if (!canon.startsWith("did:")) return true;          // scheme-qualified (file://, …)
-		if (callerDID == null) return false;                 // anonymous cannot own a DID-scoped path
-		String c = callerDID.toString();
-		return canon.equals(c) || canon.startsWith(c + "/");
 	}
 
 	// ========== Secret resolution ==========

--- a/venue/src/main/java/covia/venue/JobManager.java
+++ b/venue/src/main/java/covia/venue/JobManager.java
@@ -415,8 +415,8 @@ public class JobManager {
 	 * denies with the reason (fail-closed, never fail-open).
 	 *
 	 * <p>The gate runs under the CALLER's own authority with no capability
-	 * ceiling: a gate is policy code chosen by whoever configured the grant,
-	 * and a ceiling-less context means the checker never evaluates gates for
+	 * scope: a gate is policy code chosen by whoever configured the grant,
+	 * and a scope-less context means the checker never evaluates gates for
 	 * the gate's own sub-invocations — a structural recursion guard, no
 	 * flags. No Job is created (invokeInternal), so gate checks never bloat
 	 * the etch.</p>

--- a/venue/src/main/java/covia/venue/RequestContext.java
+++ b/venue/src/main/java/covia/venue/RequestContext.java
@@ -104,7 +104,7 @@ public class RequestContext {
 	 */
 	public static RequestContext ofAuthority(Authority authority) {
 		if (authority == null || authority.isAnonymous()) return ANONYMOUS;
-		return of(authority.getDID(), authority.getProofs());
+		return of(authority.getDID(), authority.getGrants());
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/RequestContext.java
+++ b/venue/src/main/java/covia/venue/RequestContext.java
@@ -5,28 +5,36 @@ import convex.core.data.AString;
 import convex.core.data.AVector;
 import convex.core.data.Blob;
 import convex.core.data.Strings;
-import convex.core.data.Vectors;
 import covia.exception.AuthException;
 import covia.grid.Authority;
 import covia.lattice.CapabilityChecker;
 import covia.lattice.CapabilityGate;
 
 /**
- * Represents the context of an API request, carrying caller identity,
- * UCAN proofs, and request-scoped metadata.
+ * Represents the context of an API request. It <b>wraps an {@link Authority}</b>
+ * — the caller's identity plus the grants it holds (its capability scope and any
+ * presented UCAN proofs) — and adds venue-local, per-execution state (execution
+ * scopes, job/session/task ids, the operation reference and invocation input the
+ * capability check consults).
+ *
+ * <p>Authorisation lives on the {@code Authority}: an action is allowed iff a
+ * grant covers it — <em>either you have the right or you don't</em>. A
+ * {@code null} capability scope ({@link #getCaps()}) is an unrestricted
+ * principal (the fast path), not a ceiling; presented proofs are additive.</p>
  */
 public class RequestContext {
 
-	private final AString callerDID;
-	private final AVector<ACell> proofs;
-	private final AVector<ACell> caps;
+	/** The caller's identity and grants. Never null (ANONYMOUS wraps
+	 *  {@link Authority#ANONYMOUS}). */
+	private final Authority authority;
+
 	private final AString agentId;
 	private final Blob jobId;
 	private final Blob sessionId;
 	private final Blob taskId;
 	/** The raw transport UCAN tokens (JWT strings) as presented, relayable on
-	 *  cross-venue hops. Parsed {@link #proofs} cannot be re-signed (a JWT
-	 *  signature covers the JWT bytes), so forwarding requires the originals. */
+	 *  cross-venue hops. Parsed proofs cannot be re-signed (a JWT signature covers
+	 *  the JWT bytes), so forwarding requires the originals. */
 	private final AVector<ACell> rawUcans;
 	/** Cancellation signal for the transition cycle this context drives, or
 	 *  null outside a run-loop cycle. Flipped by the framework alongside
@@ -52,15 +60,14 @@ public class RequestContext {
 	/**
 	 * Context for anonymous (unauthenticated) external requests.
 	 */
-	public static final RequestContext ANONYMOUS = new RequestContext(null, null, null, null, null, null, null, null, null, null, null, null);
+	public static final RequestContext ANONYMOUS =
+		new RequestContext(Authority.ANONYMOUS, null, null, null, null, null, null, null, null, null);
 
-	private RequestContext(AString callerDID, AVector<ACell> proofs, AVector<ACell> caps,
-			AString agentId, Blob jobId, Blob sessionId, Blob taskId, AVector<ACell> rawUcans,
-			AString op, java.util.concurrent.atomic.AtomicBoolean cancellation,
+	private RequestContext(Authority authority, AString agentId, Blob jobId, Blob sessionId,
+			Blob taskId, AVector<ACell> rawUcans, AString op,
+			java.util.concurrent.atomic.AtomicBoolean cancellation,
 			ACell invocationInput, CapabilityGate gate) {
-		this.callerDID = callerDID;
-		this.proofs = proofs;
-		this.caps = caps;
+		this.authority = (authority != null) ? authority : Authority.ANONYMOUS;
 		this.agentId = agentId;
 		this.jobId = jobId;
 		this.sessionId = sessionId;
@@ -80,13 +87,13 @@ public class RequestContext {
 	 * startup, materialisation, recovery) uses
 	 * {@link covia.venue.Engine#venueContext()}, which returns a context
 	 * bound to the venue's own DID with an unrestricted ({@code null})
-	 * ceiling. Trust is a property of the context's authority, not the call
+	 * scope. Trust is a property of the context's authority, not the call
 	 * path: both {@code JobManager.invokeOperation} and {@code invokeInternal}
-	 * enforce whatever ceiling the context carries.</p>
+	 * enforce whatever scope the context carries.</p>
 	 */
 	public static RequestContext of(AString callerDID) {
 		if (callerDID == null) return ANONYMOUS;
-		return new RequestContext(callerDID, null, null, null, null, null, null, null, null, null, null, null);
+		return new RequestContext(Authority.of(callerDID), null, null, null, null, null, null, null, null, null);
 	}
 
 	/**
@@ -94,17 +101,17 @@ public class RequestContext {
 	 */
 	public static RequestContext of(AString callerDID, AVector<ACell> proofs) {
 		if (callerDID == null) return ANONYMOUS;
-		return new RequestContext(callerDID, proofs, null, null, null, null, null, null, null, null, null, null);
+		return new RequestContext(Authority.of(callerDID).withProofs(proofs), null, null, null, null, null, null, null, null, null);
 	}
 
 	/**
 	 * Creates a RequestContext from an {@link Authority} — the caller's identity
-	 * plus the grants (verified UCAN delegations) it carries. Returns ANONYMOUS
-	 * for a null or anonymous authority.
+	 * plus the grants (capability scope and presented proofs) it carries. Returns
+	 * ANONYMOUS for a null or anonymous authority.
 	 */
 	public static RequestContext ofAuthority(Authority authority) {
 		if (authority == null || authority.isAnonymous()) return ANONYMOUS;
-		return of(authority.getDID(), authority.getGrants());
+		return new RequestContext(authority, null, null, null, null, null, null, null, null, null);
 	}
 
 	/**
@@ -123,19 +130,20 @@ public class RequestContext {
 	 * CAD3-signed tokens directly are implicitly trusted by construction.</p>
 	 */
 	public RequestContext withProofs(AVector<ACell> proofs) {
-		return new RequestContext(this.callerDID, proofs, this.caps, this.agentId, this.jobId, this.sessionId, this.taskId, this.rawUcans, this.op, this.cancellation, this.invocationInput, this.gate);
+		return new RequestContext(authority.withProofs(proofs), agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
-	 * Returns a new context with a capability ceiling. Every operation executed
-	 * under this context is checked against the ceiling at the point it runs —
-	 * by the executing adapter ({@link #requireCapability}) and by the
+	 * Returns a new context whose capability scope is replaced. Every operation
+	 * executed under this context is checked against that scope at the point it
+	 * runs — by the executing adapter ({@link #requireCapability}) and by the
 	 * {@link covia.venue.JobManager} dispatch safety net, on both the
-	 * {@code invokeOperation} and {@code invokeInternal} paths. The ceiling
-	 * composes downward into sub-operations. {@code null} = unrestricted.
+	 * {@code invokeOperation} and {@code invokeInternal} paths. The scope
+	 * composes downward into sub-operations. {@code null} = unrestricted (an
+	 * action is allowed iff a grant covers it, and there are no bounding grants).
 	 */
 	public RequestContext withCaps(AVector<ACell> caps) {
-		return new RequestContext(this.callerDID, this.proofs, caps, this.agentId, this.jobId, this.sessionId, this.taskId, this.rawUcans, this.op, this.cancellation, this.invocationInput, this.gate);
+		return new RequestContext(authority.withGrantScope(caps), agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
@@ -143,7 +151,7 @@ public class RequestContext {
 	 * resolves to the agent's private workspace at {@code g/{agentId}/n/}.
 	 */
 	public RequestContext withAgentId(AString agentId) {
-		return new RequestContext(this.callerDID, this.proofs, this.caps, agentId, this.jobId, this.sessionId, this.taskId, this.rawUcans, this.op, this.cancellation, this.invocationInput, this.gate);
+		return new RequestContext(authority, agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
@@ -153,7 +161,7 @@ public class RequestContext {
 	 * case the agent/task path takes precedence.
 	 */
 	public RequestContext withJobId(Blob jobId) {
-		return new RequestContext(this.callerDID, this.proofs, this.caps, this.agentId, jobId, this.sessionId, this.taskId, this.rawUcans, this.op, this.cancellation, this.invocationInput, this.gate);
+		return new RequestContext(authority, agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
@@ -162,7 +170,7 @@ public class RequestContext {
 	 * conversation-scoped slot at {@code g/{agentId}/sessions/{sessionId}/c/}.
 	 */
 	public RequestContext withSessionId(Blob sessionId) {
-		return new RequestContext(this.callerDID, this.proofs, this.caps, this.agentId, this.jobId, sessionId, this.taskId, this.rawUcans, this.op, this.cancellation, this.invocationInput, this.gate);
+		return new RequestContext(authority, agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
@@ -171,7 +179,7 @@ public class RequestContext {
 	 * private slot at {@code g/{agentId}/tasks/{taskId}/t/}.
 	 */
 	public RequestContext withTaskId(Blob taskId) {
-		return new RequestContext(this.callerDID, this.proofs, this.caps, this.agentId, this.jobId, this.sessionId, taskId, this.rawUcans, this.op, this.cancellation, this.invocationInput, this.gate);
+		return new RequestContext(authority, agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
@@ -184,7 +192,7 @@ public class RequestContext {
 	 * (#211): {@code {"with": "v/ops/getmine", "can": "invoke"}}.
 	 */
 	public RequestContext withOp(AString op) {
-		return new RequestContext(this.callerDID, this.proofs, this.caps, this.agentId, this.jobId, this.sessionId, this.taskId, this.rawUcans, op, this.cancellation, this.invocationInput, this.gate);
+		return new RequestContext(authority, agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
@@ -206,7 +214,7 @@ public class RequestContext {
 	 * evaluator treat gated grants as unable to authorise (fail-closed).
 	 */
 	public RequestContext withInvocation(ACell invocationInput, CapabilityGate gate) {
-		return new RequestContext(this.callerDID, this.proofs, this.caps, this.agentId, this.jobId, this.sessionId, this.taskId, this.rawUcans, this.op, this.cancellation, invocationInput, gate);
+		return new RequestContext(authority, agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
@@ -216,7 +224,7 @@ public class RequestContext {
 	 * stop the running transition thread by itself.
 	 */
 	public RequestContext withCancellation(java.util.concurrent.atomic.AtomicBoolean cancellation) {
-		return new RequestContext(this.callerDID, this.proofs, this.caps, this.agentId, this.jobId, this.sessionId, this.taskId, this.rawUcans, this.op, cancellation, this.invocationInput, this.gate);
+		return new RequestContext(authority, agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
@@ -229,42 +237,41 @@ public class RequestContext {
 	}
 
 	/**
+	 * The caller's {@link Authority} — identity plus the grants it holds — as a
+	 * single immutable value. This context <em>wraps</em> it; the credential
+	 * getters below ({@link #getCallerDID()}, {@link #getCaps()},
+	 * {@link #getProofs()}) read through to it.
+	 */
+	public Authority getAuthority() {
+		return authority;
+	}
+
+	/**
 	 * Gets the caller's DID, or null if anonymous.
 	 */
 	public AString getCallerDID() {
-		return callerDID;
+		return authority.getDID();
 	}
 
 	/**
 	 * Returns true if this is an anonymous (unauthenticated) request.
 	 */
 	public boolean isAnonymous() {
-		return callerDID == null;
+		return authority.isAnonymous();
 	}
 
 	/**
 	 * Returns true if a caller DID is present.
 	 */
 	public boolean isAuthenticated() {
-		return callerDID != null;
+		return !authority.isAnonymous();
 	}
 
 	/**
 	 * Gets the UCAN proofs attached to this request, or null if none.
 	 */
 	public AVector<ACell> getProofs() {
-		return proofs;
-	}
-
-	/**
-	 * The caller's {@link Authority} — identity plus carried grants — as a single
-	 * immutable value. A convenience view over {@link #getCallerDID()} and
-	 * {@link #getProofs()}: the request path's credential in one object. (When the
-	 * authority centralisation lands, {@code RequestContext} will hold this
-	 * directly; today it is derived, so no existing getter's contract changes.)
-	 */
-	public Authority getAuthority() {
-		return Authority.of(callerDID, proofs);
+		return authority.getProofs();
 	}
 
 	/**
@@ -273,7 +280,7 @@ public class RequestContext {
 	 * forwarding — the parsed {@link #getProofs() proofs} cannot be re-signed.
 	 */
 	public RequestContext withRawUcans(AVector<ACell> rawUcans) {
-		return new RequestContext(this.callerDID, this.proofs, this.caps, this.agentId, this.jobId, this.sessionId, this.taskId, rawUcans, this.op, this.cancellation, this.invocationInput, this.gate);
+		return new RequestContext(authority, agentId, jobId, sessionId, taskId, rawUcans, op, cancellation, invocationInput, gate);
 	}
 
 	/**
@@ -286,21 +293,22 @@ public class RequestContext {
 	}
 
 	/**
-	 * Gets the capability attenuations for this request, or null if unrestricted.
-	 * When non-null, operations must be covered by at least one capability.
+	 * Gets the caller's held capability scope, or null if unrestricted. When
+	 * non-null, an operation is authorised only if a grant in the scope covers
+	 * it (there is no ceiling — a null scope simply has no bounding grants).
 	 */
 	public AVector<ACell> getCaps() {
-		return caps;
+		return authority.getGrants();
 	}
 
 	/**
 	 * Enforces a capability at the point an operation executes. The executing
 	 * adapter names the <em>exact</em> resource it acts on and the <em>exact</em>
 	 * ability it requires, so the enforced capability is pinned to the
-	 * implementation and cannot drift from a name-keyed mapping. A {@code null}
-	 * ceiling ({@link #getCaps()}) is unrestricted, so this is a no-op for
-	 * internal and authenticated callers that carry no attenuation; only a
-	 * caller with a ceiling set (e.g. the public read-only profile) is gated.
+	 * implementation and cannot drift from a name-keyed mapping. An unrestricted
+	 * scope ({@code null} {@link #getCaps()}) is a no-op for internal and
+	 * authenticated callers that carry no bounding grants; only a caller with an
+	 * explicit scope (e.g. the public read-only profile) is gated.
 	 *
 	 * <p>Lattice resources and abilities are {@link AString}s, so this is the
 	 * primary form; see {@link #requireCapability(String, String)} for a
@@ -310,23 +318,24 @@ public class RequestContext {
 	 *                 or scheme URI); may be null for "no specific resource"
 	 * @param ability  the exact ability required (e.g.
 	 *                 {@link convex.auth.ucan.Capability#CRUD_WRITE})
-	 * @throws AuthException if the ceiling does not cover {@code (resource, ability)}
+	 * @throws AuthException if no grant covers {@code (resource, ability)}
 	 */
 	public void requireCapability(AString resource, AString ability) {
-		String denial = ceilingDenial(resource, ability);
+		String denial = grantsDenial(resource, ability);
 		if (denial != null) throw new AuthException(denial);
 	}
 
 	/**
-	 * The ceiling check against this context's own fields: the denial message if
-	 * the caller's {@code caps} ceiling does <em>not</em> cover
-	 * {@code (resource, ability)}, or {@code null} if it does (a {@code null}
-	 * ceiling is unrestricted). Package-visible so the {@code Engine} authority
-	 * seam ({@code authorityCovers}) can compose it with the cross-user proof
-	 * check without re-plumbing {@code op}/{@code invocationInput}/{@code gate}.
+	 * The grant check against this context's own authority: the denial message if
+	 * the caller's capability scope does <em>not</em> cover {@code (resource,
+	 * ability)}, or {@code null} if a grant covers it (an unrestricted, {@code
+	 * null} scope always returns null). Package-visible so the {@code Engine}
+	 * authority seam ({@code authorityCovers}) can compose it with the cross-user
+	 * proof check without re-plumbing {@code op}/{@code invocationInput}/{@code
+	 * gate}.
 	 */
-	String ceilingDenial(AString resource, AString ability) {
-		return CapabilityChecker.allows(caps, resource, ability, callerDID, op, invocationInput, gate);
+	String grantsDenial(AString resource, AString ability) {
+		return CapabilityChecker.allows(authority.getGrants(), resource, ability, authority.getDID(), op, invocationInput, gate);
 	}
 
 	/**
@@ -377,6 +386,7 @@ public class RequestContext {
 
 	@Override
 	public String toString() {
+		AString callerDID = authority.getDID();
 		if (callerDID == null) return "RequestContext[ANONYMOUS]";
 		String s = "RequestContext[" + callerDID;
 		if (agentId != null) s += " agent=" + agentId;

--- a/venue/src/main/java/covia/venue/RequestContext.java
+++ b/venue/src/main/java/covia/venue/RequestContext.java
@@ -7,6 +7,7 @@ import convex.core.data.Blob;
 import convex.core.data.Strings;
 import convex.core.data.Vectors;
 import covia.exception.AuthException;
+import covia.grid.Authority;
 import covia.lattice.CapabilityChecker;
 import covia.lattice.CapabilityGate;
 
@@ -94,6 +95,16 @@ public class RequestContext {
 	public static RequestContext of(AString callerDID, AVector<ACell> proofs) {
 		if (callerDID == null) return ANONYMOUS;
 		return new RequestContext(callerDID, proofs, null, null, null, null, null, null, null, null, null, null);
+	}
+
+	/**
+	 * Creates a RequestContext from an {@link Authority} — the caller's identity
+	 * plus the grants (verified UCAN delegations) it carries. Returns ANONYMOUS
+	 * for a null or anonymous authority.
+	 */
+	public static RequestContext ofAuthority(Authority authority) {
+		if (authority == null || authority.isAnonymous()) return ANONYMOUS;
+		return of(authority.getDID(), authority.getProofs());
 	}
 
 	/**
@@ -243,6 +254,17 @@ public class RequestContext {
 	 */
 	public AVector<ACell> getProofs() {
 		return proofs;
+	}
+
+	/**
+	 * The caller's {@link Authority} — identity plus carried grants — as a single
+	 * immutable value. A convenience view over {@link #getCallerDID()} and
+	 * {@link #getProofs()}: the request path's credential in one object. (When the
+	 * authority centralisation lands, {@code RequestContext} will hold this
+	 * directly; today it is derived, so no existing getter's contract changes.)
+	 */
+	public Authority getAuthority() {
+		return Authority.of(callerDID, proofs);
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/RequestContext.java
+++ b/venue/src/main/java/covia/venue/RequestContext.java
@@ -313,9 +313,20 @@ public class RequestContext {
 	 * @throws AuthException if the ceiling does not cover {@code (resource, ability)}
 	 */
 	public void requireCapability(AString resource, AString ability) {
-		String denial = CapabilityChecker.allows(caps, resource, ability, callerDID,
-			op, invocationInput, gate);
+		String denial = ceilingDenial(resource, ability);
 		if (denial != null) throw new AuthException(denial);
+	}
+
+	/**
+	 * The ceiling check against this context's own fields: the denial message if
+	 * the caller's {@code caps} ceiling does <em>not</em> cover
+	 * {@code (resource, ability)}, or {@code null} if it does (a {@code null}
+	 * ceiling is unrestricted). Package-visible so the {@code Engine} authority
+	 * seam ({@code authorityCovers}) can compose it with the cross-user proof
+	 * check without re-plumbing {@code op}/{@code invocationInput}/{@code gate}.
+	 */
+	String ceilingDenial(AString resource, AString ability) {
+		return CapabilityChecker.allows(caps, resource, ability, callerDID, op, invocationInput, gate);
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/Scheduler.java
+++ b/venue/src/main/java/covia/venue/Scheduler.java
@@ -56,7 +56,7 @@ import covia.exception.AuthException;
  * <p><b>No escalation.</b> An event captures the owner's DID plus the proofs and
  * caps presented at schedule time, and firing replays exactly those via
  * {@link JobManager#invokeInternal} (§5 of the design), which enforces that
- * ceiling on dispatch. The scheduler never invents authority.</p>
+ * scope on dispatch. The scheduler never invents authority.</p>
  */
 public class Scheduler {
 
@@ -303,7 +303,7 @@ public class Scheduler {
 		AVector<ACell> caps = asVector(rec.get(K_CAPS));
 		if (caps != null) ctx = ctx.withCaps(caps);
 		// Zero-Job dispatch under the owner's stapled caps. invokeInternal
-		// enforces that ceiling, so a scheduled fire cannot exceed the
+		// enforces that scope, so a scheduled fire cannot exceed the
 		// authority the owner captured at schedule time — no escalation.
 		return engine.jobs().invokeInternal(opRef, input, ctx);
 	}

--- a/venue/src/main/java/covia/venue/api/A2A.java
+++ b/venue/src/main/java/covia/venue/api/A2A.java
@@ -223,8 +223,8 @@ public class A2A extends ACoviaAPI {
 
 	/**
 	 * True when a non-owner may <em>interact</em> with a public agent — the agent
-	 * is public AND has an explicit {@code a2a.caps} ceiling (COG-14 §5). Public
-	 * without a ceiling is discoverable (card) but not anonymously interactable:
+	 * is public AND has an explicit {@code a2a.caps} grant scope (COG-14 §5). Public
+	 * without one is discoverable (card) but not anonymously interactable:
 	 * running the agent for anonymous callers requires the owner to deliberately
 	 * bound it.
 	 */
@@ -236,10 +236,10 @@ public class A2A extends ACoviaAPI {
 	/**
 	 * The context under which a non-owner's message runs on a public agent: the
 	 * <em>owner's</em> identity (so it resolves the owner's agent) narrowed by the
-	 * {@code a2a.caps} ceiling. {@code "unrestricted"} → no ceiling (full owner
+	 * {@code a2a.caps} grant scope. {@code "unrestricted"} → no scope (full owner
 	 * authority — the owner's explicit, logged choice); a malformed value falls
-	 * back to a read-only ceiling. A ceiling can only narrow, so this is
-	 * escalation-safe.
+	 * back to a read-only scope. A grant scope can only narrow what the caller may
+	 * do, so this is escalation-safe.
 	 */
 	private RequestContext ownerDispatchContext(A2ACodec.AgentRef ref, AgentState agent) {
 		AString ownerDid = Strings.create(ref.ownerDid());
@@ -248,12 +248,12 @@ public class A2A extends ACoviaAPI {
 			log.warn("A2A: public agent {} runs anonymous callers under UNRESTRICTED owner authority", ref.gridAddress());
 			return RequestContext.of(ownerDid);
 		}
-		AVector<ACell> ceiling = RT.ensureVector(caps);
-		if (ceiling == null) {
+		AVector<ACell> scope = RT.ensureVector(caps);
+		if (scope == null) {
 			log.warn("A2A: public agent {} has malformed a2a.caps; falling back to read-only", ref.gridAddress());
-			ceiling = CapabilityChecker.readOnlyCeiling(ownerDid);
+			scope = CapabilityChecker.readOnlyCeiling(ownerDid);
 		}
-		return RequestContext.of(ownerDid).withCaps(ceiling);
+		return RequestContext.of(ownerDid).withCaps(scope);
 	}
 
 	/**
@@ -278,8 +278,8 @@ public class A2A extends ACoviaAPI {
 		RequestContext caller = AuthMiddleware.callerContext(ctx);
 		boolean owner = isOwner(caller, ref);
 		// The context message/send runs under: the owner as themselves, or — for a
-		// public agent with an explicit a2a.caps ceiling — the owner's identity
-		// narrowed by that ceiling (COG-14 §5). Otherwise, no access (404/403).
+		// public agent with an explicit a2a.caps grant scope — the owner's identity
+		// narrowed by that scope (COG-14 §5). Otherwise, no access (404/403).
 		RequestContext dispatch;
 		if (owner) {
 			dispatch = caller;

--- a/venue/src/main/java/covia/venue/api/A2A.java
+++ b/venue/src/main/java/covia/venue/api/A2A.java
@@ -251,7 +251,7 @@ public class A2A extends ACoviaAPI {
 		AVector<ACell> scope = RT.ensureVector(caps);
 		if (scope == null) {
 			log.warn("A2A: public agent {} has malformed a2a.caps; falling back to read-only", ref.gridAddress());
-			scope = CapabilityChecker.readOnlyCeiling(ownerDid);
+			scope = CapabilityChecker.readOnlyScope(ownerDid);
 		}
 		return RequestContext.of(ownerDid).withCaps(scope);
 	}

--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -355,7 +355,7 @@ public class CoviaAPI extends ACoviaAPI {
 	 * bearer proof on the request.
 	 *
 	 * @param ref Asset reference (lattice address or bare hash)
-	 * @param ctx Request context (caller identity, capability ceiling, proofs)
+	 * @param ctx Request context (caller identity, grant scope, proofs)
 	 * @return the resolved Asset, or null if the reference resolves to nothing
 	 *         or to a non-asset value
 	 */

--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -360,7 +360,7 @@ public class CoviaAPI extends ACoviaAPI {
 	 */
 	private Asset resolveAssetReference(String ref, RequestContext ctx) throws IOException {
 		AString refStr = Strings.create(ref);
-		ctx.requireCapability(refStr, Strings.intern("asset/read"));
+		engine().requireAuthority(ctx,refStr, Strings.intern("asset/read"));
 
 		// Content-addressed forms (bare hex, a/<hash>, did:.../a/<hash>) — fetch
 		// the stored record so the returned bytes are byte-identical to the legacy

--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -589,10 +589,10 @@ public class CoviaAPI extends ACoviaAPI {
 		ACell input=RT.getIn(req, "input");
 		RequestContext rctx = AuthMiddleware.callerContext(ctx);
 
-		// Attach transport UCAN authority — proofs (cross-user grants) and the
-		// self-attenuation ceiling (#131) — from both channels: the `ucans`
-		// envelope array and an `Authorization: Bearer <ucan-jwt>` (IETF
-		// UCAN-HTTP) stashed by AuthMiddleware as UCAN_BEARER_ATTR.
+		// Attach transport UCAN authority — proofs are additive cross-user grants —
+		// from both channels: the `ucans` envelope array and an
+		// `Authorization: Bearer <ucan-jwt>` (IETF UCAN-HTTP) stashed by
+		// AuthMiddleware as UCAN_BEARER_ATTR.
 		AVector<ACell> ucans = RT.getIn(req, "ucans");
 		AString bearer = ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR);
 		// venueDID enables identity-from-ucans: an anonymous transport carrying a

--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -28,6 +28,7 @@ import covia.adapter.AAdapter;
 import covia.adapter.AgentAdapter;
 import covia.adapter.CoviaAdapter;
 import convex.core.util.JSON;
+import covia.api.Abilities;
 import covia.api.Fields;
 import covia.exception.AuthException;
 import covia.grid.AContent;
@@ -360,7 +361,7 @@ public class CoviaAPI extends ACoviaAPI {
 	 */
 	private Asset resolveAssetReference(String ref, RequestContext ctx) throws IOException {
 		AString refStr = Strings.create(ref);
-		engine().requireAuthority(ctx,refStr, Strings.intern("asset/read"));
+		engine().requireAuthority(ctx,refStr, Abilities.ASSET_READ);
 
 		// Content-addressed forms (bare hex, a/<hash>, did:.../a/<hash>) — fetch
 		// the stored record so the returned bytes are byte-identical to the legacy

--- a/venue/src/main/java/covia/venue/api/MCP.java
+++ b/venue/src/main/java/covia/venue/api/MCP.java
@@ -383,9 +383,9 @@ public class MCP extends McpServer {
 				Context ctx = McpServer.getCurrentContext();
 				RequestContext rctx = AuthMiddleware.callerContext(ctx);
 
-				// Attach transport UCAN authority — proofs (cross-user grants)
-				// and the self-attenuation ceiling (#131) — from the `ucans` tool
-				// argument and an Authorization bearer UCAN.
+				// Attach transport UCAN authority — proofs are additive cross-user
+				// grants — from the `ucans` tool argument and an Authorization
+				// bearer UCAN.
 				AVector<ACell> ucans = RT.getIn(arguments, Fields.UCANS);
 				AString bearer = (ctx != null) ? ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR) : null;
 				rctx = AuthMiddleware.withTransportAuth(rctx, bearer, ucans, engine().getDIDString());

--- a/venue/src/main/java/covia/venue/server/AuthMiddleware.java
+++ b/venue/src/main/java/covia/venue/server/AuthMiddleware.java
@@ -48,7 +48,7 @@ public class AuthMiddleware {
 
 	static final String CALLER_DID_ATTR = "callerDID";
 	/**
-	 * Context attribute holding the capability ceiling for an unauthenticated
+	 * Context attribute holding the capability grant scope for an unauthenticated
 	 * (public) caller, derived from {@code auth.public.caps}. Absent for
 	 * authenticated callers (unrestricted unless a transport token attenuates).
 	 */
@@ -92,7 +92,7 @@ public class AuthMiddleware {
 		this.publicAccessEnabled = auth.isPublicAccessEnabled();
 		this.externalProviders = auth.getLoginProviders().hasProviders()
 			? auth.getLoginProviders().getProviders() : null;
-		// Capability ceiling for public callers — secure read-only by default,
+		// Capability grant scope for public callers — secure read-only by default,
 		// operator-overridable via auth.public.caps. Only relevant when public
 		// access is enabled (otherwise every anonymous request is 401'd).
 		this.publicCeiling = publicAccessEnabled ? auth.getPublicCeiling(publicDID) : null;
@@ -195,7 +195,7 @@ public class AuthMiddleware {
 
 	/**
 	 * Attribute an unauthenticated request to the venue's public DID and stash
-	 * the public capability ceiling (if any), so the downstream
+	 * the public capability grant scope (if any), so the downstream
 	 * {@link #callerContext} applies it uniformly.
 	 */
 	private void markPublic(Context ctx) {
@@ -449,14 +449,14 @@ public class AuthMiddleware {
 	/**
 	 * Builds the base {@link RequestContext} for an inbound request: the caller
 	 * DID plus, for unauthenticated (public) callers, the configured capability
-	 * ceiling ({@code auth.public.caps}, default read-only). This is the single
-	 * seam where a request's ceiling is established, before transport-token
+	 * grant scope ({@code auth.public.caps}, default read-only). This is the single
+	 * seam where a request's grant scope is established, before transport-token
 	 * authority ({@link #withTransportAuth}) is layered on. Null-safe: a null
 	 * Javalin context (e.g. an MCP call with no HTTP context) yields
 	 * {@link RequestContext#ANONYMOUS}.
 	 *
 	 * @param ctx Javalin context, or null
-	 * @return the caller's request context with its ceiling applied
+	 * @return the caller's request context with its grant scope applied
 	 */
 	public static RequestContext callerContext(Context ctx) {
 		if (ctx == null) return RequestContext.ANONYMOUS;
@@ -538,7 +538,7 @@ public class AuthMiddleware {
 		if (venueDID != null && bearer == null && isPublicOrAnonymous(rctx, venueDID)) {
 			AString identity = identityFromProofs(proofs, venueDID);
 			if (identity != null) {
-				// A proven caller: fresh context — the public read-only ceiling
+				// A proven caller: fresh context — the public read-only grant scope
 				// does not apply to an authenticated identity.
 				rctx = RequestContext.of(identity);
 			}
@@ -552,7 +552,7 @@ public class AuthMiddleware {
 		// never be replayed elsewhere.
 		if (ucans != null && !ucans.isEmpty()) rctx = rctx.withRawUcans(ucans);
 		// No self-attenuation from the wire: presented proofs are additive grants,
-		// never a subtractive self-ceiling. To act with reduced authority, hand the
+		// never subtractive. To act with reduced authority, hand the
 		// callee a narrower Authority (Authority.of(did, grants)) or present only the
 		// UCANs the request needs — you never send everything and then subtract.
 		return rctx;

--- a/venue/src/main/java/covia/venue/server/AuthMiddleware.java
+++ b/venue/src/main/java/covia/venue/server/AuthMiddleware.java
@@ -20,7 +20,6 @@ import convex.auth.did.DIDVerifier;
 import convex.auth.ucan.UCANValidator;
 import convex.core.lang.RT;
 import covia.api.Fields;
-import covia.lattice.CapabilityChecker;
 import covia.venue.Auth;
 import covia.venue.RequestContext;
 import covia.venue.auth.JWKSClient;
@@ -469,28 +468,21 @@ public class AuthMiddleware {
 
 	/**
 	 * Attach transport-presented UCAN authority to a request context — the single
-	 * seam used by every invoke transport (REST, MCP). Two things, in order:
-	 * <ol>
-	 *   <li><b>Proofs</b> — the cryptographically-verified tokens, for cross-user
-	 *       grant checks (unchanged behaviour).</li>
-	 *   <li><b>Self-attenuation ceiling</b> — capabilities the <em>owner</em>
-	 *       authored over their own resources, restricting this session. Set as
-	 *       {@code caps} so the executing adapter applies them as a ceiling at its
-	 *       enforcement point. Closes the gap where a presented attenuated token
-	 *       ran with full authority (#131).</li>
-	 * </ol>
+	 * seam used by every invoke transport (REST, MCP). Presented proofs are the
+	 * cryptographically-verified tokens, attached for <b>cross-user grant
+	 * checks</b> (§5.2). Proofs are <b>additive</b>: a token only ever <em>adds</em>
+	 * a grant, it never subtracts from the caller's own authority — so there is no
+	 * wire-level self-attenuation. To act with reduced authority, run under a
+	 * narrower {@link covia.grid.Authority} (an agent's {@code config.caps}) or
+	 * present only the UCANs the request needs.
 	 *
-	 * <p>The owner is the authority over its own namespace; the venue only
-	 * enforces. So the ceiling is taken from tokens the caller authored for
-	 * itself ({@code iss == aud == caller}). A ceiling can only <em>narrow</em>
-	 * the caller's own authority — never widen it — so this is escalation-safe.
-	 * With no token presented, nothing is attached and access is unrestricted
+	 * <p>With no token presented, nothing is attached and access is unrestricted
 	 * (the common case).</p>
 	 *
 	 * @param rctx context for the authenticated caller (caller DID already set)
 	 * @param bearer Authorization bearer JWT, or null
 	 * @param ucans transport {@code ucans} vector, or null
-	 * @return rctx with proofs and (if any) the self-cap ceiling attached
+	 * @return rctx with the presented proofs attached
 	 */
 	public static RequestContext withTransportAuth(RequestContext rctx, AString bearer,
 			AVector<ACell> ucans) {
@@ -559,12 +551,10 @@ public class AuthMiddleware {
 		// NOT retained for relay — it is audienced to THIS venue (#149) and must
 		// never be replayed elsewhere.
 		if (ucans != null && !ucans.isEmpty()) rctx = rctx.withRawUcans(ucans);
-		AString caller = rctx.getCallerDID();
-		long now = System.currentTimeMillis() / 1000;
-		// Derives the self-attenuation ceiling: a single-hop selection of the caller's
-		// self-authored tokens (iss == aud == caller) plus covia's narrow-only guard.
-		AVector<ACell> caps = CapabilityChecker.selfCapabilities(proofs, caller, caller, now);
-		if (caps != null) rctx = rctx.withCaps(caps);
+		// No self-attenuation from the wire: presented proofs are additive grants,
+		// never a subtractive self-ceiling. To act with reduced authority, hand the
+		// callee a narrower Authority (Authority.of(did, grants)) or present only the
+		// UCANs the request needs — you never send everything and then subtract.
 		return rctx;
 	}
 

--- a/venue/src/main/java/covia/venue/server/AuthMiddleware.java
+++ b/venue/src/main/java/covia/venue/server/AuthMiddleware.java
@@ -80,7 +80,7 @@ public class AuthMiddleware {
 	private final Auth venueAuth;
 	private final Map<String, OAuthConfig> externalProviders;
 	private final boolean publicAccessEnabled;
-	private final AVector<ACell> publicCeiling;
+	private final AVector<ACell> publicScope;
 	private final String audiencePolicy;                  // "verify" | "require"
 	private final java.util.Set<String> acceptedAudiences;
 
@@ -95,7 +95,7 @@ public class AuthMiddleware {
 		// Capability grant scope for public callers — secure read-only by default,
 		// operator-overridable via auth.public.caps. Only relevant when public
 		// access is enabled (otherwise every anonymous request is 401'd).
-		this.publicCeiling = publicAccessEnabled ? auth.getPublicCeiling(publicDID) : null;
+		this.publicScope = publicAccessEnabled ? auth.getPublicScope(publicDID) : null;
 		// Accepted JWT audiences: the venue's own published DID (whatever its
 		// method — did:key, did:web, …) plus any operator allowlist. A bearer
 		// token's `aud` must name one of these (RFC 7519 §4.1.3), so a token
@@ -200,7 +200,7 @@ public class AuthMiddleware {
 	 */
 	private void markPublic(Context ctx) {
 		ctx.attribute(CALLER_DID_ATTR, publicDID);
-		if (publicCeiling != null) ctx.attribute(CALLER_CAPS_ATTR, publicCeiling);
+		if (publicScope != null) ctx.attribute(CALLER_CAPS_ATTR, publicScope);
 	}
 
 	void extractIdentity(Context ctx) {

--- a/venue/src/main/java/covia/venue/storage/ContentProvider.java
+++ b/venue/src/main/java/covia/venue/storage/ContentProvider.java
@@ -19,7 +19,7 @@ import covia.venue.RequestContext;
  * returns null / false for anything else, so providers compose by namespace.</p>
  *
  * <p><b>Access control is the provider's responsibility</b> — each enforces the
- * same checks its own operations enforce (ceilings, cross-user proofs), and
+ * same checks its own operations enforce (grant scope, cross-user proofs), and
  * throws on denial rather than degrading.</p>
  */
 public interface ContentProvider {

--- a/venue/src/test/java/covia/adapter/AdapterCapEnforcementTest.java
+++ b/venue/src/test/java/covia/adapter/AdapterCapEnforcementTest.java
@@ -28,12 +28,12 @@ import covia.venue.TestEngine;
  * <p>Each op is invoked <b>directly</b> on its adapter ({@code invokeFuture}),
  * bypassing {@code JobManager}'s name-keyed boundary net, so these assertions
  * isolate the adapter's own {@code ctx.requireCapability(...)} call: the right
- * resource and the right ability. Under the public read-only ceiling, mutations
+ * resource and the right ability. Under the public read-only scope, mutations
  * are denied and owner-scoped reads are allowed — including DLFS, which is a
  * DID-scoped {@code <did>/dlfs/…} namespace covered by the caller's crud/read
  * grant like {@code /w/}. Only genuinely scheme-qualified {@code file://}
  * resources fall outside the owner-scoped grant, so those reads are denied (the
- * secure default for a public caller). A null ceiling (authenticated/internal)
+ * secure default for a public caller). A null scope (authenticated/internal)
  * is unrestricted — no cap denial on any op.</p>
  */
 @TestInstance(Lifecycle.PER_CLASS)
@@ -41,13 +41,13 @@ public class AdapterCapEnforcementTest {
 
 	private static Engine engine;
 	private static final AString DID = Strings.create("did:key:zCapEnforceTest");
-	private static RequestContext readOnly;     // public read-only ceiling
-	private static RequestContext unrestricted; // null ceiling
+	private static RequestContext readOnly;     // public read-only scope
+	private static RequestContext unrestricted; // null scope
 
 	@BeforeAll
 	public void setup() {
 		engine = TestEngine.ENGINE;
-		readOnly = RequestContext.of(DID).withCaps(CapabilityChecker.readOnlyCeiling(DID));
+		readOnly = RequestContext.of(DID).withCaps(CapabilityChecker.readOnlyScope(DID));
 		unrestricted = RequestContext.of(DID); // no caps
 	}
 
@@ -106,7 +106,7 @@ public class AdapterCapEnforcementTest {
 		assertFalse(capDenied(direct("asset", "get", m(Fields.ID, "0xabc123"), readOnly)));
 	}
 	@Test public void assetStoreNotCapDeniedUnrestricted() {
-		// Null ceiling: no cap denial (may still error for missing metadata).
+		// Null scope: no cap denial (may still error for missing metadata).
 		assertFalse(capDenied(direct("asset", "store", Maps.empty(), unrestricted)));
 	}
 
@@ -118,7 +118,7 @@ public class AdapterCapEnforcementTest {
 		assertFalse(capDenied(direct("skills", "manage", m("command", "list"), readOnly)));
 	}
 	@Test public void skillsReadByAssetRefAllowedUnderReadOnly() {
-		// asset/read is in the ceiling; a missing asset errors but is not a denial.
+		// asset/read is in the scope; a missing asset errors but is not a denial.
 		assertFalse(capDenied(direct("skills", "manage",
 			m("command", "read", "ref", "a/" + "00".repeat(32)), readOnly)));
 	}
@@ -148,7 +148,7 @@ public class AdapterCapEnforcementTest {
 		assertTrue(capDenied(direct("dlfs", "write", m("drive", "d", "path", "x"), readOnly)));
 	}
 	// DLFS is a DID-scoped namespace (<callerDID>/dlfs/…) alongside /w/ and /j/, so a
-	// read-only ceiling's crud/read on the caller's own namespace covers own-drive reads
+	// read-only scope's crud/read on the caller's own namespace covers own-drive reads
 	// — same as lattice reads. (Cross-user reads are gated separately by proofsCover.)
 	@Test public void dlfsReadAllowedUnderReadOnly() {
 		assertFalse(capDenied(direct("dlfs", "read", m("drive", "d", "path", "x"), readOnly)));

--- a/venue/src/test/java/covia/adapter/AgentAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/AgentAdapterTest.java
@@ -2372,7 +2372,7 @@ public class AgentAdapterTest {
 	@SuppressWarnings("unchecked")
 	public void testToolFailureRecordedAndVisibleInContext() {
 		// toolllm calls v/test/ops/echo once, then reports the tool result as
-		// text. The ceiling's invoke grant does not cover echo → denial.
+		// text. The scope's invoke grant does not cover echo → denial.
 		engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(
@@ -4238,9 +4238,9 @@ public class AgentAdapterTest {
 		assertNull(agent.getSession(sid), "session record should be gone");
 	}
 
-	/** The read-only public ceiling denies deleteSession (agent/write). */
+	/** The read-only public scope denies deleteSession (agent/write). */
 	@Test
-	public void testDeleteSessionDeniedUnderReadOnlyCeiling() {
+	public void testDeleteSessionDeniedUnderReadOnlyScope() {
 		engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "del-cap-agent"),
@@ -4253,14 +4253,14 @@ public class AgentAdapterTest {
 		AString sidHex = RT.ensureString(RT.getIn(msg.awaitResult(5000), Fields.SESSION_ID));
 
 		RequestContext readOnly = RequestContext.of(ALICE_DID)
-			.withCaps(covia.lattice.CapabilityChecker.readOnlyCeiling(ALICE_DID));
+			.withCaps(covia.lattice.CapabilityChecker.readOnlyScope(ALICE_DID));
 		Job del = engine.jobs().invokeOperation(
 			"v/ops/agent/delete-session",
 			Maps.of(Fields.AGENT_ID, "del-cap-agent", Fields.SESSION_ID, sidHex),
 			readOnly);
 		try {
 			del.awaitResult(5000);
-			fail("read-only ceiling should deny deleteSession");
+			fail("read-only scope should deny deleteSession");
 		} catch (Exception e) {
 			assertEquals(Status.FAILED, del.getStatus());
 		}

--- a/venue/src/test/java/covia/adapter/DLFSCrossUserTest.java
+++ b/venue/src/test/java/covia/adapter/DLFSCrossUserTest.java
@@ -129,6 +129,29 @@ public class DLFSCrossUserTest {
 		return token.toMap();
 	}
 
+	// ========== Additive authority (config grant OR proof) ==========
+
+	@Test
+	public void testConfigCappedCallerUsesProofAdditively() {
+		// Alice is capped to read only her own w/reports — her ceiling does NOT
+		// reach Bob's namespace. A self-sovereign proof from Bob grants her read of
+		// his resource; under the additive model that authorises regardless of her
+		// ceiling. This is the core behaviour change, checked at the seam directly.
+		AVector<ACell> aliceCaps = Vectors.of(
+			Capability.create(Strings.create("w/reports"), Capability.CRUD_READ));
+		AString bobResource = Strings.create(BOB_DID + "/dlfs/docs/shared/report.md");
+		AMap<AString, ACell> bobGrant = ownerToken(BOB_KP, ALICE_DID,
+			BOB_DID + "/dlfs/docs/", "crud/read", 3600);
+
+		RequestContext cappedNoProof = RequestContext.of(ALICE_DID).withCaps(aliceCaps);
+		RequestContext cappedWithProof = withProofs(cappedNoProof, bobGrant);
+
+		assertFalse(engine.authorityCovers(cappedNoProof, bobResource, Capability.CRUD_READ),
+			"capped caller, no proof — the ceiling does not reach Bob");
+		assertTrue(engine.authorityCovers(cappedWithProof, bobResource, Capability.CRUD_READ),
+			"capped caller + valid proof — additive, authorised despite the ceiling");
+	}
+
 	// ========== Self-sovereign + delegation chains (covia#196) ==========
 
 	@Test

--- a/venue/src/test/java/covia/adapter/DLFSCrossUserTest.java
+++ b/venue/src/test/java/covia/adapter/DLFSCrossUserTest.java
@@ -133,10 +133,10 @@ public class DLFSCrossUserTest {
 
 	@Test
 	public void testConfigCappedCallerUsesProofAdditively() {
-		// Alice is capped to read only her own w/reports — her ceiling does NOT
+		// Alice is capped to read only her own w/reports — her scope does NOT
 		// reach Bob's namespace. A self-sovereign proof from Bob grants her read of
 		// his resource; under the additive model that authorises regardless of her
-		// ceiling. This is the core behaviour change, checked at the seam directly.
+		// scope. This is the core behaviour change, checked at the seam directly.
 		AVector<ACell> aliceCaps = Vectors.of(
 			Capability.create(Strings.create("w/reports"), Capability.CRUD_READ));
 		AString bobResource = Strings.create(BOB_DID + "/dlfs/docs/shared/report.md");
@@ -147,9 +147,9 @@ public class DLFSCrossUserTest {
 		RequestContext cappedWithProof = withProofs(cappedNoProof, bobGrant);
 
 		assertFalse(engine.authorityCovers(cappedNoProof, bobResource, Capability.CRUD_READ),
-			"capped caller, no proof — the ceiling does not reach Bob");
+			"capped caller, no proof — the scope does not reach Bob");
 		assertTrue(engine.authorityCovers(cappedWithProof, bobResource, Capability.CRUD_READ),
-			"capped caller + valid proof — additive, authorised despite the ceiling");
+			"capped caller + valid proof — additive, authorised despite the scope");
 	}
 
 	// ========== Self-sovereign + delegation chains (covia#196) ==========

--- a/venue/src/test/java/covia/adapter/MCPBridgeTest.java
+++ b/venue/src/test/java/covia/adapter/MCPBridgeTest.java
@@ -97,9 +97,9 @@ public class MCPBridgeTest {
 
 	@Test
 	public void testVenueScopeRequiresManageAbility() {
-		// A caller under the public read-only ceiling must be denied venue scope
+		// A caller under the public read-only scope must be denied venue scope
 		RequestContext capped = RequestContext.of(ALICE_DID)
-			.withCaps(CapabilityChecker.readOnlyCeiling(ALICE_DID));
+			.withCaps(CapabilityChecker.readOnlyScope(ALICE_DID));
 		Job denied = addServer("selfc", TestServer.BASE_URL, "venue", capped);
 		assertThrows(Exception.class, () -> denied.awaitResult(15000));
 		assertEquals(Status.FAILED, denied.getStatus());
@@ -247,7 +247,7 @@ public class MCPBridgeTest {
 	@Test
 	public void testAddToolVenuePathRequiresManage() {
 		RequestContext capped = RequestContext.of(ALICE_DID)
-			.withCaps(CapabilityChecker.readOnlyCeiling(ALICE_DID));
+			.withCaps(CapabilityChecker.readOnlyScope(ALICE_DID));
 		Job denied = addTool("v/ops/mcptest/echo", "test_echo", capped);
 		assertThrows(Exception.class, () -> denied.awaitResult(15000));
 		assertEquals(Status.FAILED, denied.getStatus());

--- a/venue/src/test/java/covia/adapter/SkillsLibraryTest.java
+++ b/venue/src/test/java/covia/adapter/SkillsLibraryTest.java
@@ -134,7 +134,7 @@ public class SkillsLibraryTest {
 		// invocation (verified live — skill loading grants no authority).
 		ACell config = engine.resolvePath(Strings.create("v/agents/templates/reader"), ctx);
 		AVector<ACell> caps = RT.ensureVector(RT.getIn(config, "caps"));
-		assertNotNull(caps, "reader must pin a capability ceiling");
+		assertNotNull(caps, "reader must pin a capability");
 		assertEquals(2, caps.count());
 		assertEquals("crud/read", RT.getIn(caps.get(0), "can").toString());
 		assertEquals("asset/read", RT.getIn(caps.get(1), "can").toString());

--- a/venue/src/test/java/covia/adapter/agent/LLMAgentAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/agent/LLMAgentAdapterTest.java
@@ -907,7 +907,7 @@ public class LLMAgentAdapterTest {
 	public void testCappedAgentCanCompleteTask() {
 		// Regression (covia#71 live testing): the task-lifecycle ops are
 		// self-scoped (agentId/taskId from the RequestContext) and must stay
-		// callable under a restricted config ceiling. A blanket invoke gate on
+		// callable under a restricted config scope. A blanket invoke gate on
 		// AgentAdapter.invokeFuture once denied complete_task to any capped
 		// agent, trapping every capped worker in the tool loop until the
 		// iteration limit — a capped pipeline could never finish a task.
@@ -918,7 +918,7 @@ public class LLMAgentAdapterTest {
 				Fields.CONFIG, Maps.of(
 					Fields.OPERATION, "v/ops/llmagent/chat",
 					"llmOperation", "v/test/ops/taskllm",
-					// Restricted ceiling: one read grant, no invoke ability.
+					// Restricted scope: one read grant, no invoke ability.
 					"caps", Vectors.of(Maps.of(
 						"with", Strings.create("w/allowed/"),
 						"can", Strings.create("crud/read"))))

--- a/venue/src/test/java/covia/lattice/CapabilityCheckerTest.java
+++ b/venue/src/test/java/covia/lattice/CapabilityCheckerTest.java
@@ -25,7 +25,7 @@ import covia.venue.TestEngine;
  * <p>There is no central name-keyed boundary: each adapter asserts its own cap
  * at its enforcement point (see {@code AdapterCapEnforcementTest}). These tests
  * cover the shared primitives those adapters call — {@link CapabilityChecker#allows}
- * (boundary matching via core's {@code Capability.resourceCovers}), {@code readOnlyCeiling},
+ * (boundary matching via core's {@code Capability.resourceCovers}), {@code readOnlyScope},
  * and {@link RequestContext#requireCapability} — plus
  * end-to-end enforcement through {@code JobManager}. Resource/ability prefix
  * matching ultimately delegates to convex-core's {@code Capability.covers},
@@ -57,7 +57,7 @@ public class CapabilityCheckerTest {
 	public void testPublicCallerDenialCarriesAuthHint() {
 		// The public/anonymous identity's denial points to the auth remedy
 		// (covia#206) — scoped to the ":public" caller.
-		AVector<ACell> readOnly = CapabilityChecker.readOnlyCeiling(
+		AVector<ACell> readOnly = CapabilityChecker.readOnlyScope(
 			Strings.create("did:key:zVenue:public"));
 		String pub = CapabilityChecker.allows(readOnly, "w/x", "crud/write",
 			Strings.create("did:key:zVenue:public"));
@@ -66,7 +66,7 @@ public class CapabilityCheckerTest {
 		assertTrue(pub.contains("Authenticate") && pub.contains("UCAN.md"),
 			"public denial must carry the auth hint: " + pub);
 
-		// A capped agent (real DID owner) hitting its own ceiling gets a clean
+		// A capped agent (real DID owner) hitting its own scope gets a clean
 		// message — no misleading "authenticate" advice (it already is
 		// authenticated; it should just handle the denial, #211).
 		String agent = CapabilityChecker.allows(readOnly, "w/x", "crud/write",
@@ -74,7 +74,7 @@ public class CapabilityCheckerTest {
 		assertNotNull(agent);
 		assertTrue(agent.contains("Capability denied"), agent);
 		assertFalse(agent.contains("Authenticate"),
-			"a real identity's own-ceiling denial must stay clean: " + agent);
+			"a real identity's own-scope denial must stay clean: " + agent);
 	}
 
 	// ========== End-to-end enforcement at JobManager ==========
@@ -114,10 +114,10 @@ public class CapabilityCheckerTest {
 	}
 
 	@Test
-	public void testInvokeInternalEnforcesContextCeiling() {
+	public void testInvokeInternalEnforcesContextScope() {
 		// Trust is a property of the context's authority, not the call path.
 		// invokeInternal differs from invokeOperation only in Job creation — both
-		// enforce whatever ceiling the context carries via the adapter's pin.
+		// enforce whatever scope the context carries via the adapter's pin.
 		Engine engine = TestEngine.ENGINE;
 
 		AVector<ACell> caps = Vectors.of(
@@ -133,20 +133,20 @@ public class CapabilityCheckerTest {
 				Maps.of(Fields.PATH, "w/forbidden/doc", Fields.VALUE, Strings.create("nope")), gated)
 				.awaitResult(5000));
 
-		// Internal path: same ceiling, same op — also denied. No call-path bypass.
+		// Internal path: same scope, same op — also denied. No call-path bypass.
 		assertThrows(Exception.class, () ->
 			engine.jobs().invokeInternal("v/ops/covia/write",
 				Maps.of(Fields.PATH, "w/forbidden/doc", Fields.VALUE, Strings.create("nope")), gated)
 				.join(),
-			"invokeInternal must enforce the context ceiling");
+			"invokeInternal must enforce the context scope");
 
-		// Within the ceiling, the internal write succeeds.
+		// Within the scope, the internal write succeeds.
 		ACell ok = engine.jobs().invokeInternal("v/ops/covia/write",
 			Maps.of(Fields.PATH, "w/allowed/doc", Fields.VALUE, Strings.create("ok")), gated)
 			.join();
 		assertNotNull(ok);
 
-		// The ceiling stays on the ctx — enforcement reads it, never strips it.
+		// The scope stays on the ctx — enforcement reads it, never strips it.
 		assertEquals(caps, gated.getCaps());
 	}
 
@@ -180,24 +180,24 @@ public class CapabilityCheckerTest {
 
 	@Test
 	public void testAllowsWildcardInvokeGrantCoversEverything() {
-		// Full invoke scope stays a one-liner: {"can":"invoke"} (with omitted)
+		// A full invoke grant stays a one-liner: {"can":"invoke"} (with omitted)
 		// and {"with":"", "can":"invoke"} both cover path-form, hash-form and
 		// resource-less invokes — the documented "restricted paths + full tool
 		// access" recipe keeps working after resource-precision (#211).
 		AVector<ACell> noWith = Vectors.of(
 			Maps.of(Capability.CAN, Strings.create("invoke")));
 		AVector<ACell> emptyWith = caps("", "invoke");
-		for (AVector<ACell> ceiling : java.util.List.of(noWith, emptyWith)) {
-			assertNull(allows(ceiling, "v/test/ops/echo", "invoke"));
-			assertNull(allows(ceiling, "0xdeadbeef", "invoke"));
-			assertNull(allows(ceiling, null, "invoke"));
+		for (AVector<ACell> scope : java.util.List.of(noWith, emptyWith)) {
+			assertNull(allows(scope, "v/test/ops/echo", "invoke"));
+			assertNull(allows(scope, "0xdeadbeef", "invoke"));
+			assertNull(allows(scope, null, "invoke"));
 		}
 	}
 
 	@Test
 	public void testScopedInvokeEndToEnd() {
 		// The op reference the caller supplies reaches requireInvoke via
-		// RequestContext.withOp, so a scoped invoke ceiling admits exactly
+		// RequestContext.withOp, so a scoped invoke grant admits exactly
 		// the named ops and the denial names the op that was blocked.
 		Engine engine = TestEngine.ENGINE;
 		AVector<ACell> invokeCaps = Vectors.of(
@@ -227,16 +227,16 @@ public class CapabilityCheckerTest {
 	// ==================================================================
 
 	@Test
-	public void testAllowsNullCeilingIsUnrestricted() {
-		// null ceiling = full authority (internal/unrestricted callers).
+	public void testAllowsNullScopeIsUnrestricted() {
+		// null scope = full authority (internal/unrestricted callers).
 		assertNull(allows(null, "w/anything", "crud/write"));
 		assertNull(allows(null, "did:key:zOther/w/x", "secret/write"));
 		assertNull(allows(null, null, null));
 	}
 
 	@Test
-	public void testAllowsEmptyCeilingDeniesEverything() {
-		// Empty ceiling grants NOTHING — the crucial distinction from null.
+	public void testAllowsEmptyScopeDeniesEverything() {
+		// Empty scope grants NOTHING — the crucial distinction from null.
 		assertNotNull(allows(Vectors.empty(), "w/x", "crud/read"));
 		assertNotNull(allows(Vectors.empty(), "w/x", "crud/write"));
 		assertNotNull(allows(Vectors.empty(), "v/test/ops/echo", "invoke"));
@@ -244,10 +244,10 @@ public class CapabilityCheckerTest {
 
 	@Test
 	public void testAllowsExactAndPrefix() {
-		AVector<ACell> ceiling = caps("w/notes", "crud/write");
-		assertNull(allows(ceiling, "w/notes", "crud/write"));          // exact
-		assertNull(allows(ceiling, "w/notes/2026/x", "crud/write"));   // child (prefix)
-		assertNotNull(allows(ceiling, "w/other", "crud/write"));       // sibling — denied
+		AVector<ACell> scope = caps("w/notes", "crud/write");
+		assertNull(allows(scope, "w/notes", "crud/write"));          // exact
+		assertNull(allows(scope, "w/notes/2026/x", "crud/write"));   // child (prefix)
+		assertNotNull(allows(scope, "w/other", "crud/write"));       // sibling — denied
 	}
 
 	@Test
@@ -272,19 +272,19 @@ public class CapabilityCheckerTest {
 	@Test
 	public void testAllowsCrossUserResourceDenied() {
 		// An owner-scoped read grant must not reach another identity's resource.
-		AVector<ACell> ceiling = Vectors.of(Capability.create(TEST_OWNER, Capability.CRUD_READ));
-		assertNull(allows(ceiling, "w/notes", "crud/read"));                       // own
-		assertNotNull(allows(ceiling, "did:key:zOther/w/notes", "crud/read"));     // cross-user → denied
+		AVector<ACell> scope = Vectors.of(Capability.create(TEST_OWNER, Capability.CRUD_READ));
+		assertNull(allows(scope, "w/notes", "crud/read"));                       // own
+		assertNotNull(allows(scope, "did:key:zOther/w/notes", "crud/read"));     // cross-user → denied
 	}
 
 	@Test
 	public void testAllowsMultipleCapsAnyMatchWins() {
-		AVector<ACell> ceiling = caps(
+		AVector<ACell> scope = caps(
 			"w/a", "crud/read",
 			"w/b", "crud/write");
-		assertNull(allows(ceiling, "w/b/x", "crud/write"));   // second grant matches
-		assertNull(allows(ceiling, "w/a/x", "crud/read"));    // first grant matches
-		assertNotNull(allows(ceiling, "w/a/x", "crud/write")); // neither grants write on a
+		assertNull(allows(scope, "w/b/x", "crud/write"));   // second grant matches
+		assertNull(allows(scope, "w/a/x", "crud/read"));    // first grant matches
+		assertNotNull(allows(scope, "w/a/x", "crud/write")); // neither grants write on a
 	}
 
 	@Test
@@ -316,11 +316,11 @@ public class CapabilityCheckerTest {
 	public void testAllowsEmptyWithCoversAnyResource() {
 		// An empty `with` grant covers any resource for that ability (used for
 		// content-addressed assets, which are not owner-scoped paths).
-		AVector<ACell> ceiling = Vectors.of(
+		AVector<ACell> scope = Vectors.of(
 			Capability.create(Strings.create(""), Strings.create("asset/read")));
-		assertNull(allows(ceiling, "0xdeadbeef", "asset/read"));
-		assertNull(allows(ceiling, "did:key:zOther/a/0xabc", "asset/read"));
-		assertNotNull(allows(ceiling, "0xdeadbeef", "asset/store")); // wrong ability
+		assertNull(allows(scope, "0xdeadbeef", "asset/read"));
+		assertNull(allows(scope, "did:key:zOther/a/0xabc", "asset/read"));
+		assertNotNull(allows(scope, "0xdeadbeef", "asset/store")); // wrong ability
 	}
 
 	@Test
@@ -356,33 +356,33 @@ public class CapabilityCheckerTest {
 	}
 
 	// ==================================================================
-	// readOnlyCeiling + RequestContext.requireCapability — the public
+	// readOnlyScope + RequestContext.requireCapability — the public
 	// read-only default and the adapter-facing enforcement primitive.
 	// ==================================================================
 
 	@Test
-	public void testReadOnlyCeilingGrantsOnlyReads() {
+	public void testReadOnlyScopeGrantsOnlyReads() {
 		AString did = Strings.create("did:key:zPublic");
-		AVector<ACell> ceiling = CapabilityChecker.readOnlyCeiling(did);
+		AVector<ACell> scope = CapabilityChecker.readOnlyScope(did);
 		// Reads: own/venue lattice + content-addressed assets
-		assertNull(CapabilityChecker.allows(ceiling, "w/x", "crud/read", did));
-		assertNull(CapabilityChecker.allows(ceiling, "v/ops/covia/read", "crud/read", did));
-		assertNull(CapabilityChecker.allows(ceiling, "0xhash", "asset/read", did));
+		assertNull(CapabilityChecker.allows(scope, "w/x", "crud/read", did));
+		assertNull(CapabilityChecker.allows(scope, "v/ops/covia/read", "crud/read", did));
+		assertNull(CapabilityChecker.allows(scope, "0xhash", "asset/read", did));
 		// Every mutating ability denied
-		assertNotNull(CapabilityChecker.allows(ceiling, "w/x", "crud/write", did));
-		assertNotNull(CapabilityChecker.allows(ceiling, "w/x", "crud/delete", did));
-		assertNotNull(CapabilityChecker.allows(ceiling, "s/KEY", "secret/write", did));
-		assertNotNull(CapabilityChecker.allows(ceiling, "g/Bob", "agent/create", did));
-		assertNotNull(CapabilityChecker.allows(ceiling, "0xh", "asset/store", did));
-		assertNotNull(CapabilityChecker.allows(ceiling, "v/test/ops/echo", "invoke", did));
+		assertNotNull(CapabilityChecker.allows(scope, "w/x", "crud/write", did));
+		assertNotNull(CapabilityChecker.allows(scope, "w/x", "crud/delete", did));
+		assertNotNull(CapabilityChecker.allows(scope, "s/KEY", "secret/write", did));
+		assertNotNull(CapabilityChecker.allows(scope, "g/Bob", "agent/create", did));
+		assertNotNull(CapabilityChecker.allows(scope, "0xh", "asset/store", did));
+		assertNotNull(CapabilityChecker.allows(scope, "v/test/ops/echo", "invoke", did));
 		// And no cross-user read
-		assertNotNull(CapabilityChecker.allows(ceiling, "did:key:zOther/w/x", "crud/read", did));
+		assertNotNull(CapabilityChecker.allows(scope, "did:key:zOther/w/x", "crud/read", did));
 	}
 
 	@Test
-	public void testRequireCapabilityEnforcesReadOnlyCeiling() {
+	public void testRequireCapabilityEnforcesReadOnlyScope() {
 		AString did = Strings.create("did:key:zPublic");
-		RequestContext ctx = RequestContext.of(did).withCaps(CapabilityChecker.readOnlyCeiling(did));
+		RequestContext ctx = RequestContext.of(did).withCaps(CapabilityChecker.readOnlyScope(did));
 		assertDoesNotThrow(() -> ctx.requireCapability("w/notes", "crud/read"));
 		assertThrows(AuthException.class, () -> ctx.requireCapability("w/notes", "crud/write"));
 		assertThrows(AuthException.class, () -> ctx.requireCapability("w/notes", "crud/delete"));
@@ -391,8 +391,8 @@ public class CapabilityCheckerTest {
 	}
 
 	@Test
-	public void testRequireCapabilityNullCeilingIsNoOp() {
-		// Authenticated / internal callers carry no ceiling → unrestricted.
+	public void testRequireCapabilityNullScopeIsNoOp() {
+		// Authenticated / internal callers carry no scope → unrestricted.
 		RequestContext ctx = RequestContext.of(Strings.create("did:key:zAlice"));
 		assertDoesNotThrow(() -> ctx.requireCapability("w/anything", "crud/write"));
 		assertDoesNotThrow(() -> ctx.requireCapability("s/KEY", "secret/write"));
@@ -401,20 +401,20 @@ public class CapabilityCheckerTest {
 	@Test
 	public void testAllowsAStringAndStringOverloadsAgree() {
 		AString did = Strings.create("did:key:zPublic");
-		AVector<ACell> ceiling = CapabilityChecker.readOnlyCeiling(did);
+		AVector<ACell> scope = CapabilityChecker.readOnlyScope(did);
 		// The AString-native primary and the String convenience overload must
 		// produce identical verdicts and identical denial messages.
 		assertEquals(
-			CapabilityChecker.allows(ceiling, "w/x", "crud/write", did),
-			CapabilityChecker.allows(ceiling, Strings.create("w/x"), Capability.CRUD_WRITE, did));
-		assertNull(CapabilityChecker.allows(ceiling, Strings.create("w/x"), Capability.CRUD_READ, did));
-		assertNotNull(CapabilityChecker.allows(ceiling, Strings.create("w/x"), Capability.CRUD_WRITE, did));
+			CapabilityChecker.allows(scope, "w/x", "crud/write", did),
+			CapabilityChecker.allows(scope, Strings.create("w/x"), Capability.CRUD_WRITE, did));
+		assertNull(CapabilityChecker.allows(scope, Strings.create("w/x"), Capability.CRUD_READ, did));
+		assertNotNull(CapabilityChecker.allows(scope, Strings.create("w/x"), Capability.CRUD_WRITE, did));
 	}
 
 	@Test
 	public void testRequireCapabilityAStringOverloadEnforces() {
 		AString did = Strings.create("did:key:zPublic");
-		RequestContext ctx = RequestContext.of(did).withCaps(CapabilityChecker.readOnlyCeiling(did));
+		RequestContext ctx = RequestContext.of(did).withCaps(CapabilityChecker.readOnlyScope(did));
 		assertDoesNotThrow(() -> ctx.requireCapability(Strings.create("w/x"), Capability.CRUD_READ));
 		assertThrows(AuthException.class,
 			() -> ctx.requireCapability(Strings.create("w/x"), Capability.CRUD_WRITE));
@@ -476,7 +476,7 @@ public class CapabilityCheckerTest {
 
 	@Test
 	public void testLegacyDlfsSchemeShorthandCoversOwnDrive() {
-		// A ceiling cap written in the legacy scheme form (dlfs://docs/) must cover
+		// A scope cap written in the legacy scheme form (dlfs://docs/) must cover
 		// the DID-scoped path form the adapter now enforces (dlfs/docs/…), and
 		// vice versa — both canonicalise to <owner>/dlfs/docs/….
 		AString did = Strings.create("did:key:zDlfsCompat");
@@ -498,9 +498,9 @@ public class CapabilityCheckerTest {
 	}
 
 	@Test
-	public void testEmptyWithGrantIsCeilingWildcard() {
+	public void testEmptyWithGrantIsScopeWildcard() {
 		// An empty-`with` grant matches any resource — the venue's asset/read
-		// ceiling relies on it. This wildcard lives only in the ceiling (allows)
+		// scope relies on it. This wildcard lives only in the scope (allows)
 		// path, never in the fail-closed UCAN proof path. Boundary matching for
 		// concrete grants is core's Capability.resourceCovers (Convex #585),
 		// exercised via allows() in testResourceBoundaryViaAllows above.
@@ -515,7 +515,7 @@ public class CapabilityCheckerTest {
 	public void testCrossUserDIDWritePathRejected() {
 		Engine engine = TestEngine.ENGINE;
 		AString did = convex.auth.ucan.UCAN.toDIDKey(convex.core.crypto.AKeyPair.generate().getAccountKey());
-		RequestContext ctx = RequestContext.of(did); // authenticated, null ceiling
+		RequestContext ctx = RequestContext.of(did); // authenticated, null scope
 		Throwable ex = assertThrows(Throwable.class, () ->
 			engine.jobs().invokeInternal("v/ops/covia/write",
 				Maps.of(Fields.PATH, "did:key:zOtherUser/w/x", Fields.VALUE, Strings.create("v")), ctx).join());
@@ -528,28 +528,28 @@ public class CapabilityCheckerTest {
 	}
 
 	@Test
-	public void testReadOnlyCeilingStopsMutationsEndToEnd() {
+	public void testReadOnlyScopeStopsMutationsEndToEnd() {
 		Engine engine = TestEngine.ENGINE;
 		AString did = convex.auth.ucan.UCAN.toDIDKey(
 			convex.core.crypto.AKeyPair.generate().getAccountKey());
-		RequestContext ctx = RequestContext.of(did).withCaps(CapabilityChecker.readOnlyCeiling(did));
+		RequestContext ctx = RequestContext.of(did).withCaps(CapabilityChecker.readOnlyScope(did));
 
-		// Read under a read-only ceiling is allowed (absent path → exists:false).
+		// Read under a read-only scope is allowed (absent path → exists:false).
 		Job read = engine.jobs().invokeOperation("v/ops/covia/read",
 			Maps.of(Fields.PATH, "w/x"), ctx);
-		assertNotNull(read.awaitResult(5000), "read is allowed under a read-only ceiling");
+		assertNotNull(read.awaitResult(5000), "read is allowed under a read-only scope");
 
 		// Mutations are denied — the adapter fails the Job (observed at awaitResult).
 		assertThrows(Exception.class, () -> engine.jobs().invokeOperation("v/ops/covia/write",
 			Maps.of(Fields.PATH, "w/x", Fields.VALUE, Strings.create("v")), ctx).awaitResult(5000),
-			"write must be denied under a read-only ceiling");
+			"write must be denied under a read-only scope");
 		assertThrows(Exception.class, () -> engine.jobs().invokeOperation("v/ops/covia/delete",
 			Maps.of(Fields.PATH, "w/x"), ctx).awaitResult(5000),
-			"delete must be denied under a read-only ceiling");
+			"delete must be denied under a read-only scope");
 		// s/ deletes take the delete-only namespace branch (#166) — the capability
 		// gate must still apply there (requireCap runs before the namespace rule).
 		assertThrows(Exception.class, () -> engine.jobs().invokeOperation("v/ops/covia/delete",
 			Maps.of(Fields.PATH, "s/x"), ctx).awaitResult(5000),
-			"secret delete must be denied under a read-only ceiling");
+			"secret delete must be denied under a read-only scope");
 	}
 }

--- a/venue/src/test/java/covia/lattice/CapabilityCheckerTest.java
+++ b/venue/src/test/java/covia/lattice/CapabilityCheckerTest.java
@@ -26,7 +26,7 @@ import covia.venue.TestEngine;
  * at its enforcement point (see {@code AdapterCapEnforcementTest}). These tests
  * cover the shared primitives those adapters call — {@link CapabilityChecker#allows}
  * (boundary matching via core's {@code Capability.resourceCovers}), {@code readOnlyCeiling},
- * {@code selfCapabilities}, and {@link RequestContext#requireCapability} — plus
+ * and {@link RequestContext#requireCapability} — plus
  * end-to-end enforcement through {@code JobManager}. Resource/ability prefix
  * matching ultimately delegates to convex-core's {@code Capability.covers},
  * exercised through here.</p>
@@ -421,8 +421,7 @@ public class CapabilityCheckerTest {
 	}
 
 	// ==================================================================
-	// Hardenings (Convex #585 mitigation + self-ceiling hygiene + explicit
-	// cross-user write rejection).
+	// Hardenings (Convex #585 mitigation + explicit cross-user write rejection).
 	// ==================================================================
 
 	@Test
@@ -510,27 +509,6 @@ public class CapabilityCheckerTest {
 		assertNull(CapabilityChecker.allows(caps, "a/deadbeef", "asset/read", null));   // any resource
 		assertNull(CapabilityChecker.allows(caps, "anything/else", "asset/read", null));
 		assertNotNull(CapabilityChecker.allows(caps, "a/deadbeef", "crud/write", null)); // wrong ability — DENY
-	}
-
-	@Test
-	public void testSelfCapabilitiesStripsEmptyWithCaps() {
-		convex.core.crypto.AKeyPair kp = convex.core.crypto.AKeyPair.generate();
-		AString did = convex.auth.ucan.UCAN.toDIDKey(kp.getAccountKey());
-		long now = System.currentTimeMillis() / 1000;
-		// Self-token (iss == aud == caller) granting a scoped read AND an
-		// empty-`with` wildcard write. The wildcard must not survive into the
-		// derived self-ceiling — it would broaden, not narrow.
-		AVector<ACell> caps = Vectors.of(
-			Capability.create(Strings.create(did + "/w/notes"), Capability.CRUD_READ),
-			Capability.create(Strings.create(""), Capability.CRUD_WRITE));
-		convex.auth.ucan.UCAN token = convex.auth.ucan.UCAN.create(
-			kp, kp.getAccountKey(), now + 3600, caps, Vectors.empty());
-		AVector<ACell> ceiling = CapabilityChecker.selfCapabilities(
-			Vectors.of(token.toMap()), did, did, now);
-
-		assertNotNull(ceiling);
-		assertNull(CapabilityChecker.allows(ceiling, "w/notes", "crud/read", did));        // scoped read survives
-		assertNotNull(CapabilityChecker.allows(ceiling, "w/anything", "crud/write", did)); // empty-with wildcard dropped
 	}
 
 	@Test

--- a/venue/src/test/java/covia/venue/AuthenticatedPublicAccessTest.java
+++ b/venue/src/test/java/covia/venue/AuthenticatedPublicAccessTest.java
@@ -21,10 +21,10 @@ import covia.grid.Status;
 /**
  * covia#254: an authenticated caller is at least as privileged as the
  * anonymous public caller — access to the PUBLIC user's resources follows
- * the public capability ceiling (default read-only), for any caller.
+ * the public capability scope (default read-only), for any caller.
  *
- * <p>Parity is ceiling-governed, never hard-coded: what these tests assert
- * under the default ceiling widens automatically (and deliberately —
+ * <p>Parity is scope-governed, never hard-coded: what these tests assert
+ * under the default scope widens automatically (and deliberately —
  * caveat emptor) when an operator widens {@code auth.public.caps}.</p>
  */
 public class AuthenticatedPublicAccessTest {
@@ -74,9 +74,9 @@ public class AuthenticatedPublicAccessTest {
 
 	@Test
 	public void testPublicWriteParityDeniedByDefault() {
-		// The default public ceiling is read-only, and cross-user DID-URL
+		// The default public scope is read-only, and cross-user DID-URL
 		// writes remain blocked — write parity arrives only if/when the write
-		// path supports public-targeted cursors under a widened ceiling.
+		// path supports public-targeted cursors under a widened scope.
 		assertThrows(Exception.class, () -> engine.jobs().invokeOperation("v/ops/covia/write",
 			Maps.of(Fields.PATH, PUBLIC_DID + "/w/x", Fields.VALUE, Strings.create("nope")),
 			ALICE).awaitResult(5000));
@@ -87,11 +87,11 @@ public class AuthenticatedPublicAccessTest {
 	@Test
 	public void testAuthenticatedReadsPublicJob() {
 		// ACTIVE public job — readable via the job surface (hot-cache path,
-		// canReadJob's public-ceiling fallback).
+		// canReadJob's public-scope fallback).
 		Job activeJob = engine.jobs().invokeOperation("v/test/ops/never", Maps.empty(), PUBLIC);
 		try {
 			AMap<AString, ACell> viaAlice = engine.jobs().getJobData(activeJob.getID(), ALICE);
-			assertNotNull(viaAlice, "active public-owned jobs are readable per the public ceiling");
+			assertNotNull(viaAlice, "active public-owned jobs are readable per the public scope");
 			assertEquals(PUBLIC_DID, viaAlice.get(Fields.CALLER));
 
 			// Parity, not blanket access: Bob's active job stays owner-only.
@@ -109,7 +109,7 @@ public class AuthenticatedPublicAccessTest {
 
 		// TERMINAL public job — cross-user terminal reads go via the DID-URL
 		// lattice path (same rule as delegated reads), hitting the
-		// verifyProofs public-ceiling fallback.
+		// verifyProofs public-scope fallback.
 		Job doneJob = engine.jobs().invokeOperation("v/test/ops/echo",
 			Maps.of("text", "hello"), PUBLIC);
 		doneJob.awaitResult(5000);
@@ -144,10 +144,10 @@ public class AuthenticatedPublicAccessTest {
 
 	@Test
 	public void testSecretExtractionRemainsClosed() {
-		// covia#254 ruling: extraction is CEILING-governed, not hard-coded —
+		// covia#254 ruling: extraction is SCOPE-governed, not hard-coded —
 		// today it is universally denied (gated implementation pending). When
 		// implemented it must require secret/decrypt, which the DEFAULT public
-		// ceiling withholds; an operator widening auth.public.caps to include
+		// scope withholds; an operator widening auth.public.caps to include
 		// it gets exactly what they asked for (caveat emptor). This test pins
 		// the closed state so that change is a conscious decision.
 		engine.jobs().invokeOperation("v/ops/secret/set",

--- a/venue/src/test/java/covia/venue/AuthorityCoversTest.java
+++ b/venue/src/test/java/covia/venue/AuthorityCoversTest.java
@@ -1,0 +1,65 @@
+package covia.venue;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import convex.auth.ucan.Capability;
+import convex.core.data.ACell;
+import convex.core.data.AString;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+
+/**
+ * Unit coverage for the unified {@code Engine.authorityCovers} seam: the
+ * {@code null}-caps fast path (own vs cross-user), config-grant coverage, and the
+ * additive routing. Proof-backed cross-user access is exercised by
+ * AccessControlTest / UCANTest.
+ */
+public class AuthorityCoversTest {
+
+	private static final Engine ENGINE = TestEngine.ENGINE;
+
+	private static RequestContext withCaps(RequestContext ctx, ACell... grants) {
+		return ctx.withCaps(Vectors.of(grants));
+	}
+
+	@Test
+	public void testNullCapsOwnAllowed() {
+		AString alice = TestEngine.uniqueDID("own-alice");
+		RequestContext ctx = RequestContext.of(alice);   // null caps → unrestricted own-authority
+		assertTrue(ENGINE.authorityCovers(ctx, Strings.create("w/x"), Capability.CRUD_WRITE));
+		assertTrue(ENGINE.authorityCovers(ctx, Strings.create("o/y"), Capability.CRUD_READ));
+	}
+
+	@Test
+	public void testNullCapsCrossUserDeniedWithoutProof() {
+		AString alice = TestEngine.uniqueDID("xu-alice");
+		AString bob = TestEngine.uniqueDID("xu-bob");
+		RequestContext ctx = RequestContext.of(alice);   // null caps, no proofs
+		AString bobResource = Strings.create(bob + "/w/x");
+		// the fast path must NOT reach another user's namespace
+		assertFalse(ENGINE.authorityCovers(ctx, bobResource, Capability.CRUD_WRITE));
+		assertFalse(ENGINE.authorityCovers(ctx, bobResource, Capability.CRUD_READ));
+	}
+
+	@Test
+	public void testConfigCapsBoundOwnAccess() {
+		AString alice = TestEngine.uniqueDID("cap-alice");
+		RequestContext ctx = withCaps(RequestContext.of(alice),
+			Capability.create(Strings.create("w/reports"), Capability.CRUD_READ));
+		assertTrue(ENGINE.authorityCovers(ctx, Strings.create("w/reports"), Capability.CRUD_READ));
+		// same path, different ability — not granted
+		assertFalse(ENGINE.authorityCovers(ctx, Strings.create("w/reports"), Capability.CRUD_WRITE));
+		// different path — not granted
+		assertFalse(ENGINE.authorityCovers(ctx, Strings.create("w/secrets"), Capability.CRUD_READ));
+	}
+
+	@Test
+	public void testAnonymousCrossUserDenied() {
+		AString bob = TestEngine.uniqueDID("anon-bob");
+		assertFalse(ENGINE.authorityCovers(RequestContext.ANONYMOUS,
+			Strings.create(bob + "/w/x"), Capability.CRUD_READ));
+	}
+}

--- a/venue/src/test/java/covia/venue/AuthorityCoversTest.java
+++ b/venue/src/test/java/covia/venue/AuthorityCoversTest.java
@@ -13,9 +13,10 @@ import convex.core.data.Vectors;
 
 /**
  * Unit coverage for the unified {@code Engine.authorityCovers} seam: the
- * {@code null}-caps fast path (own vs cross-user), config-grant coverage, and the
- * additive routing. Proof-backed cross-user access is exercised by
- * AccessControlTest / UCANTest.
+ * {@code null}-caps fast path (unrestricted ceiling), config-grant coverage, and
+ * the additive routing (a config-capped caller needs a proof for a resource its
+ * config does not grant). Proof-backed cross-user access is exercised end-to-end
+ * by AccessControlTest / CoviaAdapterTest / DLFSCrossUserTest.
  */
 public class AuthorityCoversTest {
 
@@ -26,22 +27,15 @@ public class AuthorityCoversTest {
 	}
 
 	@Test
-	public void testNullCapsOwnAllowed() {
+	public void testNullCapsUnrestricted() {
 		AString alice = TestEngine.uniqueDID("own-alice");
-		RequestContext ctx = RequestContext.of(alice);   // null caps → unrestricted own-authority
+		RequestContext ctx = RequestContext.of(alice);   // null caps → unrestricted ceiling
 		assertTrue(ENGINE.authorityCovers(ctx, Strings.create("w/x"), Capability.CRUD_WRITE));
 		assertTrue(ENGINE.authorityCovers(ctx, Strings.create("o/y"), Capability.CRUD_READ));
-	}
-
-	@Test
-	public void testNullCapsCrossUserDeniedWithoutProof() {
-		AString alice = TestEngine.uniqueDID("xu-alice");
-		AString bob = TestEngine.uniqueDID("xu-bob");
-		RequestContext ctx = RequestContext.of(alice);   // null caps, no proofs
-		AString bobResource = Strings.create(bob + "/w/x");
-		// the fast path must NOT reach another user's namespace
-		assertFalse(ENGINE.authorityCovers(ctx, bobResource, Capability.CRUD_WRITE));
-		assertFalse(ENGINE.authorityCovers(ctx, bobResource, Capability.CRUD_READ));
+		// content-addressed asset read — unrestricted at the ceiling (the adapter's
+		// resolver, not the ceiling, is the gate for any cross-user reach)
+		assertTrue(ENGINE.authorityCovers(ctx,
+			Strings.create(ENGINE.getDIDString() + "/a/00"), Capability.CRUD_READ));
 	}
 
 	@Test
@@ -57,9 +51,12 @@ public class AuthorityCoversTest {
 	}
 
 	@Test
-	public void testAnonymousCrossUserDenied() {
-		AString bob = TestEngine.uniqueDID("anon-bob");
-		assertFalse(ENGINE.authorityCovers(RequestContext.ANONYMOUS,
-			Strings.create(bob + "/w/x"), Capability.CRUD_READ));
+	public void testConfigCapsCrossUserNeedsProof() {
+		AString alice = TestEngine.uniqueDID("xu-alice");
+		AString bob = TestEngine.uniqueDID("xu-bob");
+		RequestContext ctx = withCaps(RequestContext.of(alice),
+			Capability.create(Strings.create("w/reports"), Capability.CRUD_READ));
+		// config-capped, cross-user resource, no proof → denied (ceiling denies, no proof)
+		assertFalse(ENGINE.authorityCovers(ctx, Strings.create(bob + "/w/x"), Capability.CRUD_READ));
 	}
 }

--- a/venue/src/test/java/covia/venue/AuthorityCoversTest.java
+++ b/venue/src/test/java/covia/venue/AuthorityCoversTest.java
@@ -13,7 +13,7 @@ import convex.core.data.Vectors;
 
 /**
  * Unit coverage for the unified {@code Engine.authorityCovers} seam: the
- * {@code null}-caps fast path (unrestricted ceiling), config-grant coverage, and
+ * {@code null}-caps fast path (unrestricted scope), config-grant coverage, and
  * the additive routing (a config-capped caller needs a proof for a resource its
  * config does not grant). Proof-backed cross-user access is exercised end-to-end
  * by AccessControlTest / CoviaAdapterTest / DLFSCrossUserTest.
@@ -29,11 +29,11 @@ public class AuthorityCoversTest {
 	@Test
 	public void testNullCapsUnrestricted() {
 		AString alice = TestEngine.uniqueDID("own-alice");
-		RequestContext ctx = RequestContext.of(alice);   // null caps → unrestricted ceiling
+		RequestContext ctx = RequestContext.of(alice);   // null caps → unrestricted scope
 		assertTrue(ENGINE.authorityCovers(ctx, Strings.create("w/x"), Capability.CRUD_WRITE));
 		assertTrue(ENGINE.authorityCovers(ctx, Strings.create("o/y"), Capability.CRUD_READ));
-		// content-addressed asset read — unrestricted at the ceiling (the adapter's
-		// resolver, not the ceiling, is the gate for any cross-user reach)
+		// content-addressed asset read — unrestricted at the scope (the adapter's
+		// resolver, not the scope, is the gate for any cross-user reach)
 		assertTrue(ENGINE.authorityCovers(ctx,
 			Strings.create(ENGINE.getDIDString() + "/a/00"), Capability.CRUD_READ));
 	}
@@ -56,7 +56,7 @@ public class AuthorityCoversTest {
 		AString bob = TestEngine.uniqueDID("xu-bob");
 		RequestContext ctx = withCaps(RequestContext.of(alice),
 			Capability.create(Strings.create("w/reports"), Capability.CRUD_READ));
-		// config-capped, cross-user resource, no proof → denied (ceiling denies, no proof)
+		// config-capped, cross-user resource, no proof → denied (scope denies, no proof)
 		assertFalse(ENGINE.authorityCovers(ctx, Strings.create(bob + "/w/x"), Capability.CRUD_READ));
 	}
 }

--- a/venue/src/test/java/covia/venue/JobManagerTest.java
+++ b/venue/src/test/java/covia/venue/JobManagerTest.java
@@ -123,20 +123,20 @@ public class JobManagerTest {
 	// ========== Capability enforcement ==========
 
 	/**
-	 * invokeInternal enforces the capability ceiling carried by the context —
+	 * invokeInternal enforces the capability scope carried by the context —
 	 * it differs from invokeOperation only in Job creation, never in trust.
-	 * A read outside the ceiling is denied; a read within it proceeds; the
-	 * ceiling is read, never stripped. "Framework-trusted" is expressed by an
+	 * A read outside the scope is denied; a read within it proceeds; the
+	 * scope is read, never stripped. "Framework-trusted" is expressed by an
 	 * unrestricted (null-caps) context, not by choosing this dispatch path.
 	 */
 	@Test
-	public void testInvokeInternalEnforcesContextCeiling() throws Exception {
+	public void testInvokeInternalEnforcesContextScope() throws Exception {
 		AVector<ACell> caps = Vectors.of(Maps.of(
 			Strings.create("with"), Strings.create("w/allowed"),
 			Strings.create("can"),  Strings.create("crud/read")));
 		RequestContext capCtx = ctx.withCaps(caps);
 
-		// Outside the ceiling — denied on the internal path too (no bypass).
+		// Outside the scope — denied on the internal path too (no bypass).
 		CompletableFuture<ACell> denied = engine.jobs().invokeInternal(
 			"v/ops/covia/read",
 			Maps.of(Strings.create("path"), Strings.create("w/forbidden/x")),
@@ -144,9 +144,9 @@ public class JobManagerTest {
 		ExecutionException ex = assertThrows(ExecutionException.class,
 			() -> denied.get(5, TimeUnit.SECONDS));
 		assertTrue(ex.getCause().getMessage().contains("Capability denied"),
-			"invokeInternal must enforce the context ceiling");
+			"invokeInternal must enforce the context scope");
 
-		// Within the ceiling — proceeds; absent path reads {exists: false}.
+		// Within the scope — proceeds; absent path reads {exists: false}.
 		ACell result = engine.jobs().invokeInternal(
 			"v/ops/covia/read",
 			Maps.of(Strings.create("path"), Strings.create("w/allowed")),

--- a/venue/src/test/java/covia/venue/PublicCeilingTest.java
+++ b/venue/src/test/java/covia/venue/PublicCeilingTest.java
@@ -79,17 +79,16 @@ public class PublicCeilingTest {
 	/**
 	 * An authenticated client whose caller carries no attenuation ceiling. The
 	 * UCAN is audienced to THIS venue (so it passes audience validation — a real
-	 * bearer must be intended for the venue it is presented to), but its audience
-	 * is not the issuer, so it is not a self-delegation: {@code selfCapabilities}
-	 * → null and the session runs unrestricted. Identity authenticates as the
-	 * issuer DID.
+	 * bearer must be intended for the venue it is presented to). Presented proofs
+	 * are additive grants, never a subtractive ceiling, so the session runs
+	 * unrestricted; identity authenticates as the issuer DID.
 	 */
 	private static VenueHTTP authed(VenueServer server) {
 		AKeyPair kp = AKeyPair.generate();
 		AString did = UCAN.toDIDKey(kp.getAccountKey());
 		long exp = (System.currentTimeMillis() / 1000) + 3600;
 		// Audience = THIS venue (its account key's DID), so the token passes
-		// audience validation; aud != iss, so it forms no self-attenuation.
+		// audience validation; the bearer authenticates identity, not a ceiling.
 		UCAN token = UCAN.create(kp, server.getEngine().getAccountKey(), exp,
 			Vectors.of(Capability.create(Strings.create(did + "/w/"), Capability.CRUD_READ)),
 			Vectors.empty());

--- a/venue/src/test/java/covia/venue/PublicScopeTest.java
+++ b/venue/src/test/java/covia/venue/PublicScopeTest.java
@@ -26,24 +26,24 @@ import covia.grid.client.VenueHTTP;
 import covia.venue.server.VenueServer;
 
 /**
- * #148 — the public read-only capability ceiling, end to end through the HTTP
+ * #148 — the public read-only capability scope, end to end through the HTTP
  * auth layer.
  *
  * <p>Verifies the three properties of the secure-by-default public profile:
  * <ol>
  *   <li>an unauthenticated (public) caller may <b>read</b> but may not
  *       <b>mutate</b> or <b>invoke</b> — invoking any operation creates a job
- *       and is therefore resource-consuming, so the read-only ceiling denies it;</li>
- *   <li>authenticating (with no token attenuation) lifts the ceiling;</li>
+ *       and is therefore resource-consuming, so the read-only scope denies it;</li>
+ *   <li>authenticating (with no token attenuation) lifts the scope;</li>
  *   <li>an operator can opt out via {@code auth.public.caps = "unrestricted"}.</li>
  * </ol>
  *
  * <p>The shared {@link TestServer} runs unrestricted (its functional tests
  * invoke as the public caller); this class launches its own venues to exercise
- * the ceiling itself.</p>
+ * the scope itself.</p>
  */
 @TestInstance(Lifecycle.PER_CLASS)
-public class PublicCeilingTest {
+public class PublicScopeTest {
 
 	private static final AString OP_WRITE = Strings.create("v/ops/covia/write");
 	private static final AString OP_READ  = Strings.create("v/ops/covia/read");
@@ -77,10 +77,10 @@ public class PublicCeilingTest {
 	}
 
 	/**
-	 * An authenticated client whose caller carries no attenuation ceiling. The
+	 * An authenticated client whose caller carries no attenuation scope. The
 	 * UCAN is audienced to THIS venue (so it passes audience validation — a real
 	 * bearer must be intended for the venue it is presented to). Presented proofs
-	 * are additive grants, never a subtractive ceiling, so the session runs
+	 * are additive grants, never a subtractive scope, so the session runs
 	 * unrestricted; identity authenticates as the issuer DID.
 	 */
 	private static VenueHTTP authed(VenueServer server) {
@@ -88,7 +88,7 @@ public class PublicCeilingTest {
 		AString did = UCAN.toDIDKey(kp.getAccountKey());
 		long exp = (System.currentTimeMillis() / 1000) + 3600;
 		// Audience = THIS venue (its account key's DID), so the token passes
-		// audience validation; the bearer authenticates identity, not a ceiling.
+		// audience validation; the bearer authenticates identity, not a scope.
 		UCAN token = UCAN.create(kp, server.getEngine().getAccountKey(), exp,
 			Vectors.of(Capability.create(Strings.create(did + "/w/"), Capability.CRUD_READ)),
 			Vectors.empty());
@@ -123,7 +123,7 @@ public class PublicCeilingTest {
 	@Test
 	public void anonymousInvokeDeniedByDefault() throws Exception {
 		// Invoking any op creates a job (resource-consuming), so the read-only
-		// ceiling denies it — even an otherwise-harmless echo.
+		// scope denies it — even an otherwise-harmless echo.
 		VenueHTTP pub = anon(secureBase);
 		Job job = pub.invokeAndWait(OP_ECHO, Maps.of(Strings.create("hi"), Strings.create("there")));
 		assertEquals(Status.FAILED, job.getStatus(), "public invoke must be denied");

--- a/venue/src/test/java/covia/venue/RequestContextAuthorityTest.java
+++ b/venue/src/test/java/covia/venue/RequestContextAuthorityTest.java
@@ -13,39 +13,56 @@ import convex.core.data.Strings;
 import convex.core.data.Vectors;
 import covia.grid.Authority;
 
-/** Covers the Authority view added to RequestContext (getAuthority / of(Authority)). */
+/** Covers RequestContext wrapping an Authority (getAuthority / ofAuthority) and
+ *  the credential getters reading through to it. */
 public class RequestContextAuthorityTest {
 
 	private static final AString ALICE = Strings.create("did:key:zAlice");
-	private static final ACell GRANT = Strings.create("grant");
+	private static final ACell PROOF = Strings.create("proof");
+	private static final ACell CAP = Strings.create("cap");
 
 	@Test
-	public void testGetAuthorityView() {
-		RequestContext ctx = RequestContext.of(ALICE, Vectors.of(GRANT));
+	public void testWrapsPresentedProofs() {
+		// of(did, proofs) attaches PRESENTED proofs; the caller stays unrestricted.
+		RequestContext ctx = RequestContext.of(ALICE, Vectors.of(PROOF));
 		Authority a = ctx.getAuthority();
 		assertEquals(ALICE, a.getDID());
-		assertEquals(1, a.getGrants().count());
-		// the derived view does not disturb the existing getters
+		assertEquals(1, a.getProofs().count());
+		assertNull(a.getGrants());   // no explicit scope = unrestricted
+		// the credential getters read through to the wrapped Authority
 		assertEquals(ALICE, ctx.getCallerDID());
 		assertEquals(1, ctx.getProofs().count());
+		assertNull(ctx.getCaps());
 	}
 
 	@Test
 	public void testOfAuthorityRoundtrip() {
-		Authority a = Authority.of(ALICE, Vectors.of(GRANT));
+		// A scoped Authority (CAP in its grant scope) survives the wrap intact.
+		Authority a = Authority.of(ALICE, Vectors.of(CAP));
 		RequestContext ctx = RequestContext.ofAuthority(a);
 		assertEquals(ALICE, ctx.getCallerDID());
-		assertEquals(a, ctx.getAuthority());
+		assertSame(a, ctx.getAuthority());
+		assertEquals(1, ctx.getCaps().count());   // getCaps reads the scope
+	}
+
+	@Test
+	public void testWithCapsSetsScopeOnAuthority() {
+		// withCaps replaces the wrapped Authority's grant scope.
+		RequestContext ctx = RequestContext.of(ALICE).withCaps(Vectors.of(CAP));
+		assertEquals(1, ctx.getCaps().count());
+		assertEquals(1, ctx.getAuthority().getGrants().count());
+		// null restores unrestricted
+		assertNull(ctx.withCaps(null).getCaps());
 	}
 
 	@Test
 	public void testGetProofsNullContractPreserved() {
 		// of(callerDID) carries no proofs — getProofs() must STILL return null
-		// (the contract the 847 call sites depend on)
+		// (the contract the call sites depend on), and the scope is unrestricted.
 		RequestContext ctx = RequestContext.of(ALICE);
 		assertNull(ctx.getProofs());
-		// while the Authority view normalises to an empty, never-null grant set
-		assertTrue(ctx.getAuthority().getGrants().isEmpty());
+		assertNull(ctx.getCaps());
+		assertNull(ctx.getAuthority().getGrants());
 	}
 
 	@Test

--- a/venue/src/test/java/covia/venue/RequestContextAuthorityTest.java
+++ b/venue/src/test/java/covia/venue/RequestContextAuthorityTest.java
@@ -24,7 +24,7 @@ public class RequestContextAuthorityTest {
 		RequestContext ctx = RequestContext.of(ALICE, Vectors.of(GRANT));
 		Authority a = ctx.getAuthority();
 		assertEquals(ALICE, a.getDID());
-		assertEquals(1, a.getProofs().count());
+		assertEquals(1, a.getGrants().count());
 		// the derived view does not disturb the existing getters
 		assertEquals(ALICE, ctx.getCallerDID());
 		assertEquals(1, ctx.getProofs().count());
@@ -45,7 +45,7 @@ public class RequestContextAuthorityTest {
 		RequestContext ctx = RequestContext.of(ALICE);
 		assertNull(ctx.getProofs());
 		// while the Authority view normalises to an empty, never-null grant set
-		assertTrue(ctx.getAuthority().getProofs().isEmpty());
+		assertTrue(ctx.getAuthority().getGrants().isEmpty());
 	}
 
 	@Test

--- a/venue/src/test/java/covia/venue/RequestContextAuthorityTest.java
+++ b/venue/src/test/java/covia/venue/RequestContextAuthorityTest.java
@@ -1,0 +1,57 @@
+package covia.venue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import convex.core.data.ACell;
+import convex.core.data.AString;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+import covia.grid.Authority;
+
+/** Covers the Authority view added to RequestContext (getAuthority / of(Authority)). */
+public class RequestContextAuthorityTest {
+
+	private static final AString ALICE = Strings.create("did:key:zAlice");
+	private static final ACell GRANT = Strings.create("grant");
+
+	@Test
+	public void testGetAuthorityView() {
+		RequestContext ctx = RequestContext.of(ALICE, Vectors.of(GRANT));
+		Authority a = ctx.getAuthority();
+		assertEquals(ALICE, a.getDID());
+		assertEquals(1, a.getProofs().count());
+		// the derived view does not disturb the existing getters
+		assertEquals(ALICE, ctx.getCallerDID());
+		assertEquals(1, ctx.getProofs().count());
+	}
+
+	@Test
+	public void testOfAuthorityRoundtrip() {
+		Authority a = Authority.of(ALICE, Vectors.of(GRANT));
+		RequestContext ctx = RequestContext.ofAuthority(a);
+		assertEquals(ALICE, ctx.getCallerDID());
+		assertEquals(a, ctx.getAuthority());
+	}
+
+	@Test
+	public void testGetProofsNullContractPreserved() {
+		// of(callerDID) carries no proofs — getProofs() must STILL return null
+		// (the contract the 847 call sites depend on)
+		RequestContext ctx = RequestContext.of(ALICE);
+		assertNull(ctx.getProofs());
+		// while the Authority view normalises to an empty, never-null grant set
+		assertTrue(ctx.getAuthority().getProofs().isEmpty());
+	}
+
+	@Test
+	public void testAnonymousAuthority() {
+		assertTrue(RequestContext.ANONYMOUS.getAuthority().isAnonymous());
+		assertSame(RequestContext.ANONYMOUS, RequestContext.ofAuthority(null));
+		assertSame(RequestContext.ANONYMOUS, RequestContext.ofAuthority(Authority.ANONYMOUS));
+	}
+}

--- a/venue/src/test/java/covia/venue/TestServer.java
+++ b/venue/src/test/java/covia/venue/TestServer.java
@@ -42,7 +42,7 @@ public class TestServer {
 						// Functional tests exercise operations as the public caller,
 						// so run public access unrestricted here. The secure read-only
 						// default and authenticated access are covered explicitly by
-						// PublicCeilingTest.
+						// PublicScopeTest.
 						Config.CAPS,Strings.create("unrestricted"))
 				)));
 		PORT=SERVER.port();

--- a/venue/src/test/java/covia/venue/TwoVenueTestServer.java
+++ b/venue/src/test/java/covia/venue/TwoVenueTestServer.java
@@ -93,7 +93,7 @@ public class TwoVenueTestServer {
 				Config.PUBLIC, Maps.of(
 					Config.ENABLED, true,
 					// Federation tests invoke ops cross-venue as the public caller,
-					// so run public access unrestricted. PublicCeilingTest covers the
+					// so run public access unrestricted. PublicScopeTest covers the
 					// secure read-only default and authenticated access.
 					Config.CAPS, Strings.create("unrestricted"))
 			)

--- a/venue/src/test/java/covia/venue/UCANTest.java
+++ b/venue/src/test/java/covia/venue/UCANTest.java
@@ -72,111 +72,20 @@ public class UCANTest {
 			ALICE).awaitResult(5000);
 	}
 
-	// ========== #131 — self-attenuation ceiling on the direct invoke path ==========
-	//
-	// The owner is the authority over its own namespace; the venue enforces. A
-	// self-ceiling is an owner-authored attenuation over the owner's own
-	// resources (iss == aud == caller). withTransportAuth derives it (via
-	// CapabilityChecker.selfCapabilities) and sets it as caps; enforceCaps applies
-	// it against owner-scoped (canonical) resources. A token NOT authored by the
-	// owner (e.g. venue-signed) forms no self-ceiling.
-
 	private static final long HOUR = 3600;
-
-	/** A token the owner signs for itself (iss == aud == owner) — the authority
-	 *  over its own namespace attenuating its own session. */
-	private AString ownerToken(AKeyPair ownerKP, AVector<ACell> caps) {
-		return UCAN.createJWT(ownerKP, ownerKP.getAccountKey(),
-			(System.currentTimeMillis() / 1000) + HOUR, caps, null);
-	}
-
-	/** A venue-signed token (iss == venue) audienced to the owner — not the
-	 *  owner's own authority, so it forms no self-ceiling. */
-	private AString venueToken(AString audienceDID, AVector<ACell> caps) {
-		Job job = engine.jobs().invokeOperation("v/ops/ucan/issue",
-			Maps.of(UCAN.AUD, audienceDID, UCAN.ATT, caps,
-				UCAN.EXP, CVMLong.create((System.currentTimeMillis() / 1000) + HOUR)), ALICE);
-		return RT.ensureString(RT.getIn(job.awaitResult(5000), "token"));
-	}
-
-	/** One capability over an absolute (owner-scoped) resource. */
-	private static AVector<ACell> caps(String withResource, AString can) {
-		return Vectors.of((ACell) Capability.create(Strings.create(withResource), can));
-	}
-
-	@Test
-	public void testSelfCapabilitiesNullArgsFailClosed() {
-		long now = System.currentTimeMillis() / 1000;
-		AVector<ACell> proofs = UCANValidator.parseTransportUCANs(
-			Vectors.of(ownerToken(ALICE_KP, caps(ALICE_DID + "/w/health", Capability.CRUD))));
-		assertNull(CapabilityChecker.selfCapabilities(null, ALICE_DID, ALICE_DID, now));
-		assertNull(CapabilityChecker.selfCapabilities(proofs, null, ALICE_DID, now));
-		assertNull(CapabilityChecker.selfCapabilities(proofs, ALICE_DID, null, now));
-	}
-
-	@Test
-	public void testSelfCapabilitiesOwnerAuthoredIncluded() {
-		// Owner signs an attenuation for itself → forms the ceiling.
-		AVector<ACell> proofs = UCANValidator.parseTransportUCANs(
-			Vectors.of(ownerToken(ALICE_KP, caps(ALICE_DID + "/w/health", Capability.CRUD))));
-		AVector<ACell> derived = CapabilityChecker.selfCapabilities(
-			proofs, ALICE_DID, ALICE_DID, System.currentTimeMillis() / 1000);
-		assertNotNull(derived);
-		assertEquals(1L, derived.count());
-	}
-
-	@Test
-	public void testSelfCapabilitiesNonOwnerIssuerExcluded() {
-		// Venue-signed (iss == venue, not the owner) is not the owner's own
-		// authority → no self-ceiling. The owner is the authority over its namespace.
-		AVector<ACell> proofs = UCANValidator.parseTransportUCANs(
-			Vectors.of(venueToken(ALICE_DID, caps(ALICE_DID + "/w/health", Capability.CRUD))));
-		assertNull(CapabilityChecker.selfCapabilities(
-			proofs, ALICE_DID, ALICE_DID, System.currentTimeMillis() / 1000));
-	}
-
-	@Test
-	public void testAttenuatedTokenRestrictsInvoke() {
-		// Owner-authored, scoped to its own w/health only.
-		AString jwt = ownerToken(ALICE_KP, caps(ALICE_DID + "/w/health", Capability.CRUD));
-		RequestContext rctx = AuthMiddleware.withTransportAuth(
-			RequestContext.of(ALICE_DID), jwt, null);
-		assertNotNull(rctx.getCaps(), "an owner-authored attenuation must set a ceiling");
-
-		// In scope: own w/health write allowed (resource canonicalises to
-		// <ALICE_DID>/w/health/bp, covered by the <ALICE_DID>/w/health grant).
-		engine.jobs().invokeOperation("v/ops/covia/write",
-			Maps.of(Fields.PATH, "w/health/bp", Fields.VALUE, Strings.create("120/80")),
-			rctx).awaitResult(5000);
-
-		// Out of scope: own w/other write denied — the ceiling, deterministically.
-		// enforceCaps throws synchronously from invokeOperation, so wrap that call.
-		Throwable ex = assertThrows(Exception.class, () ->
-			engine.jobs().invokeOperation("v/ops/covia/write",
-				Maps.of(Fields.PATH, "w/other/x", Fields.VALUE, Strings.create("nope")), rctx)
-				.awaitResult(5000));
-		assertTrue(messageChain(ex).contains("Capability denied"),
-			"out-of-scope op must be denied: " + messageChain(ex));
-	}
 
 	@Test
 	public void testNoTokenIsUnrestricted() {
-		// No bearer/ucans → no ceiling → full authority over own namespace
-		// (regression guard: existing token-less callers are unaffected).
+		// No bearer/ucans → no ceiling → full authority over own namespace.
+		// Presented proofs are additive grants, never a subtractive self-ceiling:
+		// to act with reduced authority, use a narrower Authority (Authority.of(
+		// did, grants)) or present only the UCANs the request needs.
 		RequestContext rctx = AuthMiddleware.withTransportAuth(
 			RequestContext.of(ALICE_DID), null, null);
 		assertNull(rctx.getCaps());
 		engine.jobs().invokeOperation("v/ops/covia/write",
 			Maps.of(Fields.PATH, "w/other/free", Fields.VALUE, Strings.create("ok")),
 			rctx).awaitResult(5000);  // no throw
-	}
-
-	private static String messageChain(Throwable t) {
-		StringBuilder sb = new StringBuilder();
-		for (Throwable c = t; c != null; c = c.getCause()) {
-			if (c.getMessage() != null) sb.append(c.getMessage()).append('\n');
-		}
-		return sb.toString();
 	}
 
 	// ========== ucan:issue ==========

--- a/venue/src/test/java/covia/venue/UCANTest.java
+++ b/venue/src/test/java/covia/venue/UCANTest.java
@@ -76,10 +76,10 @@ public class UCANTest {
 
 	@Test
 	public void testNoTokenIsUnrestricted() {
-		// No bearer/ucans → no ceiling → full authority over own namespace.
-		// Presented proofs are additive grants, never a subtractive self-ceiling:
-		// to act with reduced authority, use a narrower Authority (Authority.of(
-		// did, grants)) or present only the UCANs the request needs.
+		// No bearer/ucans → no scope → full authority over own namespace.
+		// Presented proofs are additive grants, never subtractive: to act with
+		// reduced authority, use a narrower Authority (Authority.of(did, grants))
+		// or present only the UCANs the request needs.
 		RequestContext rctx = AuthMiddleware.withTransportAuth(
 			RequestContext.of(ALICE_DID), null, null);
 		assertNull(rctx.getCaps());

--- a/venue/src/test/java/covia/venue/api/A2AAgentCardTest.java
+++ b/venue/src/test/java/covia/venue/api/A2AAgentCardTest.java
@@ -264,8 +264,8 @@ public class A2AAgentCardTest {
 		return UCAN.toDIDKey(kp.getAccountKey());
 	}
 
-	/** A bearer token audienced to this venue — authenticates as the key's DID
-	 *  with no self-attenuation (aud != iss). */
+	/** A bearer token audienced to this venue — authenticates as the key's DID;
+	 *  a bearer carries identity, never a ceiling. */
 	private static String bearerFor(AKeyPair kp) {
 		long exp = (System.currentTimeMillis() / 1000) + 3600;
 		return UCAN.create(kp, TestServer.ENGINE.getAccountKey(), exp, Vectors.empty(), Vectors.empty())

--- a/venue/src/test/java/covia/venue/api/A2AAgentCardTest.java
+++ b/venue/src/test/java/covia/venue/api/A2AAgentCardTest.java
@@ -215,7 +215,7 @@ public class A2AAgentCardTest {
 		VenueHTTP client = VenueHTTP.create(URI.create(BASE_URL), VenueAuth.bearer(bearerFor(kp)));
 		client.setTimeout(5000);
 
-		// Public agent WITH an explicit a2a.caps ceiling ("unrestricted" for the
+		// Public agent WITH an explicit a2a.caps scope ("unrestricted" for the
 		// test) → an anonymous message/send runs under the owner, bounded by caps.
 		Job withCaps = client.invokeAndWait(Strings.create("v/ops/agent/create"), Maps.of(
 				Strings.create("agentId"), Strings.create("PubChat"),
@@ -265,7 +265,7 @@ public class A2AAgentCardTest {
 	}
 
 	/** A bearer token audienced to this venue — authenticates as the key's DID;
-	 *  a bearer carries identity, never a ceiling. */
+	 *  a bearer carries identity, never a grant scope. */
 	private static String bearerFor(AKeyPair kp) {
 		long exp = (System.currentTimeMillis() / 1000) + 3600;
 		return UCAN.create(kp, TestServer.ENGINE.getAccountKey(), exp, Vectors.empty(), Vectors.empty())

--- a/venue/src/test/java/covia/venue/api/AgentApiTest.java
+++ b/venue/src/test/java/covia/venue/api/AgentApiTest.java
@@ -64,7 +64,7 @@ public class AgentApiTest {
 	@BeforeAll
 	public void setup() throws Exception {
 		// A fresh authenticated caller. Audience = the venue (passes validation);
-		// aud != iss, so no self-attenuation → an unrestricted authenticated
+		// a bearer carries identity, never a ceiling → an unrestricted authenticated
 		// session that may create/list its own agents. The DID is unique to this
 		// class, isolating its job count from every other test.
 		AKeyPair kp = AKeyPair.generate();

--- a/venue/src/test/java/covia/venue/api/AgentApiTest.java
+++ b/venue/src/test/java/covia/venue/api/AgentApiTest.java
@@ -64,7 +64,7 @@ public class AgentApiTest {
 	@BeforeAll
 	public void setup() throws Exception {
 		// A fresh authenticated caller. Audience = the venue (passes validation);
-		// a bearer carries identity, never a ceiling → an unrestricted authenticated
+		// a bearer carries identity, never a grant scope → an unrestricted authenticated
 		// session that may create/list its own agents. The DID is unique to this
 		// class, isolating its job count from every other test.
 		AKeyPair kp = AKeyPair.generate();

--- a/venue/src/test/java/covia/venue/api/ValuesApiTest.java
+++ b/venue/src/test/java/covia/venue/api/ValuesApiTest.java
@@ -65,7 +65,7 @@ public class ValuesApiTest {
 	@BeforeAll
 	public void setup() throws Exception {
 		// A fresh authenticated caller. Audience = the venue (passes validation);
-		// a bearer carries identity, never a ceiling → an unrestricted authenticated
+		// a bearer carries identity, never a grant scope → an unrestricted authenticated
 		// session that reads/writes its own workspace. The DID is unique to this
 		// class, isolating its job count from every other test.
 		AKeyPair kp = AKeyPair.generate();

--- a/venue/src/test/java/covia/venue/api/ValuesApiTest.java
+++ b/venue/src/test/java/covia/venue/api/ValuesApiTest.java
@@ -65,7 +65,7 @@ public class ValuesApiTest {
 	@BeforeAll
 	public void setup() throws Exception {
 		// A fresh authenticated caller. Audience = the venue (passes validation);
-		// aud != iss, so no self-attenuation → an unrestricted authenticated
+		// a bearer carries identity, never a ceiling → an unrestricted authenticated
 		// session that reads/writes its own workspace. The DID is unique to this
 		// class, isolating its job count from every other test.
 		AKeyPair kp = AKeyPair.generate();


### PR DESCRIPTION
## Summary

Centralises Covia's authorization into a single seam and makes the immutable `Authority` value load-bearing, reframing the whole model as **additive grants** — *either you have the right or you don't*. There is no ceiling.

## What changed

- **Single seam** — `Engine.authorityCovers` / `requireAuthority(ctx, resource, ability)` replaces ~847 scattered check sites. The rule: a cross-user proof covers it, OR the grant scope is `null` (unrestricted fast path), OR a grant in scope covers it.
- **`RequestContext` wraps an `Authority`** — identity + held grant scope (`null` = unrestricted, an agent's `config.caps`) + presented UCAN proofs (additive). `getCallerDID`/`getCaps`/`getProofs` read through to it.
- **Shared `covia.api.Abilities`** constants — no inline interns for fixed ability strings.
- **Wire self-attenuation removed (#131)** — presented proofs are additive-only; to act with reduced authority, hand the callee a narrower `Authority` or present only the UCANs needed. `CapabilityChecker.selfCapabilities` deleted.
- **"Ceiling" purged** — comments, identifiers (`readOnlyCeiling → readOnlyScope`, `getPublicCeiling → getPublicScope`, `PublicCeilingTest → PublicScopeTest`), and test prose now speak grants. The only remaining "ceiling" strings document its *absence* or are unrelated timing values.

## Not in scope (deliberately deferred)

- **Model B (independent agent identity)** — agents still run as the owner (#91) with `config.caps` as their grant scope, which is why a non-null scope stays load-bearing. Retiring the scope entirely is a separate, larger piece.

## Testing

Full reactor green — covia-core, venue (1815 tests), workbench, covia-sql (10 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
