### PR TITLE
Fix two flaky agent tests: real task read-lag race + non-deterministic fence timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 ### Fixed
 - `a/<hash>` references resolve without a leading slash
 - Store unlocked when engine construction fails
+- `agent:completeTask`/`failTask` tolerate the documented cross-thread lattice read lag (#214) — the in-scope task is re-read before failing "Task not found", removing a rare race (delete→recreate) where a committed task was transiently invisible to the transition thread
 
 ## [0.6.0] - 2026-07-17
 

--- a/venue/src/main/java/covia/adapter/AgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/AgentAdapter.java
@@ -1460,6 +1460,34 @@ public class AgentAdapter extends AAdapter {
 		}
 	}
 
+	/** Bounded read retries when resolving an in-scope task (#214 lattice read lag). */
+	private static final int TASK_READ_ATTEMPTS = 10;
+	private static final long TASK_READ_BACKOFF_MS = 25;
+
+	/**
+	 * Resolves the in-scope task index, waiting out the cross-thread lattice read
+	 * lag (#214): a task committed via {@code addTask} before the wake can be
+	 * transiently invisible to a fresh read on this transition thread. Re-reads a
+	 * fresh {@link AgentState} view up to {@link #TASK_READ_ATTEMPTS} times;
+	 * returns the live task index once the task appears, or null if it stays
+	 * absent (genuinely gone — double-complete, or the agent deleted mid-run,
+	 * which {@link #getAgent} reports as null for a TERMINATED agent).
+	 */
+	private Index<Blob, ACell> awaitScopedTaskIndex(AString callerDID, AString agentId, Blob taskId) {
+		for (int attempt = 0; attempt < TASK_READ_ATTEMPTS; attempt++) {
+			try {
+				Thread.sleep(TASK_READ_BACKOFF_MS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return null;
+			}
+			AgentState agent = getAgent(callerDID, agentId);
+			Index<Blob, ACell> tasks = (agent != null) ? agent.getTasks() : null;
+			if (tasks != null && tasks.get(taskId) != null) return tasks;
+		}
+		return null;
+	}
+
 	private ACell doCompleteTask(ACell input, RequestContext ctx) {
 		AString agentId = ctx.getAgentId();
 		Blob taskId = ctx.getTaskId();
@@ -1471,7 +1499,17 @@ public class AgentAdapter extends AAdapter {
 		AgentState agent = requireAgent(ctx.getCallerDID(), agentId);
 		Index<Blob, ACell> tasks = agent.getTasks();
 		if (tasks == null || tasks.get(taskId) == null) {
-			throw new IllegalArgumentException("Task not found: " + taskId.toHexString());
+			// Tolerate the documented cross-thread lattice read lag (#214): the run
+			// loop scoped this cycle to a task it observed, and handleRequest commits
+			// addTask (a CAS) before waking the loop — yet this completeTask/failTask
+			// runs on a SEPARATE transition thread whose fresh read can transiently
+			// lag that commit. Re-read before concluding the task is genuinely gone
+			// (double-complete, or the agent deleted mid-transition). Mirrors the
+			// verify-at-point-of-use guard the resume path already applies (#214).
+			tasks = awaitScopedTaskIndex(ctx.getCallerDID(), agentId, taskId);
+			if (tasks == null) {
+				throw new IllegalArgumentException("Task not found: " + taskId.toHexString());
+			}
 		}
 
 		ACell result = RT.getIn(input, Fields.RESULT);
@@ -1510,7 +1548,17 @@ public class AgentAdapter extends AAdapter {
 		AgentState agent = requireAgent(ctx.getCallerDID(), agentId);
 		Index<Blob, ACell> tasks = agent.getTasks();
 		if (tasks == null || tasks.get(taskId) == null) {
-			throw new IllegalArgumentException("Task not found: " + taskId.toHexString());
+			// Tolerate the documented cross-thread lattice read lag (#214): the run
+			// loop scoped this cycle to a task it observed, and handleRequest commits
+			// addTask (a CAS) before waking the loop — yet this completeTask/failTask
+			// runs on a SEPARATE transition thread whose fresh read can transiently
+			// lag that commit. Re-read before concluding the task is genuinely gone
+			// (double-complete, or the agent deleted mid-transition). Mirrors the
+			// verify-at-point-of-use guard the resume path already applies (#214).
+			tasks = awaitScopedTaskIndex(ctx.getCallerDID(), agentId, taskId);
+			if (tasks == null) {
+				throw new IllegalArgumentException("Task not found: " + taskId.toHexString());
+			}
 		}
 
 		ACell errorCell = RT.getIn(input, Fields.ERROR);

--- a/venue/src/test/java/covia/adapter/agent/GoalTreeLatticeFramesTest.java
+++ b/venue/src/test/java/covia/adapter/agent/GoalTreeLatticeFramesTest.java
@@ -313,9 +313,14 @@ public class GoalTreeLatticeFramesTest {
 		chat("zombie-agent", sid, "block please");
 		await(() -> ag.getSessionCycleEpoch(sid) != null, 5000, "cycle claimed");
 
-		// Suspend while the transition is parked in the tool: the settle
-		// clears the cycle claim, which fences every later write from the
-		// still-running transition thread (cancel does not stop it).
+		// The epoch the parked transition thread holds — exactly what its later,
+		// post-tool "zombie" writes will carry once cancel fails to stop it.
+		ACell zombieEpoch = ag.getSessionCycleEpoch(sid);
+		assertNotNull(zombieEpoch, "cycle epoch must be claimed before suspend");
+
+		// Suspend while the transition is parked in the tool: the settle clears
+		// the cycle claim, which fences every later write from the still-running
+		// transition thread (cancel does not stop it).
 		engine.jobs().invokeOperation(
 			"v/ops/agent/suspend",
 			Maps.of(Fields.AGENT_ID, "zombie-agent"),
@@ -327,11 +332,16 @@ public class GoalTreeLatticeFramesTest {
 
 		AVector<ACell> atSuspend = frames("zombie-agent", sid);
 
-		// Let the zombie's tool timeout fire and its post-tool writes get
-		// fenced: frames must not change after the settle.
-		Thread.sleep(2500);
+		// Deterministic I1 check (no timing dance): a frame write bearing the
+		// pre-suspend epoch — the exact write the zombie transition attempts when
+		// its tool finally returns — is rejected by the released claim and cannot
+		// touch the frames. Drives the fence directly rather than sleeping and
+		// hoping the tool timeout fired.
+		boolean applied = ag.updateSessionFrames(sid, zombieEpoch,
+			f -> f.conj(Maps.of(Strings.create("zombie"), Strings.create("write"))));
+		assertFalse(applied, "a write with the superseded cycle epoch must be fenced (I1)");
 		assertEquals(atSuspend, frames("zombie-agent", sid),
-			"zombie transition writes after the suspend settle must be fenced (I1)");
+			"fenced zombie write must not change frames (I1)");
 		assertNull(ag.getSessionCycleEpoch(sid), "claim stays released");
 	}
 


### PR DESCRIPTION
## Summary

Two agent tests flaked in CI this session. Per the principle "flaky is unacceptable — either a real bug or a badly-designed test," each was root-caused and fixed accordingly.

## 1. `testDeleteCancelsInFlightTaskAndUnblocksRecreate` — a real read-lag race (code fix)

The recreated agent's `taskcomplete` transition intermittently failed with `Task not found`. Root cause (traced end to end):

- `agent:request` commits `addTask` (a lattice CAS) then wakes the run loop with `force=true` — with an in-code comment that the write "may not yet be visible via cursor.get() (lattice write race)".
- The run loop observes the task and scopes the cycle to its `taskId` (so the ID is authoritative).
- But `agent:completeTask`/`failTask` run on a **separate** transition thread and did a **single unguarded** `requireAgent(...).getTasks().get(taskId)` read, throwing `Task not found` immediately — with none of the verify/retry the framework applies elsewhere for this exact hazard (`GoalTreeAdapter` #214 read-then-retry).

Fix: `doCompleteTask`/`doFailTask` now re-read the in-scope task a bounded number of times before concluding it is gone, mirroring the #214 guard. Genuine absence (double-complete, agent deleted mid-run — `getAgent` reports a TERMINATED agent as null) still fails; only the transient stale read is tolerated. Common path (task visible on first read) pays nothing.

## 2. `testSuspendMidRunFencesZombieWrites` — a non-deterministic test (test fix)

The epoch fence it checks is **sound** — `AgentState.updateSessionFrames` does the epoch check and the frames write in one atomic CAS (no TOCTOU). The flake was the test: `suspend → Thread.sleep(2500) → assertEquals(framesUnchanged)`, waiting for a 1500ms tool timeout to fire — a negative asserted after a wall-clock sleep, fragile under CI load.

Redesigned to be deterministic: capture the pre-suspend cycle epoch, then after the suspend releases the claim, assert that a frame write **bearing that epoch** (exactly what the zombie transition would attempt) is rejected by the fence and leaves frames unchanged. No sleep, no reliance on timeout timing.

## Verification

3 consecutive full venue-suite runs (1832 tests) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
