### PR TITLE
Scope archive '!' read-through to .zip/.jar (keep '!' literal in file paths)

### DIFF
--- a/skills/archive/SKILL.md
+++ b/skills/archive/SKILL.md
@@ -52,7 +52,7 @@ archive_zip  root=work  paths=["a.txt","logs/"]  name=bundle.zip
 
 ## `peek` — read a file inside an archive without unpacking
 
-`file_read` / `file_list` / `file_stat` / `file_tree` descend into an archive when the path carries a `!/` entry separator (the standard jar-URL form). The archive must already exist; nothing is unpacked or created.
+`file_read` / `file_list` / `file_stat` / `file_tree` descend into a `.zip`/`.jar` when the path carries a `!/` entry separator right after the archive name (the standard jar-URL form). A `!` anywhere else is an ordinary filename character. The archive must already exist; nothing is unpacked or created.
 
 ```
 file_read  root=work  path=releases/app.zip!/META-INF/MANIFEST.MF

--- a/venue/src/main/java/covia/adapter/FileAdapter.java
+++ b/venue/src/main/java/covia/adapter/FileAdapter.java
@@ -437,7 +437,7 @@ public class FileAdapter extends AAdapter {
 	 * (see {@link #rejectArchiveEntry}); use the {@code archive} adapter.</p>
 	 */
 	private Resolved resolveEntry(RequestContext ctx, String rootName, String userPath, boolean mustExist) throws IOException {
-		int bang = (userPath == null) ? -1 : userPath.indexOf('!');
+		int bang = archiveBang(userPath);
 		if (bang < 0) {
 			return new Resolved(resolvePath(ctx, rootName, userPath, mustExist), null, null);
 		}
@@ -484,10 +484,35 @@ public class FileAdapter extends AAdapter {
 		}
 	}
 
+	/** Recognised archive extensions whose {@code !} is an entry separator. */
+	private static final String[] ARCHIVE_EXTS = { ".zip", ".jar" };
+
+	/**
+	 * Index of the archive-entry separator {@code !} in a path, but only when it
+	 * immediately follows a recognised archive extension ({@code .zip}/{@code .jar},
+	 * case-insensitive) — so a literal {@code !} in an ordinary filename is not
+	 * mistaken for an archive descent. {@code !} is a jar-URL construct, not a
+	 * file-path one, so plain {@code file:} paths keep it literal. Returns -1 when
+	 * the path does not reference an archive entry.
+	 */
+	private static int archiveBang(String path) {
+		if (path == null) return -1;
+		String lower = path.toLowerCase(java.util.Locale.ROOT);
+		int best = -1;
+		for (String ext : ARCHIVE_EXTS) {
+			int idx = lower.indexOf(ext + "!");
+			if (idx >= 0) {
+				int bang = idx + ext.length(); // the '!' sits right after the extension
+				if (best < 0 || bang < best) best = bang;
+			}
+		}
+		return best;
+	}
+
 	/** Rejects an archive-entry path ({@code x.zip!/…}) on a write-class op —
 	 *  {@code file:} sees into archives read-only; mutate them via the archive adapter. */
 	private static void rejectArchiveEntry(String pathArg, String verb) {
-		if (pathArg != null && pathArg.indexOf('!') >= 0) {
+		if (archiveBang(pathArg) >= 0) {
 			throw new IllegalArgumentException("Cannot " + verb + " an archive entry ('" + pathArg
 				+ "') — file access to archives is read-only; use archive:zip / archive:extract");
 		}

--- a/venue/src/test/java/covia/adapter/FileArchiveReadTest.java
+++ b/venue/src/test/java/covia/adapter/FileArchiveReadTest.java
@@ -52,6 +52,8 @@ public class FileArchiveReadTest {
 			zos.closeEntry();
 		}
 		Files.writeString(workspace.resolve("notazip.txt"), "plain");
+		// A .zip-named file that is NOT actually a zip — exercises the mount failure.
+		Files.writeString(workspace.resolve("fake.zip"), "not really a zip");
 	}
 
 	private RequestContext ctx() { return RequestContext.of(Strings.create(DID)); }
@@ -124,10 +126,20 @@ public class FileArchiveReadTest {
 
 	@Test
 	public void testReadNonZipFails() {
-		Job job = runRaw("v/ops/file/read", Maps.of("root", "work", "path", "notazip.txt!/x"));
+		// .zip extension triggers archive mode; the bytes are not a zip → mount fails.
+		Job job = runRaw("v/ops/file/read", Maps.of("root", "work", "path", "fake.zip!/x"));
 		assertEquals(Status.FAILED, job.getStatus(), "a non-zip file must not mount as an archive");
 		assertTrue(job.getErrorMessage().toLowerCase().contains("archive"),
 			"error should mention archive: " + job.getErrorMessage());
+	}
+
+	@Test
+	public void testLiteralBangFilenameIsLiteral() {
+		// '!' NOT following a .zip/.jar extension is an ordinary filename character
+		// (jar-URL '!' is an archive construct, not a file-path one) — round-trips.
+		run("v/ops/file/write", Maps.of("root", "work", "path", "note!important.txt", "content", "hi"));
+		ACell r = run("v/ops/file/read", Maps.of("root", "work", "path", "note!important.txt"));
+		assertEquals("hi", RT.ensureString(RT.getIn(r, "content")).toString());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Follow-up correctness fix to the archive read-through. `!` (the jar-URL entry separator, `jar:<url>!/{entry}`) is an **archive** construct, not a `file:` one, and `!` is a legal filename character. The initial implementation triggered archive descent on *any* `!` in a path, which broke reading/writing ordinary files whose names contain `!` — e.g. `report!final.txt` was misread as archive `report` + entry `final.txt`.

`FileAdapter.resolveEntry` / `rejectArchiveEntry` now recognise the separator **only when `!` immediately follows a `.zip`/`.jar` extension** (case-insensitive). Plain `file:` paths keep `!` literal; archive references (`x.zip!/entry`) still descend as before.

Also answers the standing question: tar is **not** in the JDK (only zip/jar via `java.util.zip`/`jdk.zipfs`, plus single-stream gzip) — tar would need Apache Commons Compress, so it's deferred as a dependency decision.

## Testing

- New `testLiteralBangFilenameIsLiteral` — `note!important.txt` round-trips through `file:write`/`read`.
- `testReadNonZipFails` reworked to use a `.zip`-named non-zip file, exercising the mount failure through the (now correctly scoped) trigger.
- Full venue suite green (1832).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
