### PR TITLE
Retire "ceiling" as authorisation terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - HITL requests (COG-16) — `hitl:request`/`respond`/`list` over the per-user `h/` inbox, typed asks, choice-bound grants with echo-consent, restart-safe expiry; `hitl` skill
 - `Hitl` builders (covia-core) — fluent, transport-portable construction of HITL requests, asks and responses
 - Federated job observation carries caller proofs — `X-Covia-Ucans` header on body-less job reads; cross-venue HITL verified end-to-end
-- Authenticated callers get public-user access per the public ceiling (#254) — reads, public jobs, DLFS, and secret resolution fallback (use-only, never extraction)
+- Authenticated callers get public-user access per the public scope (#254) — reads, public jobs, DLFS, and secret resolution fallback (use-only, never extraction)
 - `ucan:issue` is a granting surface — mints over another principal's resource under a presented `grant/<ability>` right, expiry-capped by the right's validity
 - Archive adapter (zip/jar) — `archive:list`/`extract`/`zip` over file roots, from/to a root file, CAS asset, or inline bytes; zip-slip + zip-bomb guarded. `file:read`/`list`/`stat`/`tree` see into archives via `x.zip!/entry` (jdk.zipfs, read-only, never fabricates an archive). `archive` skill
 - Orchestration `["array", <binding>...]` — builds an array computing each element, so a step input can reference prior steps inside an array (makes `v/ops/json/cond` usable in an orchestration); `["const", …]` freezes its subtree and cannot express this (#281)

--- a/covia-core/src/main/java/covia/grid/Authority.java
+++ b/covia-core/src/main/java/covia/grid/Authority.java
@@ -15,8 +15,8 @@ import convex.core.data.Vectors;
  * state (execution scopes, job id).
  *
  * <p><b>Two grant sources, one rule.</b> An action is authorised iff a grant
- * covers it — <em>either you have the right or you don't</em>. There is no
- * ceiling: nothing here subtracts. Grants arrive two ways, both additive:</p>
+ * covers it — <em>either you have the right or you don't</em>. Nothing
+ * subtracts. Grants arrive two ways, both additive:</p>
  * <ul>
  *   <li><b>{@code grants}</b> — the caller's own held capability scope (an
  *       agent's {@code config.caps}). {@code null} means an <em>unrestricted</em>

--- a/venue/docs/A2A_AGENTS.md
+++ b/venue/docs/A2A_AGENTS.md
@@ -106,7 +106,7 @@ flag is `a2a: { public: true, caps: … }` and has two levels:
   interaction).
 - adding `caps` makes it **interactable** by non-owners. A non-owner's
   `message/send` then runs the agent under the *owner's* identity narrowed by
-  that ceiling — `RequestContext.of(ownerDID).withCaps(ceiling)`. A ceiling can
+  that scope — `RequestContext.of(ownerDID).withCaps(scope)`. A scope can
   only narrow, so it is escalation-safe. `caps: "unrestricted"` is honoured
   (full owner authority for anonymous callers) with a warning, mirroring
   `auth.public.caps`; a public agent with **no** `caps` is discoverable but its
@@ -117,10 +117,10 @@ The operator's `defaultChatOp` front-door is the venue-level version of the
 public flag.
 
 The **run authority** for a non-owner interaction — whose identity executes, the
-ceiling applied, and how the public and delegated levers differ — is worked out
+scope applied, and how the public and delegated levers differ — is worked out
 in [A2A_INTERACTION_AUTHORITY.md](./A2A_INTERACTION_AUTHORITY.md). In short: the
 agent always runs under its *owner's* identity; the levers are pure admission; a
-public run is narrowed by `a2a.caps`; the named-delegate ceiling (gated by a
+public run is narrowed by `a2a.caps`; the named-delegate scope (gated by a
 dedicated `agent/request` ability) and initiator-provenance are pending
 ratification there.
 
@@ -179,5 +179,5 @@ Logical pieces this design implies (not an implementation plan):
   agent list/info read surface.
 - The interaction mapping shifting from `Task = Job` to `context = session,
   task = task`.
-- The per-agent public flag and its attenuated anonymous ceiling, alongside the
+- The per-agent public flag and its attenuated anonymous scope, alongside the
   existing UCAN delegation path.

--- a/venue/docs/A2A_INTERACTION_AUTHORITY.md
+++ b/venue/docs/A2A_INTERACTION_AUTHORITY.md
@@ -43,14 +43,14 @@ Any run — owner-initiated or not — is bounded by the intersection of:
   (the `CapabilityChecker` gate on its tool calls) bounds what the agent may
   *ever* do, independent of any caller — including the owner's own interactions.
   This is the owner's standing statement: "this is what my agent is allowed to
-  do." It is the **absolute ceiling** on every run.
+  do." It is the **absolute bound** on every run.
 
 - **Layer 1 — admission.** Owner (always); anonymous/public (via the agent's
   public flag); a named delegate (via a UCAN grant). Denials are leak-shaped —
   an anonymous caller gets *not-found*, an authenticated caller without standing
   gets *forbidden* — so the address space is not a disclosure oracle.
 
-- **Layer 2 — the interaction ceiling.** A *further* narrowing applied to the
+- **Layer 2 — the interaction scope.** A *further* narrowing applied to the
   owner-identity run when the initiator is **not** the owner, so that an outside
   party can never drive the agent at the owner's unrestricted authority even
   within Layer 0. This is the new concept this document pins down.
@@ -72,7 +72,7 @@ it was admitted. Collapsing the two (recording only the owner as "caller") loses
 the accountability the venue exists to provide — "who caused this" is exactly the
 question a system of record must answer. This is a required field, not a nicety.
 
-## The interaction ceiling, per admission class
+## The interaction scope, per admission class
 
 Layer 2 is the open design point. Its value depends only on **how the caller was
 admitted** (Layer 1), never on the caller's own ambient authority:
@@ -81,7 +81,7 @@ admitted** (Layer 1), never on the caller's own ambient authority:
   Layer 0.
 
 - **Public / anonymous** — bounded by the agent's configured **`a2a.caps`**,
-  the *public interaction ceiling*. This is a required, owner-declared bound: a
+  the *public interaction scope*. This is a required, owner-declared bound: a
   public agent with no `a2a.caps` is discoverable (its card) but **not
   interactable** — the owner must deliberately bound what an anonymous run may
   do. `a2a.caps: "unrestricted"` is honoured (with a warning) as the owner's
@@ -96,14 +96,14 @@ admitted** (Layer 1), never on the caller's own ambient authority:
   "unrestricted is honoured because the owner chose it" rule, one step stronger:
   issuing a capability that names a specific principal *and* a specific agent is
   a deliberate, higher-bar trust decision than flipping a public flag, so it
-  warrants at least the authority the public ceiling could grant. The owner may
-  optionally attach a **narrower** ceiling to a specific grant to restrict that
+  warrants at least the authority the public scope could grant. The owner may
+  optionally attach a **narrower** scope to a specific grant to restrict that
   delegate further (narrowing-only — a grant can never widen beyond Layer 0).
 
 The invariant this produces:
 
-> `a2a.caps` is the **public** interaction ceiling — not "all non-owner". Layer 0
-> (the agent's own config caps) is the absolute ceiling for **every** run. No
+> `a2a.caps` is the **public** interaction scope — not "all non-owner". Layer 0
+> (the agent's own config caps) is the absolute bound for **every** run. No
 > interaction, by anyone other than the owner, can ever cause the agent to exceed
 > Layer 0.
 
@@ -111,7 +111,7 @@ The trade-off to weigh: a uniform "`a2a.caps` bounds *every* non-owner run,
 delegates included" is simpler to reason about, but it makes a named grant unable
 to express more trust than the anonymous public gets — which defeats the point of
 naming a delegate. The recommendation above keeps the two admission classes with
-distinct ceilings; the alternative collapses them. This is the decision to ratify.
+distinct scopes; the alternative collapses them. This is the decision to ratify.
 
 ## Admission mechanics (logical)
 
@@ -131,7 +131,7 @@ distinct ceilings; the alternative collapses them. This is the decision to ratif
 
 Both levers are pure **admission**; neither changes the execution identity (still
 the owner) — they only decide whether a run happens and, for the public lever,
-which ceiling applies.
+which scope applies.
 
 ## Lifecycle and boundaries
 
@@ -160,10 +160,10 @@ which ceiling applies.
 
 ## Decisions to ratify
 
-1. **Named-delegate ceiling** — Layer-0-only by default (recommended), vs a
+1. **Named-delegate scope** — Layer-0-only by default (recommended), vs a
    uniform `a2a.caps` for all non-owner runs, vs a separate owner-configured
-   "delegated ceiling". This is the central call.
-2. **Per-grant narrowing** — support an optional narrower ceiling attached to a
+   "delegated scope". This is the central call.
+2. **Per-grant narrowing** — support an optional narrower scope attached to a
    specific grant now, or defer to C2.
 3. **Initiator provenance** — the field/shape recording the initiator alongside
    the owner authority on a non-owner task/session (name, and whether it also

--- a/venue/docs/AGENT_CONTEXT.md
+++ b/venue/docs/AGENT_CONTEXT.md
@@ -407,7 +407,7 @@ The capability this unification adds: **agent-managed entries are no longer path
 
 - **Resolver & rendering** — identical for both roles: the contract in §3.6 (skip-absent, fail-visible, required-throws; string verbatim, structured value as budget-bounded JSON5).
 - **One budget** — a single per-agent context budget. Each entry, in either role, carries a per-entry byte budget (declared or derived) that bounds its rendering and is accounted against the total.
-- **Context map** — one live inventory lists every loaded entry with its role, label, and budget, plus total usage and a near-ceiling warning. Configured entries become visible and accounted consistently — today they consume budget but appear in neither the context map nor the safety valve, so a heavy pinned entry can silently starve the working set with no signal.
+- **Context map** — one live inventory lists every loaded entry with its role, label, and budget, plus total usage and a near-scope warning. Configured entries become visible and accounted consistently — today they consume budget but appear in neither the context map nor the safety valve, so a heavy pinned entry can silently starve the working set with no signal.
 
 ### 8.4 What differs — role semantics only
 

--- a/venue/docs/AGENT_TEMPLATES.md
+++ b/venue/docs/AGENT_TEMPLATES.md
@@ -299,7 +299,7 @@ A `manager` agent decides the pipeline at runtime by calling `agent_request` on 
 
 ### Capabilities for handoff
 
-A worker can read a handoff path **only if its capability ceiling covers it** — sharing the owner's namespace is not sufficient. An agent's `config.caps` narrows it to exactly the listed `{with, can}` grants (`ContextBuilder` applies `ctx.withCaps(caps)` to the transition context); an agent with **no** `caps` runs with the owner's full authority and can read any of the owner's paths.
+A worker can read a handoff path **only if its capability scope covers it** — sharing the owner's namespace is not sufficient. An agent's `config.caps` narrows it to exactly the listed `{with, can}` grants (`ContextBuilder` applies `ctx.withCaps(caps)` to the transition context); an agent with **no** `caps` runs with the owner's full authority and can read any of the owner's paths.
 
 So for a pipeline of *capped* workers, provision the handoff area explicitly:
 

--- a/venue/docs/CONFIG.md
+++ b/venue/docs/CONFIG.md
@@ -159,10 +159,10 @@ explicit `enabled` always wins.
 ```
 
 Anonymous callers are attributed to `<venueDID>:public` under the public
-capability ceiling: unset `caps` → the secure read-only default; an explicit
-`{with, can}` array → that ceiling; `"unrestricted"` → no ceiling (loopback
+capability scope: unset `caps` → the secure read-only default; an explicit
+`{with, can}` array → that scope; `"unrestricted"` → no scope (loopback
 dev only). Authenticated callers hold the public-user grants ambiently
-(covia#254) — the ceiling governs both. See `docs/UCAN.md` §4.7.
+(covia#254) — the scope governs both. See `docs/UCAN.md` §4.7.
 
 ## User registration (`users`)
 
@@ -387,7 +387,7 @@ registered **only** when an `a2a` block is present. Without it, `POST /a2a` and
   `organization`/`providerUrl` for the card's `provider`). All optional.
 
 **Auth note:** `message/send` invokes `defaultChatOp` as the *calling*
-identity. Under the default read-only public ceiling an unauthenticated caller
+identity. Under the default read-only public scope an unauthenticated caller
 cannot invoke, so the Task comes back `TASK_STATE_FAILED`. To exercise
 `message/send` from an unauthenticated client, either authenticate the caller
 or widen `auth.public.caps` to permit the op — do the latter only on a
@@ -401,8 +401,8 @@ addressable at `POST /a2a/<ownerDID>/g/<agentId>` (JSON-RPC `SendMessage` →
 base. Private by default: the owner interacts as themselves; anonymous
 non-owners get an existence-hiding 404, authenticated non-owners 403.
 Publishing is per-agent config: `a2a: {public: true}` makes the card
-discoverable; adding an explicit `a2a.caps` ceiling accepts stranger
-messages, dispatched as the OWNER narrowed by that ceiling — it must include
+discoverable; adding an explicit `a2a.caps` scope accepts stranger
+messages, dispatched as the OWNER narrowed by that scope — it must include
 `agent/request` plus whatever the agent's own work needs. `"unrestricted"`
 grants full owner authority (logged loudly). Wire method names are SDK-style
 (`SendMessage`, not `message/send`). Per-agent task continuation (incoming

--- a/venue/docs/READ_API.md
+++ b/venue/docs/READ_API.md
@@ -95,7 +95,7 @@ CoviaAdapter
   ```
 
   — calls the accessor, and serialises via `buildResult(ctx, 200, value)`. No job,
-  no future, no adapter dispatch. The caller's ceiling and UCAN proofs ride along
+  no future, no adapter dispatch. The caller's scope and UCAN proofs ride along
   inside the accessor's `requireCapability`.
 
 `aggregate` is one new pure function that walks the value the read already
@@ -308,9 +308,9 @@ those routes are simply not ETagged (honest, rather than a subtly-broken validat
 Unchanged from the invoke path; only the job is dropped.
 
 - `AuthMiddleware` already runs `before("/api/*")`, so caller identity, the
-  public-read ceiling, and any presented UCAN are attached before the handler.
+  public-read scope, and any presented UCAN are attached before the handler.
 - The accessor calls `ctx.requireCapability(path, "crud/read")`. Unauthenticated
-  callers carry the read-only public ceiling (`crud/read` + `asset/read`), so they
+  callers carry the read-only public scope (`crud/read` + `asset/read`), so they
   can read public / their-own data and are denied cross-user paths unless a UCAN
   proof covers them — **exactly** as `covia:read` via invoke behaves today.
 - Cap denied → **403**. Auth required (no token, public access disabled) → **401**.
@@ -338,7 +338,7 @@ a fully-qualified path works anywhere a relative one does.
 **Capability enforcement is what differs, not the plumbing.** The accessor calls
 `requireCapability` with the full DID-URL resource, so:
 
-- own DID (relative or qualified) → allowed under the normal ceiling;
+- own DID (relative or qualified) → allowed under the normal scope;
 - another user's DID → **denied (403)** unless the caller presents a UCAN proof
   whose resource covers that DID-URL path — identical to `covia:read` today.
 

--- a/venue/docs/SKILLS.md
+++ b/venue/docs/SKILLS.md
@@ -289,7 +289,7 @@ One command-dispatched op at `v/ops/skills` (tool name `skills`), following the 
 | `list` | `sources?` (defaults to `["w/skills", "v/skills"]`) | The rendered index text — a string, or null when no skills exist (the assemble-op contract: null → entry skipped) |
 | `read` | exactly one of `name` (looked up across `sources?`) / `ref` | `{name, description, body?, tools, context?, path}` — `body` present when the skill has content |
 
-Capability pins, per source actually read: workspace/venue/DID paths → `crud/read`; content-addressed refs → `asset/read`. Both sit inside the anonymous read-only ceiling, so venue skills are publicly discoverable. There is **no write surface** — skills are authored with `covia:write` and `asset:store`.
+Capability pins, per source actually read: workspace/venue/DID paths → `crud/read`; content-addressed refs → `asset/read`. Both sit inside the anonymous read-only scope, so venue skills are publicly discoverable. There is **no write surface** — skills are authored with `covia:write` and `asset:store`.
 
 Because `list` honours the assemble-op contract, an operator can pin the index into any agent the data-driven way instead of using `config.skills`:
 

--- a/venue/docs/UCAN.md
+++ b/venue/docs/UCAN.md
@@ -111,7 +111,7 @@ This aligns with `DIDURL` from convex-core — the DID is the authority, the pat
 
 **Canonical vs. shorthand.** A canonical `with` is absolute (owner-named) as above; a **bare** lattice path is shorthand whose owner is implied by context, always the same principal: **the authority whose grant it is**.
 
-- **Agent caps (config ceilings)**: a bare `w/projects/foo` is the *caller's own* resource; enforcement canonicalises it to `<callerDID>/w/projects/foo` before matching, so bare and DID-URL grants compare identically. The same applies to bare `dlfs/<drive>/…` paths.
+- **Agent caps (config scopes)**: a bare `w/projects/foo` is the *caller's own* resource; enforcement canonicalises it to `<callerDID>/w/projects/foo` before matching, so bare and DID-URL grants compare identically. The same applies to bare `dlfs/<drive>/…` paths.
 - **Signed UCAN tokens**: a bare `with` means the **token issuer's own** namespace, resolved at evaluation against the token's signed `iss` (`CapabilityChecker.normaliseProofs`, applied inside `proofsCover` recursively per chain hop — a bare path in a re-delegation binds to the re-delegator). A self-sovereign owner can therefore sign bare paths naturally; they can never be reinterpreted against the presenter or the target.
 - **Custodial issuance** (`ucan:issue`): the venue signs for its own resources or a locally managed `did:web:<host>:u:<user>`, so its `iss` is not the caller — bare paths are absolutised to the *caller's* DID before signing (§4.1). Self-sovereign owners sign client-side. Tokens minted by the venue always carry the canonical form.
 
@@ -183,10 +183,10 @@ Semantics (see `CapabilityChecker.allows` and `JobManager.evaluateGate`):
   gate unresolvable, times out (30s), or no evaluator in scope → denied.
   Never fail-open.
 - **Execution authority**: the gate runs under the *caller's own* authority
-  with no capability ceiling — a ceiling-less context never evaluates gates
+  with no capability scope — a scope-less context never evaluates gates
   for the gate's own sub-invocations, which is the recursion guard. No Job
   is created for gate checks.
-- **Scope (phase 1)**: agent `config.caps` and any venue-side ceiling. Gates
+- **Scope (phase 1)**: agent `config.caps` and any venue-side scope. Gates
   in *delegated UCAN tokens* additionally require caveat collection along
   the proof chain so a delegatee cannot drop a parent's gate — that lands
   with Convex-Dev/convex#643 (tracked in covia#221).
@@ -428,10 +428,10 @@ Revocations are published to the lattice. Venues check revocation
 lists during verification. Revoking a parent invalidates all
 downstream delegations.
 
-### 4.7 Authenticating — lifting the public read-only ceiling
+### 4.7 Authenticating — lifting the public read-only scope
 
 An unauthenticated caller runs under the venue's public identity, whose
-default ceiling is **read-only** (`crud/read` on its own namespace + `asset/read`;
+default scope is **read-only** (`crud/read` on its own namespace + `asset/read`;
 no `invoke`, so `POST /api/v1/invoke` of a compute op returns a `FAILED` job with
 `"Capability denied"`). Two ways to gain invoke/write authority:
 
@@ -441,8 +441,8 @@ no `invoke`, so `POST /api/v1/invoke` of a compute op returns a `FAILED` job wit
    unrestricted within its own namespace (own-namespace implicit grant, §5.1).
    The SDKs mint and attach this for you (Ed25519 keypair auth); the MCP and
    REST endpoints both honour the header (§4.3).
-2. **Widen the public ceiling (operator, trusted venues only)** — set
-   `auth.public.caps` in the venue config. `"unrestricted"` removes the ceiling
+2. **Widen the public scope (operator, trusted venues only)** — set
+   `auth.public.caps` in the venue config. `"unrestricted"` removes the scope
    for anonymous callers entirely; an array of `{with, can}` grants widens it
    selectively. Only do this on a loopback-bound (`bindAddress: 127.0.0.1`)
    development venue, never a LAN/public-reachable one — it hands invoke
@@ -534,14 +534,14 @@ naturally:
 Granting `crud` (without a verb suffix) covers read+write+delete uniformly;
 trailing-slash on the resource is the conventional way to cover a subtree.
 
-**Own-namespace enforcement (ceiling).** The points above are the cross-user
+**Own-namespace enforcement (scope).** The points above are the cross-user
 checks (a *grant* of access to someone else's resource). A caller running under
 a **narrower Authority** — an agent started with `config.caps` (§5.4) — has the
-same capability check applied to its **own** operations as a *ceiling*: the op's
+same capability check applied to its **own** operations as a *scope*: the op's
 resource and each grant's `with` are canonicalised to absolute owner-scoped form
 (a bare `w/health/bp` → `<callerDID>/w/health/bp`; DID-URL and `file://`/`dlfs://`
 left as-is), then matched with `Capability.covers`. Own and cross-user resources
-thus match by one rule. A caller with no ceiling (the null-caps fast path) holds
+thus match by one rule. A caller with no scope (the null-caps fast path) holds
 the full implicit grant and is unaffected.
 
 ### 5.4 Agent Identity Models
@@ -639,7 +639,7 @@ operates within one user's namespace with restricted permissions.
 5. Tool calls go through CoviaAdapter which verifies the token against the requested path/ability
 6. Writes outside the allowed scope are denied
 
-**Reading an agent's live caps.** An agent's ceiling lives at `config.caps`,
+**Reading an agent's live caps.** An agent's scope lives at `config.caps`,
 so read it via the config: `agent:info` (returns the record, whose `config.caps`
 holds the array) or `covia:read g/<agentId>` then `.value.config.caps`. There is
 **no** `g/<agentId>/caps` projection — `covia:read g/<agentId>/caps` returns
@@ -768,9 +768,9 @@ a RequestContext for the tool invocation. The context determines enforcement:
 Two complementary checks apply, both built on the same `Capability.covers`
 matcher over canonical owner-scoped resources (§3.1):
 
-- **`CapabilityChecker`** enforces a *ceiling* — the agent's config `caps`
+- **`CapabilityChecker`** enforces a *scope* — the agent's config `caps`
   (§5.4) — on every operation (`enforceCaps` at job dispatch, and before each
-  tool call). A ceiling can only narrow.
+  tool call). A scope can only narrow.
 - **`CoviaAdapter.verifyProofs()`** authorises *cross-user* access against
   presented proofs (§5.2). A proof grants reach into another namespace.
 
@@ -782,15 +782,15 @@ For Model A, the key change is that the agent's tool calls go through a
 The venue becomes the enforcement mechanism — it issued the scoped token
 and it verifies it on every tool call.
 
-#### The `invoke` ability under a ceiling (#211)
+#### The `invoke` ability under a scope (#211)
 
 Invoke-classed operations (compute, LLM, external I/O, federation — anything
 that does not act on a specific named lattice resource) require the `invoke`
-ability. Under a restricted `config.caps` ceiling:
+ability. Under a restricted `config.caps` scope:
 
 - **Full tool access** is a one-liner: `{"can": "invoke"}` (or the equivalent
   `{"with": "", "can": "invoke"}`) — an empty/absent `with` is a match-any
-  wildcard in the ceiling path. The standard restricted-but-tool-capable
+  wildcard in the grant-scope path. The standard restricted-but-tool-capable
   recipe is therefore:
 
   ```json
@@ -809,7 +809,7 @@ ability. Under a restricted `config.caps` ceiling:
 
 - **Caveat:** invoking by hex hash (or from resolved metadata directly)
   carries no path, so only the wildcard grant covers it — a path-scoped
-  invoke ceiling denies hash-form invocation by design (fail-closed).
+  invoke grant denies hash-form invocation by design (fail-closed).
 
 ### 5.6 Trust Anchors and Federation
 

--- a/venue/src/main/java/covia/venue/RequestContext.java
+++ b/venue/src/main/java/covia/venue/RequestContext.java
@@ -21,7 +21,8 @@ import covia.lattice.CapabilityGate;
  * <p>Authorisation lives on the {@code Authority}: an action is allowed iff a
  * grant covers it — <em>either you have the right or you don't</em>. A
  * {@code null} capability scope ({@link #getCaps()}) is an unrestricted
- * principal (the fast path), not a ceiling; presented proofs are additive.</p>
+ * principal (the fast path) with no bounding grants; nothing subtracts, and
+ * presented proofs are additive.</p>
  */
 public class RequestContext {
 
@@ -349,7 +350,7 @@ public class RequestContext {
 	/**
 	 * Gets the caller's held capability scope, or null if unrestricted. When
 	 * non-null, an operation is authorised only if a grant in the scope covers
-	 * it (there is no ceiling — a null scope simply has no bounding grants).
+	 * it; a null scope simply has no bounding grants (nothing subtracts).
 	 */
 	public AVector<ACell> getCaps() {
 		return authority.getGrants();
@@ -389,7 +390,7 @@ public class RequestContext {
 	 * gate}.
 	 *
 	 * <p>Bare paths canonicalise against {@link #getUserDID()}, not the caller —
-	 * this is the single point at which the ceiling path decides <em>whose
+	 * this is the single point at which the grant-scope check decides <em>whose
 	 * namespace</em> {@code w/foo} names. For an agent that is its owner's, so a
 	 * {@code config.caps} grant of {@code w/decisions/} keeps meaning the owner's
 	 * workspace once the agent has a DID of its own. The request resource and


### PR DESCRIPTION
"Ceiling" was the old name for the capability-scope model, dropped in the authority refactor (#262) because it was misleading — it implied `config.caps` sets a *maximum* that grants subtract from. The model is purely **additive**: an action is allowed iff a grant covers it, and a `null` scope means "no bounding grants", not "a ceiling of everything". The private `ceilingDenial` was already renamed `grantsDenial`; the word lingered in comments and docs, and I reintroduced one affirmative use in #280.

## Code

- **One affirmative misuse fixed** — `RequestContext.grantsDenial` javadoc called the grant-scope check "the ceiling path" (my #280 regression) → "the grant-scope check".
- **Three concept-denials reworded** — `"there is no ceiling…"` in `RequestContext` (×2) and `Authority` stated the additive model *by naming the term they were rejecting*. Now they state it positively without invoking it.

## Docs

Swept across 8 files. `ceiling` → **`scope`** for the grant-scope concept (public / capability / config / interaction / read-only / anonymous / …), and → **`bound`** where it specifically meant a maximum (A2A Layer 0, "absolute bound"). The A2A design doc's coined **"interaction ceiling"** is the same grant-scope concept and is now **"interaction scope"** — flagging that one explicitly since it was load-bearing vocabulary in a design doc; revert that rename if the term was deliberate.

## Deliberately left unchanged

- **Ordinary English "upper bound"** — `RetryPolicy`/`VenueHTTP` backoff & poll-delay ceilings, `EnginePersistence` awaitTermination ceiling, `RetryPolicyTest` backoff ceiling, and `READ_API` **"Byte ceiling"** (a byte-size limit). None of these are the authorisation concept.
- **CHANGELOG released-version entries** (0.6.0, 0.3.0) — an append-only record of what shipped at the time. Only the `[Unreleased]` entry was updated.

## Verification

No behaviour change — comments and docs only. `covia-core` compiles; auth suite green (`UCANTest` 30, `PublicScopeTest` 5, `RequestContextAuthorityTest` 5). A grep confirms the only remaining `ceiling` tokens are the intentional English/history ones listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
