### PR TITLE
Treat an unanswered tool call as a failed one, not as a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - Wire self-attenuation on `/invoke` (#131) — presented proofs are additive-only; reduce authority via a narrower `Authority`, not subtractive tokens
 
 ### Fixed
+- An unanswered agent tool call is repaired on every conversation load (#271) — a turn aborted mid-tool-call no longer leaves a `tool_use` with no result, which providers reject outright and which permanently poisoned the session until a venue restart
 - Orchestration failure containment (#281) — a failed step no longer releases its dependents, and no further step starts once a run has failed, so a failed orchestration cannot apply downstream side effects
 - Orchestration specs are validated at construction (#281) — a malformed step or `result` spec fails before any step runs rather than mid-run with side effects already applied; note this rejects a bad spec even where execution would never have reached it
 - `a/<hash>` references resolve without a leading slash

--- a/venue/src/main/java/covia/adapter/agent/GoalTreeAdapter.java
+++ b/venue/src/main/java/covia/adapter/agent/GoalTreeAdapter.java
@@ -538,10 +538,26 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 				}
 				store = new FrameStore.LatticeFrameStore(agentState, sid, epoch, ctx.getCancellation());
 
+				// Drives frame settling below (:665) — a crash resume runs child
+				// frames, an operator stop does not. Repair is deliberately NOT
+				// gated on it; see below.
 				tidyInterrupted = !resuming && store.frames().count() > 1;
-				if (resuming || tidyInterrupted) {
+
+				// An unanswered tool call is simply a FAILED tool call (#271).
+				// Tool failures are already ordinary outcomes everywhere else —
+				// a timeout, a denial or malformed arguments all come back as an
+				// "Error: …" tool result the model reads and recovers from — so a
+				// call that never returned gets the same treatment, and the agent
+				// decides what to do. Repairing only when the session LOOKS
+				// crashed (resuming/tidyInterrupted) left any other abort — a
+				// cancelled transition, a failed CAS, a suspend — with a
+				// tool_use carrying no tool_result. Providers reject such a
+				// history outright, so one transient failure poisoned the session
+				// permanently, with nothing to heal it short of a venue restart.
+				// Repairing on every load makes that state unreachable.
+				if (store.frames().count() > 0) {
 					AString note = Strings.create(
-						"Error: venue restarted before this tool call returned — "
+						"Error: this tool call did not return — "
 						+ "its effects may or may not have applied; verify before retrying.");
 					if (!store.update(f -> GoalTreeContext.repairDanglingToolCalls(f, note))) {
 						return abortedOutput(store);

--- a/venue/src/test/java/covia/venue/GoalTreeCrashResumeTest.java
+++ b/venue/src/test/java/covia/venue/GoalTreeCrashResumeTest.java
@@ -176,13 +176,95 @@ public class GoalTreeCrashResumeTest {
 				15_000, "resumed cycle completes and releases the claim");
 
 			AVector<ACell> conv = rootConversation(engine, "boot-agent", sid);
-			assertEquals(1, countTurnsContaining(conv, "venue restarted"),
-				"exactly one synthetic restart result for the dangling call: " + conv);
+			assertEquals(1, countTurnsContaining(conv, "did not return"),
+				"exactly one synthetic error result for the dangling call: " + conv);
 			assertTrue(countTurnsContaining(conv, "gave up") > 0,
 				"the model continued from the synthetic result: " + conv);
 			assertEquals(1, countTurnsContaining(conv, "please use the slow tool"),
 				"no duplicated user turn on resume");
 
+			engine.close();
+			ns.close();
+		}
+	}
+
+	/**
+	 * An unanswered tool call is repaired WITHOUT a restart (#271).
+	 *
+	 * <p>Every other tool failure — timeout, denial, malformed arguments — already
+	 * comes back as an {@code "Error: …"} tool result the model reads and recovers
+	 * from. A call that never returned must be no different. Repair used to be
+	 * gated on the session looking crashed, so any other abort left a
+	 * {@code tool_use} with no {@code tool_result}; providers reject such a
+	 * history outright, so one transient failure poisoned the session
+	 * permanently — every later message on it failed while fresh sessions worked.</p>
+	 *
+	 * <p>{@code agent:suspend} reproduces it deterministically with no process
+	 * death: it cancels the in-flight transition AND clears the cycle claim, so
+	 * the session presents as perfectly clean while its conversation still holds
+	 * the dangling call. Nothing here restarts the venue.</p>
+	 */
+	@Test
+	public void testAbortedTurnRepairsWithoutRestart() throws Exception {
+		EtchStore store = EtchStore.createTemp();
+		AKeyPair kp = AKeyPair.generate();
+		String did = "did:key:" + Multikey.encodePublicKey(kp.getAccountKey());
+		AMap<AString, ACell> config = Maps.of(Config.DID, did,
+			Config.USERS, Maps.of(Config.AUTO_CREATE, true));
+		Blob sid = Blob.fromHex("cc112233445566778899aabbccddee09");
+
+		NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
+		ns.launch();
+		Engine engine = new Engine(config, ns.getCursor(), kp).start();
+		Engine.addDemoAssets(engine);
+		try {
+			createGoalAgent(engine, "nokill-agent", "v/test/ops/nevertoolllm");
+			agent(engine, "nokill-agent").ensureSession(sid, ALICE);
+
+			engine.jobs().invokeOperation(
+				"v/ops/agent/message",
+				Maps.of(Fields.AGENT_ID, "nokill-agent",
+					Fields.SESSION_ID, Strings.create(sid.toHexString()),
+					Fields.MESSAGE, Strings.create("please use the slow tool")),
+				RequestContext.of(ALICE)).awaitResult(5000);
+
+			await(() -> {
+				AVector<ACell> conv = rootConversation(engine, "nokill-agent", sid);
+				return conv != null && countTurnsContaining(conv, "toolCalls") > 0;
+			}, 10_000, "cycle parked in the never-tool");
+
+			// Abort the turn in place — no crash, no restart.
+			engine.jobs().invokeOperation(
+				"v/ops/agent/suspend",
+				Maps.of(Fields.AGENT_ID, "nokill-agent"),
+				RequestContext.of(ALICE)).awaitResult(5000);
+
+			// The poisoned shape: the session looks clean (no cycle claim), yet
+			// the conversation still carries a tool call with no result.
+			await(() -> agent(engine, "nokill-agent").getSessionCycleEpoch(sid) == null,
+				10_000, "cycle claim cleared by suspend");
+			assertTrue(countTurnsContaining(
+					rootConversation(engine, "nokill-agent", sid), "toolCalls") > 0,
+				"precondition: the dangling toolCall is still on the lattice");
+
+			engine.jobs().invokeOperation(
+				"v/ops/agent/resume",
+				Maps.of(Fields.AGENT_ID, "nokill-agent"),
+				RequestContext.of(ALICE)).awaitResult(5000);
+
+			// Next turn on the SAME session: loading the conversation must heal
+			// the dangling call rather than hand the provider an invalid history.
+			engine.jobs().invokeOperation(
+				"v/ops/agent/message",
+				Maps.of(Fields.AGENT_ID, "nokill-agent",
+					Fields.SESSION_ID, Strings.create(sid.toHexString()),
+					Fields.MESSAGE, Strings.create("are you still there")),
+				RequestContext.of(ALICE)).awaitResult(5000);
+
+			await(() -> countTurnsContaining(
+					rootConversation(engine, "nokill-agent", sid), "did not return") == 1,
+				10_000, "dangling call answered with a synthetic error result, no restart involved");
+		} finally {
 			engine.close();
 			ns.close();
 		}
@@ -378,8 +460,8 @@ public class GoalTreeCrashResumeTest {
 
 			// The resumed cycle finished the conversation in that session.
 			AVector<ACell> conv = rootConversation(engine, "mint-agent", sid);
-			assertEquals(1, countTurnsContaining(conv, "venue restarted"),
-				"exactly one synthetic restart turn");
+			assertEquals(1, countTurnsContaining(conv, "did not return"),
+				"exactly one synthetic error turn");
 
 			engine.close();
 			ns.close();


### PR DESCRIPTION
Fixes the session-poisoning half of #271.

## The principle

A tool call can fail for many reasons, and it is up to the agent to recover. That is **already** how this codebase works everywhere else — a timeout, a denied capability or malformed arguments all come back as an `"Error: …"` tool result the model reads and handles:

```java
// AbstractLLMAdapter.invokeOperation
} catch (TimeoutException e) {
    return Strings.create("Error: tool call timed out after " + timeoutMs + "ms");
} catch (Exception e) {
    return Strings.create("Error: " + unwrap(e).getMessage());
}
```

A call that never returned was the single exception: it was modelled as a **crash** needing recovery, rather than as a failure the agent can deal with.

## Why sessions got poisoned

Repair was gated on the session *looking* crashed:

```java
tidyInterrupted = !resuming && store.frames().count() > 1;
if (resuming || tidyInterrupted) { …repairDanglingToolCalls… }
```

So any other abort — a cancelled transition, a failed CAS, an operator suspend — left a `tool_use` with no matching `tool_result`. Providers reject that history outright, so one transient failure poisoned the session **permanently**: every later message failed deterministically while fresh sessions worked, with nothing to heal it short of a venue restart. That matches the reported incident exactly (venue never restarted).

## The fix removes a special case

Repair now runs whenever a conversation is loaded and has frames. The dangling call gets a synthetic error result, the agent sees it and decides — as for any other tool failure.

- no crash-versus-failure distinction
- no restart dependency
- **ask #3 of the issue evaporates** — no separate session-repair primitive is needed
- **ask #1 is deliberately not done** — trimming the dangling assistant message would destroy the record that `GoalTreeAdapter:1036` persists *on purpose* ("a crash mid-tools leaves a detectable dangling toolCall for resume, instead of losing the response")

`tidyInterrupted` still selects the frame driver (`resumeFrames` vs `runFrame`) at its original call site; only repair is decoupled from it. The flag conflated two questions — how to settle child frames is genuinely different from whether the conversation is valid.

The synthetic note no longer claims a restart happened (`"venue restarted before this tool call returned"` — crash-specific and usually untrue). It now reads `"this tool call did not return"`, honest in every case including a real restart. Two existing assertions updated accordingly.

## Deliberately **not** changed

Ask #2 (error propagation) looked like a one-line fix at `AgentAdapter:2508`, where a transition returning neither response nor error leaves the chat job unsettled. It is not a bug — the fall-through is the **yield** path (`// else: yield — keep slot reserved for the next wake`), and failing there would break agents that legitimately park across cycles. The empty-response symptom needs its own diagnosis with logs; note that once the session is no longer poisoned, the *repeated* failures it caused stop regardless.

## Test

Deterministic, no process death: an agent parks in `v/test/ops/never`, then `agent:suspend` aborts the turn in place — cancelling the transition **and** clearing the cycle claim, so the session presents as perfectly clean while still holding the dangling call. That is precisely the poisoned shape. The next message on the same session must heal it.

Verified to fail before the fix: *"timeout waiting for: dangling call answered with a synthetic error result, no restart involved"*.

Full suite green: venue 1898, covia-core, SQL 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
