### PR TITLE
ArchiveAdapter (zip/jar) + FileAdapter archive read-through

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Engine (core state, adapters, assets, content, identity)
     └── JobManager        (job lifecycle, per-user persistence, recovery)
     |
 Adapter Layer (~25 pluggable adapters — canonical table in venue/CLAUDE.md)
-    ├── Data & state:  covia (lattice CRUD), asset, dlfs, vault, memory, secret, file
+    ├── Data & state:  covia (lattice CRUD), asset, dlfs, vault, memory, secret, file, archive
     ├── Execution:     langchain (LLMs), mcp, http, convex, jvm, schema, orchestrator, scheduler
     ├── Agents:        agent, llmagent, goaltree, skills, hitl (COG-16 h/ inbox)
     ├── Federation:    grid (run/invoke/jobStatus), ucan (granting surface, COG-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - Federated job observation carries caller proofs — `X-Covia-Ucans` header on body-less job reads; cross-venue HITL verified end-to-end
 - Authenticated callers get public-user access per the public ceiling (#254) — reads, public jobs, DLFS, and secret resolution fallback (use-only, never extraction)
 - `ucan:issue` is a granting surface — mints over another principal's resource under a presented `grant/<ability>` right, expiry-capped by the right's validity
+- Archive adapter (zip/jar) — `archive:list`/`extract`/`zip` over file roots, from/to a root file, CAS asset, or inline bytes; zip-slip + zip-bomb guarded. `file:read`/`list`/`stat`/`tree` see into archives via `x.zip!/entry` (jdk.zipfs, read-only, never fabricates an archive). `archive` skill
 
 ### Changed
 - Job lifecycle hardening — atomic updates, post-commit persistence, shutdown admission gate

--- a/skills/archive/SKILL.md
+++ b/skills/archive/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: archive
+description: Work with zip and jar archive files on a Covia venue — list, extract, and create archives, and read files inside archives without unpacking. Use when an agent needs to inspect, unpack, or bundle archive files.
+argument-hint: [list|extract|zip|peek] [args]
+---
+
+# Archive Files (zip / jar)
+
+**Prerequisite:** The venue must be running and connected as an MCP server (`http://localhost:8080/mcp`). If MCP tools are not available, run `/venue-setup local` first. Archive operations act on the **file adapter's configured roots** — if none are set, the venue provides a single ephemeral `tmp` root (see `/venue-setup`). Check with `file_roots`.
+
+Everything stays inside a configured root: an archive is a jailed `root`+`path` file (or a content-addressed asset / inline bytes), extraction is zip-slip protected, and reads never create an archive.
+
+## Choosing an operation
+
+| Goal | Use |
+|------|-----|
+| See what's in an archive | `archive_list` |
+| Unpack an archive to files | `archive_extract` |
+| Bundle files into a zip | `archive_zip` |
+| Read one file inside an archive, no unpacking | `file_read` with a `!/` path (peek) |
+
+## `list` — inspect entries
+
+```
+archive_list  root=work  path=releases/app.zip
+```
+
+Source is exactly one of `root`+`path` (a file), `asset` (a CAS reference), or `bytes` (base64). Returns each entry's `name`, `size`, `compressedSize`, `directory`, and `modified`; `count` is the true total (the entry list is capped, `truncated` flags when more exist).
+
+## `extract` — unpack into a directory
+
+```
+archive_extract  root=work  path=releases/app.zip  destRoot=work  destPath=unpacked
+```
+
+Writes under `destRoot` (must be a **writable** root) at optional `destPath` (created if needed). Source may instead be `asset=<ref>` or `bytes=<base64>`. Extraction is jailed to the destination — entries that escape via `..` are rejected — and capped against zip bombs. Returns `extracted` (count), `bytes` (total written), and a capped `files` list.
+
+## `zip` — bundle files
+
+To a file:
+```
+archive_zip  root=work  path=reports  destRoot=work  destPath=reports.zip
+```
+
+To a content-addressed **asset** (omit `destRoot`/`destPath`) — the archive becomes a grid artifact you can hand to other operations:
+```
+archive_zip  root=work  paths=["a.txt","logs/"]  name=bundle.zip
+→ { entries, bytes, asset: "did:key:z…/a/<hash>" }
+```
+
+`path` (single) or `paths` (array) name files/directories relative to `root`. Entry names preserve the given relative paths (zip -r style); directories are added recursively.
+
+## `peek` — read a file inside an archive without unpacking
+
+`file_read` / `file_list` / `file_stat` / `file_tree` descend into an archive when the path carries a `!/` entry separator (the standard jar-URL form). The archive must already exist; nothing is unpacked or created.
+
+```
+file_read  root=work  path=releases/app.zip!/META-INF/MANIFEST.MF
+file_list  root=work  path=releases/app.zip!/            → entries at the archive root
+file_stat  root=work  path=releases/app.zip!/config.json
+```
+
+File access into archives is **read-only** — `file_write`/`delete`/`mkdir` on a `!/` path are rejected. Create or modify archives with `archive_zip` / `archive_extract`.
+
+## Notes
+
+- **Formats:** zip and jar (a jar is a zip).
+- **Sources:** `root`+`path` file · `asset` (CAS reference) · `bytes` (base64) — pick one.
+- **Destinations (zip):** a root file, or a CAS asset (default when no `destRoot`).
+- **Safety:** paths are jailed to their root; extraction is zip-slip protected and size/entry capped; read paths open existing-only and never fabricate an archive.

--- a/venue/CLAUDE.md
+++ b/venue/CLAUDE.md
@@ -74,7 +74,8 @@ AUTH_REQUIRED).
 | `langchain` | AI/LLM models | `openai`, `ollama`, `anthropic`, `gemini`, `deepseek`, `models` |
 | `http` | HTTP requests (SSRF-protected) | `get`, `post` |
 | `jvm` | JVM utilities | `stringConcat`, `urlEncode`, `urlDecode` |
-| `file` | Filesystem (root-jailed) | `roots`, `list`, `tree`, `read`, `write`, `append`, `delete`, `mkdir`, `stat` |
+| `file` | Filesystem (root-jailed); reads see into archives via `x.zip!/entry` | `roots`, `list`, `tree`, `read`, `write`, `append`, `delete`, `mkdir`, `stat` |
+| `archive` | Zip/jar archives over file roots (zip-slip + zip-bomb guarded) | `list`, `extract`, `zip` |
 | `schema` | JSON Schema | `validate`, `validateAll`, `infer`, `coerce`, `check` |
 | `orchestrator` | Multi-step workflows | Custom orchestration |
 | `covia` | Lattice CRUD | `read`, `write`, `delete`, `append`, `slice`, `list`, `inspect`, `aggregate`, `functions`, `describe`, `adapters` |

--- a/venue/src/main/java/covia/adapter/ArchiveAdapter.java
+++ b/venue/src/main/java/covia/adapter/ArchiveAdapter.java
@@ -1,0 +1,438 @@
+package covia.adapter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Base64;
+import java.util.Enumeration;
+import java.util.concurrent.CompletableFuture;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import convex.core.data.ABlob;
+import convex.core.data.ACell;
+import convex.core.data.AMap;
+import convex.core.data.AString;
+import convex.core.data.AVector;
+import convex.core.data.Blob;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+import convex.core.data.prim.CVMBool;
+import convex.core.data.prim.CVMLong;
+import convex.core.crypto.Hashing;
+import convex.core.lang.RT;
+import convex.core.util.JSON;
+import convex.auth.ucan.Capability;
+import covia.api.Abilities;
+import covia.api.Fields;
+import covia.venue.RequestContext;
+
+/**
+ * Archive adapter — lets agents work with common archive files (zip and jar).
+ *
+ * <p>Operations run over the {@link FileAdapter}'s configured roots (one source
+ * of truth for the file jail) and, where useful, content-addressed assets.
+ * Nothing here escapes a root: an archive source is a jailed root+path file (or
+ * a CAS asset / inline bytes), and extraction targets a jailed directory with
+ * per-entry zip-slip checks.</p>
+ *
+ * <h3>Operations</h3>
+ * <ul>
+ *   <li>{@code archive:list}    — list entries + metadata without extracting</li>
+ *   <li>{@code archive:extract} — extract a zip/jar into a destination directory</li>
+ *   <li>{@code archive:zip}     — build a zip from root+path files/dirs → a file or an asset</li>
+ * </ul>
+ */
+public class ArchiveAdapter extends AAdapter {
+
+	private static final Logger log = LoggerFactory.getLogger(ArchiveAdapter.class);
+
+	private static final String ASSETS_PATH = "/adapters/archive/";
+	private static final String ZIP_MEDIA_TYPE = "application/zip";
+
+	private static final AString FIELD_ROOT = Strings.intern("root");
+	private static final AString FIELD_PATH = Strings.intern("path");
+	private static final AString FIELD_PATHS = Strings.intern("paths");
+	private static final AString FIELD_ASSET = Strings.intern("asset");
+	private static final AString FIELD_BYTES = Strings.intern("bytes");
+	private static final AString FIELD_DEST_ROOT = Strings.intern("destRoot");
+	private static final AString FIELD_DEST_PATH = Strings.intern("destPath");
+	private static final AString FIELD_NAME = Strings.intern("name");
+
+	/** Guards against runaway/zip-bomb extraction: caps on entry count and total
+	 *  uncompressed bytes written. Generous for legitimate archives. */
+	private static final int MAX_ENTRIES = 100_000;
+	private static final long MAX_TOTAL_BYTES = 2L * 1024 * 1024 * 1024; // 2 GiB
+	/** Cap on the entry list returned by extract/list, so a huge archive does not
+	 *  produce an unbounded result (the operation still processes every entry). */
+	private static final int MAX_LISTED = 5000;
+
+	@Override
+	public String getName() {
+		return "archive";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Work with archive files (zip and jar). List entries, extract archives into a "
+			+ "filesystem root, or build a zip from files/directories — output to a root path or a "
+			+ "content-addressed asset. Sources may be a root+path file, a CAS asset, or inline base64 "
+			+ "bytes. All paths stay inside the FileAdapter's configured roots; extraction is zip-slip "
+			+ "protected and capped against zip bombs.";
+	}
+
+	@Override
+	protected void installAssets() {
+		installAsset("archive/list",    ASSETS_PATH + "list.json");
+		installAsset("archive/extract", ASSETS_PATH + "extract.json");
+		installAsset("archive/zip",     ASSETS_PATH + "zip.json");
+	}
+
+	// ==================== Invocation ====================
+
+	@Override
+	public CompletableFuture<ACell> invokeFuture(RequestContext ctx, AMap<AString, ACell> meta, ACell input) {
+		String subOp = getSubOperation(meta);
+		if (subOp == null) {
+			return CompletableFuture.failedFuture(
+				new IllegalArgumentException("No archive sub-operation specified"));
+		}
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				AMap<AString, ACell> in = RT.castMap(input);
+				if (in == null) in = Maps.empty();
+				return switch (subOp) {
+					case "list"    -> handleList(ctx, in);
+					case "extract" -> handleExtract(ctx, in);
+					case "zip"     -> handleZip(ctx, in);
+					default -> throw new IllegalArgumentException("Unknown archive operation: " + subOp);
+				};
+			} catch (RuntimeException e) {
+				throw e;
+			} catch (Exception e) {
+				throw new RuntimeException(e.getMessage(), e);
+			}
+		}, VIRTUAL_EXECUTOR);
+	}
+
+	/** The FileAdapter that owns the roots, or a clear error if unavailable. */
+	private FileAdapter files() {
+		AAdapter raw = engine.getAdapter("file");
+		if (!(raw instanceof FileAdapter fa)) {
+			throw new IllegalStateException("Archive operations require the file adapter to be registered");
+		}
+		return fa;
+	}
+
+	// ==================== Source resolution ====================
+
+	/** A readable archive source resolved to a local file; {@link #temp} ones are
+	 *  deleted on {@link #close}. */
+	private record Source(Path path, boolean temp) implements AutoCloseable {
+		@Override public void close() {
+			if (temp) {
+				try { Files.deleteIfExists(path); } catch (IOException ignored) { }
+			}
+		}
+	}
+
+	/**
+	 * Resolves the archive source — exactly one of {@code root}+{@code path} (a
+	 * jailed file, read-checked), {@code asset} (a CAS reference), or {@code bytes}
+	 * (inline base64). Asset/bytes sources are spooled to a temp file so every op
+	 * reads via {@link ZipFile} (existing-only — a source is never created here).
+	 */
+	private Source resolveSource(RequestContext ctx, AMap<AString, ACell> input) throws IOException {
+		AString root = RT.ensureString(input.get(FIELD_ROOT));
+		AString path = RT.ensureString(input.get(FIELD_PATH));
+		AString assetRef = RT.ensureString(input.get(FIELD_ASSET));
+		AString bytesB64 = RT.ensureString(input.get(FIELD_BYTES));
+
+		int provided = ((root != null && path != null) ? 1 : 0)
+			+ (assetRef != null ? 1 : 0) + (bytesB64 != null ? 1 : 0);
+		if (provided == 0) {
+			throw new IllegalArgumentException(
+				"Provide an archive source: 'root'+'path', 'asset', or 'bytes'");
+		}
+		if (provided > 1) {
+			throw new IllegalArgumentException(
+				"Provide only one archive source: 'root'+'path', 'asset', or 'bytes'");
+		}
+
+		if (root != null && path != null) {
+			engine.requireAuthority(ctx, Strings.create(schemeResource("file", root, path)), Capability.CRUD_READ);
+			Path file = files().resolve(ctx, root.toString(), path.toString(), true);
+			if (!Files.isRegularFile(file)) {
+				throw new IllegalArgumentException("Archive is not a regular file: " + path);
+			}
+			return new Source(file, false);
+		}
+
+		Path tmp = Files.createTempFile("covia-archive-", ".zip");
+		try {
+			if (assetRef != null) {
+				// resolveContent spans every storage mechanism (CAS record, DLFS,
+				// provider) under the caller's authority — unlike getContentStream,
+				// which only serves metadata-declared content.
+				covia.venue.storage.ContentProvider.Resolved resolved = engine.resolveContent(assetRef, ctx);
+				if (resolved == null || resolved.content() == null) {
+					throw new IllegalArgumentException("Asset not found or has no content: " + assetRef);
+				}
+				Files.write(tmp, resolved.content().getBlob().getBytes());
+			} else {
+				byte[] raw = Base64.getDecoder().decode(bytesB64.toString());
+				Files.write(tmp, raw);
+			}
+			return new Source(tmp, true);
+		} catch (RuntimeException | IOException e) {
+			Files.deleteIfExists(tmp);
+			throw e;
+		}
+	}
+
+	// ==================== list ====================
+
+	private ACell handleList(RequestContext ctx, AMap<AString, ACell> input) throws IOException {
+		try (Source src = resolveSource(ctx, input);
+		     ZipFile zip = new ZipFile(src.path().toFile())) {
+			AVector<ACell> entries = Vectors.empty();
+			long count = 0;
+			for (Enumeration<? extends ZipEntry> e = zip.entries(); e.hasMoreElements(); ) {
+				ZipEntry ze = e.nextElement();
+				count++;
+				if (entries.count() < MAX_LISTED) {
+					entries = entries.conj(Maps.of(
+						"name", Strings.create(ze.getName()),
+						"size", CVMLong.create(ze.getSize()),
+						"compressedSize", CVMLong.create(ze.getCompressedSize()),
+						"directory", CVMBool.create(ze.isDirectory()),
+						"modified", CVMLong.create(ze.getTime())
+					));
+				}
+			}
+			return Maps.of(
+				"entries", entries,
+				"count", CVMLong.create(count),
+				"truncated", CVMBool.create(count > entries.count())
+			);
+		}
+	}
+
+	// ==================== extract ====================
+
+	private ACell handleExtract(RequestContext ctx, AMap<AString, ACell> input) throws IOException {
+		AString destRoot = RT.ensureString(input.get(FIELD_DEST_ROOT));
+		AString destPath = RT.ensureString(input.get(FIELD_DEST_PATH));
+		if (destRoot == null) {
+			throw new IllegalArgumentException("'destRoot' is required (the root to extract into)");
+		}
+		engine.requireAuthority(ctx, Strings.create(schemeResource("file", destRoot, destPath)), Capability.CRUD_WRITE);
+		files().requireWritableRoot(destRoot.toString());
+		Path destDir = files().resolve(ctx, destRoot.toString(), destPath != null ? destPath.toString() : null, false);
+		Files.createDirectories(destDir);
+		Path destReal = destDir.toRealPath();
+
+		long entries = 0;
+		long totalBytes = 0;
+		AVector<ACell> files = Vectors.empty();
+
+		try (Source src = resolveSource(ctx, input);
+		     ZipFile zip = new ZipFile(src.path().toFile())) {
+			for (Enumeration<? extends ZipEntry> e = zip.entries(); e.hasMoreElements(); ) {
+				ZipEntry ze = e.nextElement();
+				if (++entries > MAX_ENTRIES) {
+					throw new IllegalArgumentException("Archive exceeds the entry cap (" + MAX_ENTRIES + ")");
+				}
+				// Zip-slip: resolve the entry inside the destination and verify it
+				// cannot escape (normalize collapses any '..'), before touching disk.
+				Path target = destReal.resolve(ze.getName()).normalize();
+				if (!target.startsWith(destReal)) {
+					throw new IllegalArgumentException("Archive entry escapes destination: " + ze.getName());
+				}
+				if (ze.isDirectory()) {
+					Files.createDirectories(target);
+					continue;
+				}
+				Path parent = target.getParent();
+				if (parent != null) Files.createDirectories(parent);
+				try (InputStream is = zip.getInputStream(ze);
+				     OutputStream os = Files.newOutputStream(target,
+						StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+					totalBytes += copyCapped(is, os, MAX_TOTAL_BYTES - totalBytes);
+				}
+				if (files.count() < MAX_LISTED) {
+					files = files.conj(Strings.create(destReal.relativize(target).toString().replace('\\', '/')));
+				}
+			}
+		}
+
+		return Maps.of(
+			"extracted", CVMLong.create(entries),
+			"bytes", CVMLong.create(totalBytes),
+			"destRoot", destRoot,
+			"files", files,
+			"truncated", CVMBool.create(entries > files.count())
+		);
+	}
+
+	/** Copies at most {@code remaining} bytes; throws if the source would exceed it
+	 *  (zip-bomb guard). Returns bytes copied. */
+	private static long copyCapped(InputStream is, OutputStream os, long remaining) throws IOException {
+		byte[] buf = new byte[8192];
+		long copied = 0;
+		int n;
+		while ((n = is.read(buf)) != -1) {
+			if (n > remaining) {
+				throw new IllegalArgumentException("Archive exceeds the total-size cap (" + MAX_TOTAL_BYTES + " bytes)");
+			}
+			os.write(buf, 0, n);
+			copied += n;
+			remaining -= n;
+		}
+		return copied;
+	}
+
+	// ==================== zip ====================
+
+	private ACell handleZip(RequestContext ctx, AMap<AString, ACell> input) throws IOException {
+		AString srcRoot = RT.ensureString(input.get(FIELD_ROOT));
+		if (srcRoot == null) {
+			throw new IllegalArgumentException("'root' is required (the source root to zip from)");
+		}
+		// Sources: 'paths' (array) or a single 'path'.
+		java.util.List<String> relPaths = new java.util.ArrayList<>();
+		ACell pathsCell = input.get(FIELD_PATHS);
+		if (pathsCell instanceof AVector<?> v) {
+			for (long i = 0; i < v.count(); i++) {
+				AString s = RT.ensureString(v.get(i));
+				if (s != null) relPaths.add(s.toString());
+			}
+		}
+		AString single = RT.ensureString(input.get(FIELD_PATH));
+		if (single != null) relPaths.add(single.toString());
+		if (relPaths.isEmpty()) {
+			throw new IllegalArgumentException("Provide 'path' or 'paths' — the files/directories to zip");
+		}
+
+		AString destRoot = RT.ensureString(input.get(FIELD_DEST_ROOT));
+		AString destPath = RT.ensureString(input.get(FIELD_DEST_PATH));
+		boolean toFile = destRoot != null && destPath != null;
+
+		// Read-check every source; collect (jailed path, entry name).
+		java.util.List<Path> srcFiles = new java.util.ArrayList<>();
+		java.util.List<String> srcEntryBases = new java.util.ArrayList<>();
+		for (String rel : relPaths) {
+			engine.requireAuthority(ctx,
+				Strings.create(schemeResource("file", srcRoot, Strings.create(rel))), Capability.CRUD_READ);
+			Path p = files().resolve(ctx, srcRoot.toString(), rel, true);
+			srcFiles.add(p);
+			// Entry name preserves the caller-supplied relative path (zip -r style).
+			srcEntryBases.add(rel.replace('\\', '/').replaceAll("^/+", ""));
+		}
+
+		// Destination: a jailed file, or (default) a content-addressed asset.
+		Path destFile = null;
+		if (toFile) {
+			engine.requireAuthority(ctx,
+				Strings.create(schemeResource("file", destRoot, destPath)), Capability.CRUD_WRITE);
+			files().requireWritableRoot(destRoot.toString());
+			destFile = files().resolve(ctx, destRoot.toString(), destPath.toString(), false);
+			Path parent = destFile.getParent();
+			if (parent != null && !Files.exists(parent)) {
+				throw new java.nio.file.NoSuchFileException("Parent directory does not exist: " + parent);
+			}
+		} else {
+			engine.requireAuthority(ctx, Strings.create("a/"), Abilities.ASSET_STORE);
+		}
+
+		Path zipTmp = toFile ? null : Files.createTempFile("covia-zip-", ".zip");
+		long[] entryCount = {0};
+		try {
+			Path out = toFile ? destFile : zipTmp;
+			try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(out,
+					StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE))) {
+				for (int i = 0; i < srcFiles.size(); i++) {
+					addToZip(zos, srcFiles.get(i), srcEntryBases.get(i), entryCount);
+				}
+			}
+
+			long size = Files.size(out);
+			if (toFile) {
+				return Maps.of(
+					"entries", CVMLong.create(entryCount[0]),
+					"bytes", CVMLong.create(size),
+					"destRoot", destRoot,
+					"destPath", destPath
+				);
+			}
+			// Produce a content-addressed asset.
+			byte[] zipBytes = Files.readAllBytes(zipTmp);
+			ABlob content = Blob.wrap(zipBytes);
+			AString nameCell = RT.ensureString(input.get(FIELD_NAME));
+			String name = (nameCell != null) ? nameCell.toString() : "archive.zip";
+			// The asset store keys on the metadata hash and requires content.sha256
+			// to match the bytes — declare it, exactly as AssetAdapter.store does.
+			AString sha = Strings.create(Hashing.sha256(zipBytes).toHexString());
+			AMap<AString, ACell> meta = Maps.of(
+				FIELD_NAME, Strings.create(name),
+				Strings.create("mediaType"), Strings.create(ZIP_MEDIA_TYPE),
+				Fields.CONTENT, Maps.of(
+					Strings.create("mediaType"), Strings.create(ZIP_MEDIA_TYPE),
+					Fields.SHA256, sha)
+			);
+			var hash = engine.storeUserAsset(JSON.printPretty(meta), content, ctx);
+			AString didUrl = ctx.getCallerDID().append("/a/" + hash.toHexString());
+			return Maps.of(
+				"entries", CVMLong.create(entryCount[0]),
+				"bytes", CVMLong.create(size),
+				"asset", didUrl
+			);
+		} finally {
+			if (zipTmp != null) Files.deleteIfExists(zipTmp);
+		}
+	}
+
+	/** Adds a file or (recursively) a directory to the zip, entries named under
+	 *  {@code entryBase}. */
+	private void addToZip(ZipOutputStream zos, Path src, String entryBase, long[] count) throws IOException {
+		if (Files.isDirectory(src)) {
+			try (java.util.stream.Stream<Path> walk = Files.walk(src)) {
+				java.util.List<Path> all = walk.sorted().toList();
+				for (Path p : all) {
+					String rel = src.relativize(p).toString().replace('\\', '/');
+					String name = rel.isEmpty() ? entryBase : entryBase + "/" + rel;
+					if (Files.isDirectory(p)) {
+						if (!name.endsWith("/")) name = name + "/";
+						writeEntry(zos, name, null, count);
+					} else {
+						writeEntry(zos, name, p, count);
+					}
+				}
+			}
+		} else {
+			writeEntry(zos, entryBase, src, count);
+		}
+	}
+
+	private void writeEntry(ZipOutputStream zos, String name, Path file, long[] count) throws IOException {
+		if (++count[0] > MAX_ENTRIES) {
+			throw new IllegalArgumentException("Zip exceeds the entry cap (" + MAX_ENTRIES + ")");
+		}
+		ZipEntry ze = new ZipEntry(name);
+		zos.putNextEntry(ze);
+		if (file != null) {
+			try (InputStream is = Files.newInputStream(file)) {
+				is.transferTo(zos);
+			}
+		}
+		zos.closeEntry();
+	}
+}

