### PR TITLE
fix(deploy): stop double-invoking java in EC2/Azure containers

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -85,11 +85,14 @@ jobs:
           # Wait for the health check to settle; fail the deploy rather than
           # leaving a crash-looping container behind a green checkmark.
           status="starting"
-          for i in $(seq 1 18); do
+          # Cover the full health window: 15s start period + three 30s
+          # intervals + check time, with a final boundary inspection.
+          for i in $(seq 1 25); do
             status=$(docker inspect --format='{{.State.Health.Status}}' covia-venue 2>/dev/null || echo "unknown")
             echo "Health status: $status"
             [ "$status" = "healthy" ] && break
-            sleep 5
+            [ "$status" = "unhealthy" ] && break
+            [ "$i" -lt 25 ] && sleep 5
           done
           if [ "$status" != "healthy" ]; then
             echo "::error::covia-venue did not become healthy — deploy failed"

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -62,12 +62,17 @@ jobs:
           docker stop covia-venue 2>/dev/null || true
           docker rm covia-venue 2>/dev/null || true
 
-          # Run new container
+          # Run new container. The image's ENTRYPOINT already invokes java and
+          # forwards CMD as arguments to MainVenue (see Dockerfile) — CMD must
+          # be just the config path, not a full java command line, or the
+          # entrypoint double-invokes java and MainVenue receives "java" as
+          # its config path instead of the real one.
           docker run -d \
             --name covia-venue \
             --stop-timeout 30 \
             -p 8080:8080 \
             -v /home/azureuser/covia-data:/data \
+            -e JAVA_OPTS="-Xmx2g -XX:+UseContainerSupport -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8" \
             --restart unless-stopped \
             --health-cmd='curl -f --max-time 3 http://localhost:8080/' \
             --health-interval=30s \
@@ -75,11 +80,22 @@ jobs:
             --health-start-period=15s \
             --health-retries=3 \
             ghcr.io/covia-ai/covia:latest \
-            java -Xmx2g -XX:+UseContainerSupport -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8 -jar covia.jar /data/config.json
+            /data/config.json
 
-          # Wait for health check
-          sleep 10
-          docker inspect --format='{{.State.Health.Status}}' covia-venue
+          # Wait for the health check to settle; fail the deploy rather than
+          # leaving a crash-looping container behind a green checkmark.
+          status="starting"
+          for i in $(seq 1 18); do
+            status=$(docker inspect --format='{{.State.Health.Status}}' covia-venue 2>/dev/null || echo "unknown")
+            echo "Health status: $status"
+            [ "$status" = "healthy" ] && break
+            sleep 5
+          done
+          if [ "$status" != "healthy" ]; then
+            echo "::error::covia-venue did not become healthy — deploy failed"
+            docker logs --tail 80 covia-venue
+            exit 1
+          fi
 
           # Prune old images
           docker image prune -f

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -58,12 +58,17 @@ jobs:
           # Container runs as UID 1001 (appuser) — grant write access to data dir
           sudo chown -R 1001:1001 /home/ec2-user/covia-data
 
-          # Run new container
+          # Run new container. The image's ENTRYPOINT already invokes java and
+          # forwards CMD as arguments to MainVenue (see Dockerfile) — CMD must
+          # be just the config path, not a full java command line, or the
+          # entrypoint double-invokes java and MainVenue receives "java" as
+          # its config path instead of the real one.
           docker run -d \
             --name covia-venue \
             --stop-timeout 30 \
             -p 8080:8080 \
             -v /home/ec2-user/covia-data:/data \
+            -e JAVA_OPTS="-Xmx2g -XX:+UseContainerSupport -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8" \
             --log-driver=awslogs \
             --log-opt awslogs-region=ap-southeast-1 \
             --log-opt awslogs-group=/covia/venue \
@@ -76,11 +81,22 @@ jobs:
             --health-start-period=15s \
             --health-retries=3 \
             ghcr.io/covia-ai/covia:latest \
-            java -Xmx2g -XX:+UseContainerSupport -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF-8 -jar covia.jar /data/config.json
+            /data/config.json
 
