### PR TITLE
Update the dependency table for the merged version bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,11 @@ mvn test -pl covia-core
 |------------|---------|---------|
 | Convex | 0.8.9 | Lattice platform, immutable data, cryptography |
 | Javalin | 7.2.2 | HTTP server with OpenAPI/Swagger/ReDoc |
-| LangChain4j | 1.17.2 | LLM orchestration (OpenAI, Ollama, Gemini, DeepSeek) |
+| LangChain4j | 1.18.0 | LLM orchestration (OpenAI, Ollama, Gemini, DeepSeek) |
 | MCP SDK | 2.0.0 | Model Context Protocol |
-| A2A | 1.0.0.Final | Agent-to-Agent protocol |
+| A2A | 1.1.0.Final | Agent-to-Agent protocol |
 | JUnit | 6.1.1 | Testing |
-| SLF4J/Logback | 2.0.18/1.5.37 | Logging |
+| SLF4J/Logback | 2.0.18/1.6.0 | Logging |
 
 ## Architecture Overview
 


### PR DESCRIPTION
Docs-only follow-up to the Dependabot merges (#168, #276, #277, #278, #279).

`AGENTS.md` pins dependency versions in its table, and three are now stale:

| Dependency | Was | Now |
|---|---|---|
| LangChain4j | 1.17.2 | **1.18.0** |
| A2A | 1.0.0.Final | **1.1.0.Final** |
| SLF4J/Logback | 2.0.18/1.5.37 | 2.0.18/**1.6.0** |

SLF4J itself is unchanged. The maven-compiler-plugin (#276) and google-genai (#279) bumps are not listed in that table, so they need no entry.

The table is the documented contract for anyone setting the project up, so a stale entry is worse than no entry at all.

**On the bumps themselves:** before merging them I integrated all five onto current `develop` locally and ran the full suite — venue 1897, covia-core, SQL 10, all green. Worth doing, because each PR's CI had run against a `develop` from before today's two feature merges, and branch protection has `strict: false`, so stale check results are mergeable.

Two residual risks that tests cannot cover and are worth knowing:

- **LangChain4j 1.18.0** — provider call paths need real API keys, so they are exercised by neither CI nor the local suite. A runtime API change would not have been caught.
- **google-genai 1.0.0 → 1.63.0** — a 63-minor jump, but there is no direct `com.google.genai` usage in our Java; it is a runtime provider dependency for Gemini. Cannot break compilation; could affect the Gemini path only.

Logback 1.6.0 and A2A 1.1.0.Final are better covered — the suite initialises logback from `logback.xml` and emits through it, and the A2A card/streaming/extended-card tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