--- a/venue/src/main/java/covia/adapter/FileAdapter.java
+++ b/venue/src/main/java/covia/adapter/FileAdapter.java
@@ -409,6 +409,34 @@ public class FileAdapter extends AAdapter {
 		}
 	}
 
+	// ==================== Sibling-adapter API ====================
+	// A single source of truth for the file roots and their jail. Sibling
+	// adapters that operate on the same roots (e.g. ArchiveAdapter) resolve
+	// through here rather than duplicating the root config or the escape checks.
+	// These do NOT check capabilities — the caller enforces its own at the point
+	// of action, naming the exact file:// resource and ability it requires.
+
+	/**
+	 * Resolves a {@code (root, path)} pair to a jailed absolute path inside the
+	 * named root, for reuse by sibling adapters. Throws on an unknown root or a
+	 * path that escapes the root (lexically or via a symlink).
+	 *
+	 * @param mustExist require the resolved path to exist (else {@link NoSuchFileException})
+	 */
+	public Path resolve(RequestContext ctx, String root, String path, boolean mustExist) throws IOException {
+		return resolvePath(ctx, root, path, mustExist);
+	}
+
+	/** True if the named root is read-only; throws if the root is unknown. */
+	public boolean isReadOnlyRoot(String root) {
+		return requireRoot(root).readOnly;
+	}
+
+	/** Throws if the named root is read-only or unknown. */
+	public void requireWritableRoot(String root) {
+		requireWritable(root);
+	}
+
 	// ==================== Invocation ====================
 
 	@Override