-          # Wait for health check
-          sleep 10
-          docker inspect --format='{{.State.Health.Status}}' covia-venue
+          # Wait for the health check to settle; fail the deploy rather than
+          # leaving a crash-looping container behind a green checkmark.
+          status="starting"
+          for i in $(seq 1 18); do
+            status=$(docker inspect --format='{{.State.Health.Status}}' covia-venue 2>/dev/null || echo "unknown")
+            echo "Health status: $status"
+            [ "$status" = "healthy" ] && break
+            sleep 5
+          done
+          if [ "$status" != "healthy" ]; then
+            echo "::error::covia-venue did not become healthy — deploy failed"
+            docker logs --tail 80 covia-venue
+            exit 1
+          fi
 
           # Prune old images
           docker image prune -f

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -86,11 +86,14 @@ jobs:
           # Wait for the health check to settle; fail the deploy rather than
           # leaving a crash-looping container behind a green checkmark.
           status="starting"
-          for i in $(seq 1 18); do
+          # Cover the full health window: 15s start period + three 30s
+          # intervals + check time, with a final boundary inspection.
+          for i in $(seq 1 25); do
             status=$(docker inspect --format='{{.State.Health.Status}}' covia-venue 2>/dev/null || echo "unknown")
             echo "Health status: $status"
             [ "$status" = "healthy" ] && break
-            sleep 5
+            [ "$status" = "unhealthy" ] && break
+            [ "$i" -lt 25 ] && sleep 5
           done
           if [ "$status" != "healthy" ]; then
             echo "::error::covia-venue did not become healthy — deploy failed"


### PR DESCRIPTION
## Summary

`1fb06a7` changed the Dockerfile's `CMD` to an `ENTRYPOINT` that execs `java` itself and forwards `CMD` as arguments to `MainVenue` (so `docker run IMAGE /path/to/config.json` works without repeating the java command). `deploy-ec2.yml` and `deploy-azure.yml` were never updated to match — they still pass the old-style full `java -Xmx2g ... -jar covia.jar /data/config.json` as `CMD`, which the new entrypoint appends *after* its own `java` invocation instead of replacing it. The container ends up running:

```
java $JAVA_OPTS -jar /app/covia.jar java -Xmx2g ... -jar covia.jar /data/config.json
```

so `MainVenue` receives `"java"` as its first argument (its config path) instead of the real path, and crashes immediately with `FileNotFoundException: File does not exist: /java` — forever, since the restart policy just keeps retrying the identical broken command.

Every deploy since `1fb06a7` (2026-07-25 14:07 UTC) has silently replaced the running venue with a crash-looping container on **both** venue-3 (EC2) and venue-4 (Azure), while the workflows reported green the whole time — the "wait for health check" step only printed `docker inspect ... Health.Status`, it never checked it. Confirmed by SSHing into both boxes: venue-4's container was `Exited (66)` in a restart loop, and venue-3's Docker container was also crash-looping (masked only by an unrelated legacy systemd process that happened to still be running from before the Docker migration).

## Fix

- `CMD` is now just the config path (`/data/config.json`), matching the entrypoint's documented contract in the Dockerfile.
- The deploy's intended JVM tuning (`-Xmx2g`, `-XX:+ExitOnOutOfMemoryError`) moves to `-e JAVA_OPTS=...` so it isn't silently dropped now that it's not riding along on the command line.
- The health-check wait now actually **fails the job** (`exit 1`, with the container's logs printed) if the container doesn't reach `healthy` within its own start-period/retries window, instead of only printing the status. This is the guardrail that should have caught this the first time.

## Test plan

- [x] YAML syntax validated (`yaml.safe_load`)
- [ ] Manually verified the corrected `docker run` invocation against the current image on both venue-3 and venue-4 (recreated the containers by hand with the same fixed command during the incident; both came up healthy and serving `/api/v1/status`)
- [ ] After merge, confirm the next real `Deploy to EC2` / `Deploy to Azure` run completes with a `healthy` container and would correctly fail if it didn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)