### PR TITLE
feat(agent): implement session title on agent sessions

### DIFF
--- a/venue/src/main/java/covia/adapter/AgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/AgentAdapter.java
@@ -210,6 +210,7 @@ public class AgentAdapter extends AAdapter {
 		installAsset("agent/complete-task", BASE + "completeTask.json");
 		installAsset("agent/fail-task",     BASE + "failTask.json");
 		installAsset("agent/delete-session", BASE + "deleteSession.json");
+		installAsset("agent/rename-session", BASE + "renameSession.json");
 
 		// Install standard agent templates at v/agents/templates/<name>.
 		// Discoverable via covia_list path=v/agents/templates and usable in
@@ -408,7 +409,7 @@ public class AgentAdapter extends AAdapter {
 			case "create", "fork" -> Abilities.AGENT_CREATE;
 			case "request"        -> Abilities.AGENT_REQUEST;
 			case "message", "chat" -> Abilities.AGENT_MESSAGE;
-			case "delete", "suspend", "resume", "update", "cancelTask", "deleteSession" -> Abilities.AGENT_WRITE;
+			case "delete", "suspend", "resume", "update", "cancelTask", "deleteSession", "renameSession" -> Abilities.AGENT_WRITE;
 			default -> null; // info/list/context (reads), trigger, completeTask/failTask
 		};
 		if (ability == null) return;
@@ -455,6 +456,7 @@ public class AgentAdapter extends AAdapter {
 				case "update"       -> handleUpdate(job, input, ctx);
 				case "cancelTask"   -> handleCancelTask(job, input, ctx);
 				case "deleteSession" -> handleDeleteSession(job, input, ctx);
+				case "renameSession" -> handleRenameSession(job, input, ctx);
 				case "completeTask" -> handleCompleteTask(job, input, ctx);
 				case "failTask"     -> handleFailTask(job, input, ctx);
 				default             -> job.fail("Unknown agent operation: " + getSubOperation(meta));
@@ -1652,6 +1654,47 @@ public class AgentAdapter extends AAdapter {
 			Fields.AGENT_ID,   agentId,
 			Fields.SESSION_ID, sidHex,
 			Fields.DELETED,    CVMBool.TRUE));
+	}
+
+	/**
+	 * Sets or clears a session's free-form {@code title} (docs/AGENT_SESSIONS.md
+	 * §4.3 — the field the "suggested" session meta shape always documented
+	 * but the framework never implemented). An absent or blank {@code title}
+	 * clears it back to unset — callers wanting the auto-derived
+	 * first-message label (client-side) just don't set one.
+	 */
+	private void handleRenameSession(Job job, ACell input, RequestContext ctx) {
+		AString agentId = RT.ensureString(RT.getIn(input, Fields.AGENT_ID));
+		if (agentId == null) { job.fail("agentId is required"); return; }
+
+		AString sidHex = RT.ensureString(RT.getIn(input, Fields.SESSION_ID));
+		if (sidHex == null) { job.fail("sessionId is required"); return; }
+
+		AgentState agent = lookupAgent(job, ctx.getUserDID(), agentId);
+		if (agent == null) return;
+
+		Blob sid;
+		try {
+			sid = Blob.fromHex(sidHex.toString());
+		} catch (Exception e) {
+			sid = null;
+		}
+		if (sid == null) { job.fail("Invalid sessionId format: " + sidHex); return; }
+
+		AString title = RT.ensureString(RT.getIn(input, Fields.TITLE));
+		if (title != null && title.toString().isBlank()) title = null;
+
+		if (!agent.setSessionTitle(sid, title)) {
+			job.fail("Session not found: " + sidHex);
+			return;
+		}
+
+		job.setStatus(Status.STARTED);
+		AMap<AString, ACell> result = Maps.of(
+			Fields.AGENT_ID,   agentId,
+			Fields.SESSION_ID, sidHex);
+		if (title != null) result = result.assoc(Fields.TITLE, title);
+		job.completeWith(result);
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/AgentState.java
+++ b/venue/src/main/java/covia/venue/AgentState.java
@@ -562,6 +562,34 @@ public class AgentState extends ALatticeComponent<ACell> {
 	}
 
 	/**
+	 * Sets (or clears, when {@code title} is null) the free-form human-facing
+	 * title in a session's {@code meta} — the field documented but never
+	 * implemented in the "suggested" shape at AGENT_SESSIONS.md §4.3. A
+	 * no-op if the session doesn't exist (caller should check first if it
+	 * needs to distinguish "not found" from "renamed").
+	 *
+	 * @return true if the session existed and was updated, false otherwise
+	 */
+	@SuppressWarnings("unchecked")
+	public boolean setSessionTitle(Blob sid, AString title) {
+		boolean[] found = { false };
+		update(r -> {
+			Index<Blob, ACell> sessions = (r.get(K_SESSIONS) instanceof Index idx)
+				? (Index<Blob, ACell>) idx : Index.none();
+			ACell sessionCell = sessions.get(sid);
+			if (!(sessionCell instanceof AMap)) return r;
+			found[0] = true;
+			AMap<AString, ACell> session = (AMap<AString, ACell>) sessionCell;
+			AMap<AString, ACell> meta = (session.get(K_META) instanceof AMap m)
+				? (AMap<AString, ACell>) m : Maps.empty();
+			meta = (title != null) ? meta.assoc(Fields.TITLE, title) : meta.dissoc(Fields.TITLE);
+			session = session.assoc(K_META, meta);
+			return r.assoc(K_SESSIONS, sessions.assoc(sid, session));
+		});
+		return found[0];
+	}
+
+	/**
 	 * Whether a session record represents outstanding work: it has pending
 	 * messages, or it is mid-cycle ({@code inCycle} present — a claimed cycle
 	 * whose merge has not run, i.e. live right now or interrupted by a crash;

--- a/venue/src/main/resources/adapters/agent/renameSession.json
+++ b/venue/src/main/resources/adapters/agent/renameSession.json
@@ -1,0 +1,27 @@
+{
+	"name": "Rename Agent Session",
+	"description": "Sets or clears the free-form human-facing title on a session. Omitting title (or passing an empty string) clears it back to unset. Titled sessions are easier to pick out in a session list than the raw id/timestamp.",
+	"dateCreated": "2026-08-04T00:00:00Z",
+	"operation": {
+		"adapter": "agent:renameSession",
+		"internal": false,
+		"toolName": "agent_rename_session",
+		"input": {
+			"type": "object",
+			"properties": {
+				"agentId": { "type": "string", "description": "The agent that owns the session" },
+				"sessionId": { "type": "string", "description": "Hex ID of the session to rename" },
+				"title": { "type": "string", "description": "New title, or omitted/empty to clear it" }
+			},
+			"required": ["agentId", "sessionId"]
+		},
+		"output": {
+			"type": "object",
+			"properties": {
+				"agentId": { "type": "string" },
+				"sessionId": { "type": "string" },
+				"title": { "type": "string" }
+			}
+		}
+	}
+}

--- a/venue/src/test/java/covia/adapter/AgentAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/AgentAdapterTest.java
@@ -4821,6 +4821,121 @@ public class AgentAdapterTest {
 		}
 	}
 
+	// ========== agent:renameSession ==========
+
+	/**
+	 * Happy path: renaming a session sets {@code meta.title}; renaming again
+	 * with a blank title clears it back to unset.
+	 */
+	@Test
+	public void testRenameSessionSetsAndClearsTitle() {
+		engine.jobs().invokeOperation(
+			"v/ops/agent/create",
+			Maps.of(Fields.AGENT_ID, "rename-agent"),
+			RequestContext.of(ALICE_DID)).awaitResult(5000);
+
+		Job msg = engine.jobs().invokeOperation(
+			"v/ops/agent/message",
+			Maps.of(Fields.AGENT_ID, "rename-agent",
+				Fields.MESSAGE, Maps.of("content", "hello")),
+			RequestContext.of(ALICE_DID));
+		AString sidHex = RT.ensureString(RT.getIn(msg.awaitResult(5000), Fields.SESSION_ID));
+
+		Job rename = engine.jobs().invokeOperation(
+			"v/ops/agent/rename-session",
+			Maps.of(Fields.AGENT_ID, "rename-agent", Fields.SESSION_ID, sidHex,
+				Fields.TITLE, "Planning the launch"),
+			RequestContext.of(ALICE_DID));
+		ACell result = rename.awaitResult(5000);
+		assertEquals(Strings.create("Planning the launch"), RT.getIn(result, Fields.TITLE));
+
+		User user = engine.getVenueState().users().get(ALICE_DID);
+		AMap<AString, ACell> session = user.agent("rename-agent").getSession(Blob.fromHex(sidHex.toString()));
+		assertEquals(Strings.create("Planning the launch"), RT.getIn(session, "meta", "title"));
+
+		Job clear = engine.jobs().invokeOperation(
+			"v/ops/agent/rename-session",
+			Maps.of(Fields.AGENT_ID, "rename-agent", Fields.SESSION_ID, sidHex, Fields.TITLE, ""),
+			RequestContext.of(ALICE_DID));
+		ACell clearResult = clear.awaitResult(5000);
+		assertNull(RT.getIn(clearResult, Fields.TITLE), "blank title should not round-trip in the result");
+
+		session = user.agent("rename-agent").getSession(Blob.fromHex(sidHex.toString()));
+		assertNull(RT.getIn(session, "meta", "title"), "title should be cleared, not left blank");
+	}
+
+	@Test
+	public void testRenameSessionUnknownSessionFails() {
+		engine.jobs().invokeOperation(
+			"v/ops/agent/create",
+			Maps.of(Fields.AGENT_ID, "rename-unknown-agent"),
+			RequestContext.of(ALICE_DID)).awaitResult(5000);
+
+		Job rename = engine.jobs().invokeOperation(
+			"v/ops/agent/rename-session",
+			Maps.of(Fields.AGENT_ID, "rename-unknown-agent",
+				Fields.SESSION_ID, Strings.create("eeee0003eeee0003eeee0003eeee0003"),
+				Fields.TITLE, "x"),
+			RequestContext.of(ALICE_DID));
+		try {
+			rename.awaitResult(5000);
+			fail("renameSession should fail for an unknown session");
+		} catch (Exception e) {
+			assertEquals(Status.FAILED, rename.getStatus());
+			assertTrue(String.valueOf(RT.getIn(rename.getData(), Fields.ERROR)).contains("Session not found"));
+		}
+	}
+
+	@Test
+	public void testRenameSessionRequiresSessionId() {
+		engine.jobs().invokeOperation(
+			"v/ops/agent/create",
+			Maps.of(Fields.AGENT_ID, "rename-noarg-agent"),
+			RequestContext.of(ALICE_DID)).awaitResult(5000);
+
+		Job rename = engine.jobs().invokeOperation(
+			"v/ops/agent/rename-session",
+			Maps.of(Fields.AGENT_ID, "rename-noarg-agent", Fields.TITLE, "x"),
+			RequestContext.of(ALICE_DID));
+		try {
+			rename.awaitResult(5000);
+			fail("renameSession should fail without a sessionId");
+		} catch (Exception e) {
+			assertEquals(Status.FAILED, rename.getStatus());
+		}
+	}
+
+	/** The read-only public scope denies renameSession (agent/write). */
+	@Test
+	public void testRenameSessionDeniedUnderReadOnlyScope() {
+		engine.jobs().invokeOperation(
+			"v/ops/agent/create",
+			Maps.of(Fields.AGENT_ID, "rename-cap-agent"),
+			RequestContext.of(ALICE_DID)).awaitResult(5000);
+		Job msg = engine.jobs().invokeOperation(
+			"v/ops/agent/message",
+			Maps.of(Fields.AGENT_ID, "rename-cap-agent",
+				Fields.MESSAGE, Maps.of("content", "hi")),
+			RequestContext.of(ALICE_DID));
+		AString sidHex = RT.ensureString(RT.getIn(msg.awaitResult(5000), Fields.SESSION_ID));
+
+		RequestContext readOnly = RequestContext.of(ALICE_DID)
+			.withCaps(covia.lattice.CapabilityChecker.readOnlyScope(ALICE_DID));
+		Job rename = engine.jobs().invokeOperation(
+			"v/ops/agent/rename-session",
+			Maps.of(Fields.AGENT_ID, "rename-cap-agent", Fields.SESSION_ID, sidHex, Fields.TITLE, "nope"),
+			readOnly);
+		try {
+			rename.awaitResult(5000);
+			fail("read-only scope should deny renameSession");
+		} catch (Exception e) {
+			assertEquals(Status.FAILED, rename.getStatus());
+		}
+		User user = engine.getVenueState().users().get(ALICE_DID);
+		AMap<AString, ACell> session = user.agent("rename-cap-agent").getSession(Blob.fromHex(sidHex.toString()));
+		assertNull(RT.getIn(session, "meta", "title"), "title must not be set by a denied attempt");
+	}
+
 	/** Builds the L3 input via the same code path as agent:context and returns tool names. */
 	@SuppressWarnings("unchecked")
 	private java.util.Set<String> runtimeToolNames(String agentId) {


### PR DESCRIPTION
## Summary
- `AGENT_SESSIONS.md` §4.3 has always documented a "suggested" session meta shape including a free-form `title`, but the framework never implemented it — `AgentState.ensureSession` only ever wrote `created`/`turns`/`parties`.
- Adds `AgentState.setSessionTitle(sid, title)` — sets or (title omitted/blank) clears `meta.title` on an existing session.
- Adds a new `agent:renameSession` operation (`agent/write` capability, same shape/pattern as the existing `deleteSession`): `{agentId, sessionId, title?}` → `{agentId, sessionId, title?}`.
- This unblocks the frontend's Agent Explorer, which currently has to fake session naming via `localStorage` (per-browser, invisible to other clients/parties) because there's nowhere on the venue to persist it. Follow-up PRs in `covia-sdk` (typed `renameSession()` method) and `frontend` (write-through instead of localStorage) depend on this merging first.

## Test plan
- [x] `mvn -pl venue -am test` — full venue module, 2004/2004 pass
- [x] New tests: happy path (set + clear title), unknown session fails, missing sessionId fails, read-only scope denies rename
- [x] `mvn -pl venue -am compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)