--- a/venue/src/main/java/covia/adapter/FileAdapter.java
+++ b/venue/src/main/java/covia/adapter/FileAdapter.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
@@ -403,6 +404,95 @@ public class FileAdapter extends AAdapter {
 		return r;
 	}
 
+	// ==================== Archive read-through (jdk.zipfs) ====================
+
+	/** A resolved target: a plain filesystem path, or an entry inside a mounted
+	 *  archive. {@link #close} releases the archive filesystem and its per-archive
+	 *  lock when present; a plain path closes to nothing. */
+	private record Resolved(Path path, FileSystem archiveFs,
+			java.util.concurrent.locks.ReentrantLock lock) implements java.io.Closeable {
+		@Override public void close() throws IOException {
+			try { if (archiveFs != null) archiveFs.close(); }
+			finally { if (lock != null) lock.unlock(); }
+		}
+	}
+
+	/** Per-archive mount lock — {@code jdk.zipfs} keys a FileSystem by the archive
+	 *  path and rejects a second concurrent mount, so reads of the SAME archive
+	 *  serialise while reads of different archives run in parallel. */
+	private final java.util.concurrent.ConcurrentHashMap<String, java.util.concurrent.locks.ReentrantLock>
+		archiveLocks = new java.util.concurrent.ConcurrentHashMap<>();
+
+	/**
+	 * Resolves a {@code (root, path)} pair, transparently descending into a
+	 * zip/jar when the path carries a {@code !} archive-entry separator
+	 * ({@code app.zip!/dir/file} — the standard jar-URL convention). The archive
+	 * itself is resolved and jailed like any file and <b>must already exist</b>;
+	 * it is mounted <b>existing-only</b> via {@code jdk.zipfs} (never created — a
+	 * read of a missing archive fails, it does not fabricate one). The entry is
+	 * jailed within the archive root. With no {@code !} this is a plain
+	 * {@link #resolvePath} wrapped in a no-op {@link Resolved}.
+	 *
+	 * <p>Read-only: writing into an archive is not a {@code file:} side effect
+	 * (see {@link #rejectArchiveEntry}); use the {@code archive} adapter.</p>
+	 */
+	private Resolved resolveEntry(RequestContext ctx, String rootName, String userPath, boolean mustExist) throws IOException {
+		int bang = (userPath == null) ? -1 : userPath.indexOf('!');
+		if (bang < 0) {
+			return new Resolved(resolvePath(ctx, rootName, userPath, mustExist), null, null);
+		}
+		String archivePart = userPath.substring(0, bang);
+		String entryPart = userPath.substring(bang + 1);
+
+		// The archive must exist and be a regular file — never created here.
+		Path archive = resolvePath(ctx, rootName, archivePart, true);
+		if (!Files.isRegularFile(archive)) {
+			throw new IllegalArgumentException("Not an archive file: " + archivePart);
+		}
+
+		java.util.concurrent.locks.ReentrantLock lock = archiveLocks.computeIfAbsent(
+			archive.toRealPath().toString(), k -> new java.util.concurrent.locks.ReentrantLock());
+		lock.lock();
+		FileSystem fs;
+		try {
+			// Existing-only mount: no {"create":"true"} env, so a non-zip or a
+			// missing file fails here rather than fabricating an archive.
+			fs = java.nio.file.FileSystems.newFileSystem(archive);
+		} catch (Exception mountErr) {
+			lock.unlock();
+			throw new IllegalArgumentException("Not a readable zip/jar archive: " + archivePart
+				+ " (" + mountErr.getClass().getSimpleName() + ")");
+		}
+		try {
+			Path zipRoot = fs.getRootDirectories().iterator().next();
+			String stripped = entryPart;
+			while (!stripped.isEmpty() && (stripped.charAt(0) == '/' || stripped.charAt(0) == '\\')) {
+				stripped = stripped.substring(1);
+			}
+			Path entry = stripped.isEmpty() ? zipRoot : zipRoot.resolve(stripped).normalize();
+			if (!entry.startsWith(zipRoot)) {
+				throw new IllegalArgumentException("Path escapes archive '" + archivePart + "': " + entryPart);
+			}
+			if (mustExist && !Files.exists(entry)) {
+				throw new NoSuchFileException(rootName + ":" + userPath);
+			}
+			return new Resolved(entry, fs, lock);
+		} catch (RuntimeException | IOException e) {
+			try { fs.close(); } catch (IOException ignored) { }
+			lock.unlock();
+			throw e;
+		}
+	}
+
+	/** Rejects an archive-entry path ({@code x.zip!/…}) on a write-class op —
+	 *  {@code file:} sees into archives read-only; mutate them via the archive adapter. */
+	private static void rejectArchiveEntry(String pathArg, String verb) {
+		if (pathArg != null && pathArg.indexOf('!') >= 0) {
+			throw new IllegalArgumentException("Cannot " + verb + " an archive entry ('" + pathArg
+				+ "') — file access to archives is read-only; use archive:zip / archive:extract");
+		}
+	}
+
 	private void requireWritable(String rootName) {
 		if (requireRoot(rootName).readOnly) {
 			throw new IllegalArgumentException("Root '" + rootName + "' is read-only");
@@ -525,28 +615,30 @@ public class FileAdapter extends AAdapter {
 	private ACell handleList(RequestContext ctx, AMap<AString, ACell> input) throws IOException {
 		String rootName = stringArg(input, FIELD_ROOT);
 		String pathArg = stringArg(input, FIELD_PATH);
-		Path dir = resolvePath(ctx, rootName, pathArg, true);
-		if (!Files.isDirectory(dir)) {
-			throw new IllegalArgumentException("Not a directory: " + pathArg);
-		}
-
-		AVector<ACell> entries = Vectors.empty();
-		try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
-			for (Path child : stream) {
-				BasicFileAttributes attrs = Files.readAttributes(child, BasicFileAttributes.class);
-				String type = attrs.isDirectory() ? "directory"
-					: attrs.isRegularFile() ? "file"
-					: attrs.isSymbolicLink() ? "symlink"
-					: "other";
-				entries = entries.conj(Maps.of(
-					"name", child.getFileName().toString(),
-					"type", type,
-					"size", CVMLong.create(attrs.size()),
-					"modified", CVMLong.create(attrs.lastModifiedTime().toMillis())
-				));
+		try (Resolved r = resolveEntry(ctx, rootName, pathArg, true)) {
+			Path dir = r.path();
+			if (!Files.isDirectory(dir)) {
+				throw new IllegalArgumentException("Not a directory: " + pathArg);
 			}
+
+			AVector<ACell> entries = Vectors.empty();
+			try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+				for (Path child : stream) {
+					BasicFileAttributes attrs = Files.readAttributes(child, BasicFileAttributes.class);
+					String type = attrs.isDirectory() ? "directory"
+						: attrs.isRegularFile() ? "file"
+						: attrs.isSymbolicLink() ? "symlink"
+						: "other";
+					entries = entries.conj(Maps.of(
+						"name", child.getFileName().toString(),
+						"type", type,
+						"size", CVMLong.create(attrs.size()),
+						"modified", CVMLong.create(attrs.lastModifiedTime().toMillis())
+					));
+				}
+			}
+			return Maps.of("entries", entries);
 		}
-		return Maps.of("entries", entries);
 	}
 
 	/** Tree-walk state shared across the recursion. */
@@ -567,19 +659,20 @@ public class FileAdapter extends AAdapter {
 		AString infoCell = RT.ensureString(input.get(Strings.create("info")));
 		String info = (infoCell != null) ? infoCell.toString() : null;
 
-		Path dir = resolvePath(ctx, rootName, pathArg, true);
-		if (!Files.isDirectory(dir)) {
-			throw new IllegalArgumentException("Not a directory: " + pathArg);
+		try (Resolved r = resolveEntry(ctx, rootName, pathArg, true)) {
+			Path dir = r.path();
+			if (!Files.isDirectory(dir)) {
+				throw new IllegalArgumentException("Not a directory: " + pathArg);
+			}
+
+			TreeState state = new TreeState();
+			walkTree(dir, 0, maxDepth, maxEntries, info, state);
+
+			return Maps.of(
+				"tree", state.out.toString(),
+				"truncated", CVMBool.create(state.truncated)
+			);
 		}
-
-		TreeState state = new TreeState();
-		walkTree(dir, 0, maxDepth, maxEntries, info, state);
-
-		AMap<AString, ACell> out = Maps.of(
-			"tree", state.out.toString(),
-			"truncated", CVMBool.create(state.truncated)
-		);
-		return out;
 	}
 
 	private static void walkTree(Path dir, int depth, int maxDepth, int maxEntries,
@@ -640,15 +733,18 @@ public class FileAdapter extends AAdapter {
 		String mode = stringArg(input, FIELD_MODE);
 		if (mode == null || mode.isEmpty()) mode = "auto";
 
-		Path file = resolvePath(ctx, rootName, pathArg, true);
-		if (!Files.isRegularFile(file)) {
-			throw new IllegalArgumentException("Not a regular file: " + pathArg);
+		byte[] bytes;
+		String mime;
+		try (Resolved r = resolveEntry(ctx, rootName, pathArg, true)) {
+			Path file = r.path();
+			if (!Files.isRegularFile(file)) {
+				throw new IllegalArgumentException("Not a regular file: " + pathArg);
+			}
+			bytes = Files.readAllBytes(file);
+			mime = MimeUtils.guess(file.getFileName() != null
+				? file.getFileName().toString() : "", bytes);
 		}
-
-		byte[] bytes = Files.readAllBytes(file);
 		CVMLong size = CVMLong.create(bytes.length);
-		String mime = MimeUtils.guess(file.getFileName() != null
-			? file.getFileName().toString() : "", bytes);
 
 		switch (mode) {
 			case "text": {
@@ -709,6 +805,7 @@ public class FileAdapter extends AAdapter {
 		String rootName = stringArg(input, FIELD_ROOT);
 		String pathArg = stringArg(input, FIELD_PATH);
 		requireWritable(rootName);
+		rejectArchiveEntry(pathArg, "write");
 
 		Path file = resolvePath(ctx, rootName, pathArg, false);
 		Path parent = file.getParent();
@@ -729,6 +826,7 @@ public class FileAdapter extends AAdapter {
 		String rootName = stringArg(input, FIELD_ROOT);
 		String pathArg = stringArg(input, FIELD_PATH);
 		requireWritable(rootName);
+		rejectArchiveEntry(pathArg, "append to");
 
 		Path file = resolvePath(ctx, rootName, pathArg, false);
 		boolean existed = fileExists(file);
@@ -745,6 +843,7 @@ public class FileAdapter extends AAdapter {
 		String pathArg = stringArg(input, FIELD_PATH);
 		boolean recursive = RT.bool(input.get(FIELD_RECURSIVE));
 		requireWritable(rootName);
+		rejectArchiveEntry(pathArg, "delete");
 
 		Path target = resolvePath(ctx, rootName, pathArg, false);
 		if (!Files.exists(target)) {
@@ -773,6 +872,7 @@ public class FileAdapter extends AAdapter {
 		String pathArg = stringArg(input, FIELD_PATH);
 		boolean parents = RT.bool(input.get(FIELD_PARENTS));
 		requireWritable(rootName);
+		rejectArchiveEntry(pathArg, "create");
 
 		Path target = resolvePath(ctx, rootName, pathArg, false);
 		boolean existed = Files.exists(target);
@@ -795,28 +895,30 @@ public class FileAdapter extends AAdapter {
 		String rootName = stringArg(input, FIELD_ROOT);
 		String pathArg = stringArg(input, FIELD_PATH);
 
-		Path target = resolvePath(ctx, rootName, pathArg, false);
-		if (!Files.exists(target)) {
-			return Maps.of("exists", CVMBool.FALSE);
+		try (Resolved r = resolveEntry(ctx, rootName, pathArg, false)) {
+			Path target = r.path();
+			if (!Files.exists(target)) {
+				return Maps.of("exists", CVMBool.FALSE);
+			}
+			BasicFileAttributes attrs = Files.readAttributes(target, BasicFileAttributes.class);
+			String type = attrs.isDirectory() ? "directory"
+				: attrs.isRegularFile() ? "file"
+				: attrs.isSymbolicLink() ? "symlink"
+				: "other";
+			AMap<AString, ACell> out = Maps.of(
+				"exists", CVMBool.TRUE,
+				"type", type,
+				"size", CVMLong.create(attrs.size()),
+				"modified", CVMLong.create(attrs.lastModifiedTime().toMillis()),
+				"readOnly", CVMBool.create(requireRoot(rootName).readOnly)
+			);
+			if (attrs.isRegularFile()) {
+				String mime = MimeUtils.guess(target.getFileName() != null
+					? target.getFileName().toString() : "", null);
+				out = out.assoc(Strings.create("mime"), Strings.create(mime));
+			}
+			return out;
 		}
-		BasicFileAttributes attrs = Files.readAttributes(target, BasicFileAttributes.class);
-		String type = attrs.isDirectory() ? "directory"
-			: attrs.isRegularFile() ? "file"
-			: attrs.isSymbolicLink() ? "symlink"
-			: "other";
-		AMap<AString, ACell> out = Maps.of(
-			"exists", CVMBool.TRUE,
-			"type", type,
-			"size", CVMLong.create(attrs.size()),
-			"modified", CVMLong.create(attrs.lastModifiedTime().toMillis()),
-			"readOnly", CVMBool.create(requireRoot(rootName).readOnly)
-		);
-		if (attrs.isRegularFile()) {
-			String mime = MimeUtils.guess(target.getFileName() != null
-				? target.getFileName().toString() : "", null);
-			out = out.assoc(Strings.create("mime"), Strings.create(mime));
-		}
-		return out;
 	}
 
 	// ==================== Helpers ====================

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -560,6 +560,7 @@ public class Engine {
 		venue.registerAdapter(new HTTPAdapter());
 		venue.registerAdapter(new JVMAdapter());
 		venue.registerAdapter(new FileAdapter());
+		venue.registerAdapter(new covia.adapter.ArchiveAdapter());
 		venue.registerAdapter(new SchemaAdapter());
 		venue.registerAdapter(new JSONAdapter());
 		venue.registerAdapter(new Orchestrator());

--- a/venue/src/main/resources/adapters/archive/extract.json
+++ b/venue/src/main/resources/adapters/archive/extract.json
@@ -1,0 +1,31 @@
+{
+  "name": "Extract Archive",
+  "description": "Extract a zip or jar archive into a filesystem directory. The archive source is exactly one of: a 'root'+'path' file, a content-addressed 'asset', or inline base64 'bytes'. Files are written under 'destRoot' (a writable root) at optional 'destPath', which is created if needed. Extraction is jailed to the destination (zip-slip protected — entries that escape are rejected) and capped against zip bombs. Returns the number of entries extracted, total bytes written, and a (capped) list of extracted file paths.",
+  "creator": "Covia",
+  "operation": {
+    "adapter": "archive:extract",
+    "toolName": "archive_extract",
+    "input": {
+      "type": "object",
+      "properties": {
+        "root": { "type": "string", "description": "Source archive root (with 'path')" },
+        "path": { "type": "string", "description": "Source archive path relative to 'root'" },
+        "asset": { "type": "string", "description": "Source asset reference to the archive bytes" },
+        "bytes": { "type": "string", "description": "Base64-encoded source archive bytes" },
+        "destRoot": { "type": "string", "description": "Destination root to extract into (must be writable)" },
+        "destPath": { "type": "string", "description": "Destination directory relative to 'destRoot' (default: root itself)" }
+      },
+      "required": ["destRoot"]
+    },
+    "output": {
+      "type": "object",
+      "properties": {
+        "extracted": { "type": "integer", "description": "Number of entries processed" },
+        "bytes": { "type": "integer", "description": "Total uncompressed bytes written" },
+        "destRoot": { "type": "string", "description": "Destination root" },
+        "files": { "type": "array", "description": "Extracted file paths (capped)", "items": { "type": "string" } },
+        "truncated": { "type": "boolean", "description": "True if more files were extracted than are listed" }
+      }
+    }
+  }
+}

--- a/venue/src/main/resources/adapters/archive/list.json
+++ b/venue/src/main/resources/adapters/archive/list.json
@@ -1,0 +1,26 @@
+{
+  "name": "List Archive",
+  "description": "List the entries of a zip or jar archive without extracting it. The archive source is exactly one of: a filesystem 'root'+'path' file, a content-addressed 'asset' reference, or inline base64 'bytes'. Returns each entry's name, uncompressed size, compressed size, directory flag, and modified time. Large archives are capped: 'count' is the true total, 'entries' is capped and 'truncated' indicates when more exist.",
+  "creator": "Covia",
+  "operation": {
+    "adapter": "archive:list",
+    "toolName": "archive_list",
+    "input": {
+      "type": "object",
+      "properties": {
+        "root": { "type": "string", "description": "Configured file root of the archive (with 'path')" },
+        "path": { "type": "string", "description": "Archive file path relative to 'root'" },
+        "asset": { "type": "string", "description": "Content-addressed asset reference to the archive bytes" },
+        "bytes": { "type": "string", "description": "Base64-encoded archive bytes (inline source)" }
+      }
+    },
+    "output": {
+      "type": "object",
+      "properties": {
+        "entries": { "type": "array", "description": "Entry metadata (capped)", "items": { "type": "object" } },
+        "count": { "type": "integer", "description": "True total number of entries" },
+        "truncated": { "type": "boolean", "description": "True if more entries exist than are listed" }
+      }
+    }
+  }
+}

--- a/venue/src/main/resources/adapters/archive/zip.json
+++ b/venue/src/main/resources/adapters/archive/zip.json
@@ -1,0 +1,31 @@
+{
+  "name": "Create Zip Archive",
+  "description": "Build a zip archive from files and/or directories under a filesystem root. 'root' names the source root; 'path' (single) or 'paths' (array) name the files/directories to include — entry names preserve the given relative paths (zip -r style), directories are added recursively. Output goes to a file when 'destRoot'+'destPath' are given (must be a writable root); otherwise a content-addressed asset is produced and its reference returned (optionally named via 'name'). Capped against runaway entry counts.",
+  "creator": "Covia",
+  "operation": {
+    "adapter": "archive:zip",
+    "toolName": "archive_zip",
+    "input": {
+      "type": "object",
+      "properties": {
+        "root": { "type": "string", "description": "Source root containing the files to zip" },
+        "path": { "type": "string", "description": "A single file/directory to include (relative to 'root')" },
+        "paths": { "type": "array", "description": "Files/directories to include (relative to 'root')", "items": { "type": "string" } },
+        "destRoot": { "type": "string", "description": "Output root for the .zip file (omit to produce an asset)" },
+        "destPath": { "type": "string", "description": "Output .zip path relative to 'destRoot'" },
+        "name": { "type": "string", "description": "Asset name when producing an asset (default 'archive.zip')" }
+      },
+      "required": ["root"]
+    },
+    "output": {
+      "type": "object",
+      "properties": {
+        "entries": { "type": "integer", "description": "Number of entries written" },
+        "bytes": { "type": "integer", "description": "Size of the resulting zip in bytes" },
+        "asset": { "type": "string", "description": "Asset reference (when producing an asset)" },
+        "destRoot": { "type": "string", "description": "Output root (when writing a file)" },
+        "destPath": { "type": "string", "description": "Output path (when writing a file)" }
+      }
+    }
+  }
+}

--- a/venue/src/test/java/covia/adapter/ArchiveAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/ArchiveAdapterTest.java
@@ -1,0 +1,190 @@
+package covia.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import convex.core.data.ACell;
+import convex.core.data.AVector;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+import convex.core.lang.RT;
+import covia.grid.Job;
+import covia.grid.Status;
+import covia.venue.Engine;
+import covia.venue.RequestContext;
+
+public class ArchiveAdapterTest {
+
+	@TempDir static Path workspace;
+	@TempDir static Path readonly;
+
+	private static Engine engine;
+	private static final String DID = "did:key:z6Mk-test-ArchiveAdapterTest";
+
+	@BeforeAll
+	static void setup() throws IOException {
+		engine = Engine.createTemp(Maps.of(
+			"file", Maps.of("roots", Maps.of(
+				"work", workspace.toAbsolutePath().toString(),
+				"ro", Maps.of(
+					"path", readonly.toAbsolutePath().toString(),
+					"readOnly", true)
+			))
+		));
+		Engine.addDemoAssets(engine);
+
+		// Seed a small tree under the 'work' root: data/a.txt, data/sub/b.txt
+		Files.createDirectories(workspace.resolve("data/sub"));
+		Files.writeString(workspace.resolve("data/a.txt"), "alpha");
+		Files.writeString(workspace.resolve("data/sub/b.txt"), "bravo");
+	}
+
+	private RequestContext ctx() {
+		return RequestContext.of(Strings.create(DID));
+	}
+
+	private ACell run(String op, ACell input) {
+		Job job = engine.jobs().invokeOperation(op, input, ctx());
+		ACell result = job.awaitResult(5000);
+		if (job.getStatus() == Status.FAILED) {
+			throw new AssertionError("Job failed: " + job.getErrorMessage());
+		}
+		return result;
+	}
+
+	private Job runRaw(String op, ACell input) {
+		Job job = engine.jobs().invokeOperation(op, input, ctx());
+		try { job.awaitResult(5000); } catch (RuntimeException ignored) { }
+		return job;
+	}
+
+	/** Build a zip in memory from name -> bytes (a '/'-terminated name is a dir). */
+	private static byte[] makeZip(Map<String, byte[]> entries) throws IOException {
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		try (ZipOutputStream zos = new ZipOutputStream(bos)) {
+			for (var e : entries.entrySet()) {
+				zos.putNextEntry(new ZipEntry(e.getKey()));
+				if (e.getValue() != null) zos.write(e.getValue());
+				zos.closeEntry();
+			}
+		}
+		return bos.toByteArray();
+	}
+
+	// =========================================================
+
+	@Test
+	public void testZipToFileThenList() {
+		ACell zipped = run("v/ops/archive/zip", Maps.of(
+			"root", "work", "path", "data",
+			"destRoot", "work", "destPath", "out.zip"));
+		assertTrue(RT.getIn(zipped, "entries") != null);
+		assertTrue(Files.exists(workspace.resolve("out.zip")), "zip file must be created");
+
+		ACell listed = run("v/ops/archive/list", Maps.of("root", "work", "path", "out.zip"));
+		AVector<?> entries = RT.ensureVector(RT.getIn(listed, "entries"));
+		boolean hasA = false, hasB = false;
+		for (long i = 0; i < entries.count(); i++) {
+			String name = RT.ensureString(RT.getIn(entries.get(i), "name")).toString();
+			if (name.equals("data/a.txt")) hasA = true;
+			if (name.equals("data/sub/b.txt")) hasB = true;
+		}
+		assertTrue(hasA, "listing must contain data/a.txt");
+		assertTrue(hasB, "listing must contain data/sub/b.txt (recursive)");
+	}
+
+	@Test
+	public void testZipToAssetThenExtractRoundTrips() throws IOException {
+		ACell zipped = run("v/ops/archive/zip", Maps.of(
+			"root", "work", "paths", Vectors.of(Strings.create("data"))));
+		String assetRef = RT.ensureString(RT.getIn(zipped, "asset")).toString();
+		assertNotNull(assetRef);
+		assertTrue(assetRef.contains("/a/"), "zip must return a CAS asset ref: " + assetRef);
+
+		run("v/ops/archive/extract", Maps.of(
+			"asset", assetRef, "destRoot", "work", "destPath", "restored"));
+		assertEquals("alpha", Files.readString(workspace.resolve("restored/data/a.txt")));
+		assertEquals("bravo", Files.readString(workspace.resolve("restored/data/sub/b.txt")));
+	}
+
+	@Test
+	public void testExtractFromInlineBytes() throws IOException {
+		Map<String, byte[]> m = new LinkedHashMap<>();
+		m.put("hello.txt", "world".getBytes(StandardCharsets.UTF_8));
+		String b64 = Base64.getEncoder().encodeToString(makeZip(m));
+
+		run("v/ops/archive/extract", Maps.of(
+			"bytes", b64, "destRoot", "work", "destPath", "frombytes"));
+		assertEquals("world", Files.readString(workspace.resolve("frombytes/hello.txt")));
+	}
+
+	@Test
+	public void testZipSlipRejectedAndNoFileEscapes() throws IOException {
+		// A malicious archive whose entry escapes the destination via '..'.
+		Map<String, byte[]> m = new LinkedHashMap<>();
+		m.put("../escaped.txt", "pwned".getBytes(StandardCharsets.UTF_8));
+		Files.write(workspace.resolve("evil.zip"), makeZip(m));
+
+		Job job = runRaw("v/ops/archive/extract", Maps.of(
+			"root", "work", "path", "evil.zip",
+			"destRoot", "work", "destPath", "sandbox"));
+		assertEquals(Status.FAILED, job.getStatus(), "zip-slip must be rejected");
+		assertTrue(job.getErrorMessage().toLowerCase().contains("escape"),
+			"error should mention escape: " + job.getErrorMessage());
+		// The escaping file must NOT have been written outside the sandbox.
+		assertFalse(Files.exists(workspace.resolve("escaped.txt")),
+			"zip-slip entry must never land outside the destination");
+	}
+
+	@Test
+	public void testMissingSourceFailsAndCreatesNothing() {
+		Job job = runRaw("v/ops/archive/list", Maps.of("root", "work", "path", "does-not-exist.zip"));
+		assertEquals(Status.FAILED, job.getStatus(), "missing archive must fail");
+		assertFalse(Files.exists(workspace.resolve("does-not-exist.zip")),
+			"a read-path op must never create the archive file");
+	}
+
+	@Test
+	public void testExtractToReadOnlyRootRejected() {
+		Job job = runRaw("v/ops/archive/extract", Maps.of(
+			"bytes", "UEsDBAoAAAAAAA==",   // any value; rejected before parsing
+			"destRoot", "ro", "destPath", "x"));
+		assertEquals(Status.FAILED, job.getStatus(), "read-only destination must be rejected");
+		assertTrue(job.getErrorMessage().toLowerCase().contains("read-only"),
+			"error should mention read-only: " + job.getErrorMessage());
+	}
+
+	@Test
+	public void testListReportsMetadata() {
+		run("v/ops/archive/zip", Maps.of(
+			"root", "work", "path", "data",
+			"destRoot", "work", "destPath", "meta.zip"));
+		ACell listed = run("v/ops/archive/list", Maps.of("root", "work", "path", "meta.zip"));
+		assertTrue(RT.getIn(listed, "count") != null, "list must report a count");
+		AVector<?> entries = RT.ensureVector(RT.getIn(listed, "entries"));
+		assertTrue(entries.count() > 0);
+		// every entry carries name + directory flag
+		for (long i = 0; i < entries.count(); i++) {
+			assertNotNull(RT.getIn(entries.get(i), "name"));
+			assertNotNull(RT.getIn(entries.get(i), "directory"));
+		}
+	}
+}

--- a/venue/src/test/java/covia/adapter/FileArchiveReadTest.java
+++ b/venue/src/test/java/covia/adapter/FileArchiveReadTest.java
@@ -1,0 +1,148 @@
+package covia.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import convex.core.data.ACell;
+import convex.core.data.AVector;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import convex.core.lang.RT;
+import covia.grid.Job;
+import covia.grid.Status;
+import covia.venue.Engine;
+import covia.venue.RequestContext;
+
+/** FileAdapter read-through into zip/jar archives via the {@code x.zip!/entry}
+ *  convention (jdk.zipfs), including the safety guarantee that a read never
+ *  creates an archive. */
+public class FileArchiveReadTest {
+
+	@TempDir static Path workspace;
+
+	private static Engine engine;
+	private static final String DID = "did:key:z6Mk-test-FileArchiveReadTest";
+
+	@BeforeAll
+	static void setup() throws IOException {
+		engine = Engine.createTemp(Maps.of(
+			"file", Maps.of("roots", Maps.of("work", workspace.toAbsolutePath().toString()))));
+		Engine.addDemoAssets(engine);
+
+		// A real archive in the root: readme.txt, dir/, dir/inner.txt
+		try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(workspace.resolve("app.zip")))) {
+			zos.putNextEntry(new ZipEntry("readme.txt"));
+			zos.write("hello".getBytes());
+			zos.closeEntry();
+			zos.putNextEntry(new ZipEntry("dir/"));
+			zos.closeEntry();
+			zos.putNextEntry(new ZipEntry("dir/inner.txt"));
+			zos.write("nested".getBytes());
+			zos.closeEntry();
+		}
+		Files.writeString(workspace.resolve("notazip.txt"), "plain");
+	}
+
+	private RequestContext ctx() { return RequestContext.of(Strings.create(DID)); }
+
+	private ACell run(String op, ACell input) {
+		Job job = engine.jobs().invokeOperation(op, input, ctx());
+		ACell result = job.awaitResult(5000);
+		if (job.getStatus() == Status.FAILED) throw new AssertionError("Job failed: " + job.getErrorMessage());
+		return result;
+	}
+
+	private Job runRaw(String op, ACell input) {
+		Job job = engine.jobs().invokeOperation(op, input, ctx());
+		try { job.awaitResult(5000); } catch (RuntimeException ignored) { }
+		return job;
+	}
+
+	// =========================================================
+
+	@Test
+	public void testReadEntryFromZip() {
+		ACell r = run("v/ops/file/read", Maps.of("root", "work", "path", "app.zip!/readme.txt"));
+		assertEquals("hello", RT.ensureString(RT.getIn(r, "content")).toString());
+	}
+
+	@Test
+	public void testReadNestedEntry() {
+		ACell r = run("v/ops/file/read", Maps.of("root", "work", "path", "app.zip!/dir/inner.txt"));
+		assertEquals("nested", RT.ensureString(RT.getIn(r, "content")).toString());
+	}
+
+	@Test
+	public void testListInsideZip() {
+		ACell root = run("v/ops/file/list", Maps.of("root", "work", "path", "app.zip!/"));
+		AVector<?> top = RT.ensureVector(RT.getIn(root, "entries"));
+		boolean hasReadme = false, hasDir = false;
+		for (long i = 0; i < top.count(); i++) {
+			String name = RT.ensureString(RT.getIn(top.get(i), "name")).toString();
+			if (name.equals("readme.txt")) hasReadme = true;
+			if (name.equals("dir")) hasDir = true;
+		}
+		assertTrue(hasReadme && hasDir, "zip root listing must show readme.txt and dir");
+
+		ACell sub = run("v/ops/file/list", Maps.of("root", "work", "path", "app.zip!/dir"));
+		AVector<?> subEntries = RT.ensureVector(RT.getIn(sub, "entries"));
+		assertEquals("inner.txt", RT.ensureString(RT.getIn(subEntries.get(0), "name")).toString());
+	}
+
+	@Test
+	public void testStatEntry() {
+		ACell r = run("v/ops/file/stat", Maps.of("root", "work", "path", "app.zip!/readme.txt"));
+		assertEquals(convex.core.data.prim.CVMBool.TRUE, RT.getIn(r, "exists"));
+		assertEquals("file", RT.ensureString(RT.getIn(r, "type")).toString());
+		assertEquals(5L, RT.ensureLong(RT.getIn(r, "size")).longValue());
+	}
+
+	@Test
+	public void testStatMissingEntryInExistingZip() {
+		ACell r = run("v/ops/file/stat", Maps.of("root", "work", "path", "app.zip!/nope.txt"));
+		assertEquals(convex.core.data.prim.CVMBool.FALSE, RT.getIn(r, "exists"));
+	}
+
+	@Test
+	public void testReadMissingArchiveDoesNotCreateIt() {
+		Job job = runRaw("v/ops/file/read", Maps.of("root", "work", "path", "missing.zip!/x"));
+		assertEquals(Status.FAILED, job.getStatus(), "reading into a missing archive must fail");
+		assertFalse(Files.exists(workspace.resolve("missing.zip")),
+			"the read path must NEVER create the archive file");
+	}
+
+	@Test
+	public void testReadNonZipFails() {
+		Job job = runRaw("v/ops/file/read", Maps.of("root", "work", "path", "notazip.txt!/x"));
+		assertEquals(Status.FAILED, job.getStatus(), "a non-zip file must not mount as an archive");
+		assertTrue(job.getErrorMessage().toLowerCase().contains("archive"),
+			"error should mention archive: " + job.getErrorMessage());
+	}
+
+	@Test
+	public void testEntryEscapeRejected() {
+		Job job = runRaw("v/ops/file/read", Maps.of("root", "work", "path", "app.zip!/../escape"));
+		assertEquals(Status.FAILED, job.getStatus(), "an entry escaping the archive must be rejected");
+	}
+
+	@Test
+	public void testWriteIntoArchiveRejected() {
+		Job job = runRaw("v/ops/file/write", Maps.of(
+			"root", "work", "path", "app.zip!/injected.txt", "content", "x"));
+		assertEquals(Status.FAILED, job.getStatus(), "writing into an archive via file: must be rejected");
+		assertTrue(job.getErrorMessage().toLowerCase().contains("read-only")
+				|| job.getErrorMessage().toLowerCase().contains("archive"),
+			"error should explain archives are read-only: " + job.getErrorMessage());
+	}
+}


### PR DESCRIPTION
## Summary

A new `ArchiveAdapter` and zip/jar read-through for the `FileAdapter`, so agents can work with common archive files. Everything stays inside the `FileAdapter`'s configured roots (one source of truth for the jail); raw `jar:file://` URIs are never exposed — `jdk.zipfs` is the internal mechanism.

## Part A — `ArchiveAdapter`

- **`archive:list`** — entries + metadata (name, size, compressed size, dir flag, mtime) without extracting.
- **`archive:extract`** — extract a zip/jar into a writable root. Zip-slip protected (per-entry normalize + `startsWith`), zip-bomb capped (entry count + total bytes).
- **`archive:zip`** — build a zip from root+path file(s)/dir(s) → a root file **or** a content-addressed asset (zip -r style names, recursive).

Sources: a jailed root+path file, a CAS asset (via `resolveContent`), or inline base64 bytes. Read paths open existing-only — a missing source fails cleanly and never creates a file.

## Part B — `FileAdapter` reads into archives

`file:read`/`list`/`tree`/`stat` transparently descend into an archive when the path carries a `!` entry separator (`app.zip!/dir/file` — the standard jar-URL form). The archive is jailed like any file and mounted **existing-only** via `jdk.zipfs` (no `{"create":"true"}`), so reading a missing/non-zip path fails and **never fabricates an archive**. Entries are jailed within the archive; a per-archive lock serialises same-archive mounts. Read-only — `write`/`delete`/`mkdir` on a `!` path are rejected and point to the archive adapter.

## Part C — skill + docs

`archive` skill (list/extract/zip + peek-into-archive), plus venue CLAUDE.md / AGENTS.md / CHANGELOG.

## Testing

Full reactor green: venue **1831** tests (ArchiveAdapterTest 7 — incl. asset round-trip, inline-bytes, zip-slip, missing source, read-only dest; FileArchiveReadTest 9 — incl. nested read, list/stat inside a zip, **missing-archive-never-created**, non-zip rejected, entry-escape rejected, write-into-zip rejected), covia-sql 10, covia-core + workbench build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
