### PR TITLE
Make agent creation exclusive

### DIFF
--- a/skills/ap-demo/SKILL.md
+++ b/skills/ap-demo/SKILL.md
@@ -38,7 +38,7 @@ Run all setup steps — secret, reference data, artifacts, orchestration, agents
 2. **Seed reference data** — three vendors (Acme Corp, Globex Ltd, Initech Systems) and their purchase orders (see [setup.md](setup.md)). Initech is suspended/sanctioned to enable rejection demos.
 3. **Write shared documents** — read `assets/ap-policy-rules.md` and `assets/ap-data-guide.md`, write each to its workspace path with `covia_write`: `w/docs/policy-rules` and `w/docs/data-guide`.
 4. **Pin the pipeline orchestration** — read `assets/ap-pipeline.json` and `covia_write path=o/ap-pipeline value=<contents>`. The pipeline is now invokable by name as `grid_run operation=o/ap-pipeline` — no hash dereferencing.
-5. **Create all four agents** in parallel (see [setup.md](setup.md) for full config). Agent prompts are short — reference material loads from context. Each agent has `caps` scoping their workspace access.
+5. **Create all four agents** in parallel (see [setup.md](setup.md) for full config). If a named demo agent already exists, delete it first with `remove=true`; create is exclusive and never overwrites. Agent prompts are short — reference material loads from context. Each agent has `caps` scoping their workspace access.
 6. **Verify** with `agent_list` — Alice, Bob, Carol, Dave all SLEEPING
 7. **Confirm context and caps** — query Bob or Carol and verify `config.context` and `config.caps` are present
 

--- a/skills/ap-demo/assets/alice.json
+++ b/skills/ap-demo/assets/alice.json
@@ -1,6 +1,5 @@
 {
   "agentId": "Alice",
-  "overwrite": true,
   "config": {
     "operation": "v/ops/goaltree/chat",
     "llmOperation": "v/ops/langchain/openai",

--- a/skills/ap-demo/assets/bob.json
+++ b/skills/ap-demo/assets/bob.json
@@ -1,6 +1,5 @@
 {
   "agentId": "Bob",
-  "overwrite": true,
   "config": {
     "operation": "v/ops/goaltree/chat",
     "llmOperation": "v/ops/langchain/openai",

--- a/skills/ap-demo/assets/carol.json
+++ b/skills/ap-demo/assets/carol.json
@@ -1,6 +1,5 @@
 {
   "agentId": "Carol",
-  "overwrite": true,
   "config": {
     "operation": "v/ops/goaltree/chat",
     "llmOperation": "v/ops/langchain/openai",

--- a/skills/ap-demo/assets/dave.json
+++ b/skills/ap-demo/assets/dave.json
@@ -1,6 +1,5 @@
 {
   "agentId": "Dave",
-  "overwrite": true,
   "config": {
     "operation": "v/ops/goaltree/chat",
     "llmOperation": "v/ops/langchain/openai",

--- a/skills/ap-demo/setup.md
+++ b/skills/ap-demo/setup.md
@@ -45,7 +45,7 @@ Agent configs are standalone JSON files in `assets/`. Each is a complete `agent_
 | Carol | [carol.json](assets/carol.json) | gpt-5.4-mini | covia_read, covia_write | read all w/, write decisions only | typed complete (decision schema) |
 | Dave | [dave.json](assets/dave.json) | gpt-5.4-mini | 8 ops + subgoal, compact, more_tools | read w/, agent message/request, invoke | none (conversational) |
 
-All use `goaltree:chat` transition with `defaultTools: false`. Typed `outputs` auto-inject `complete`/`fail` tools with schema enforcement. `overwrite: true` allows re-running setup to update configs without losing timelines.
+All use `goaltree:chat` transition with `defaultTools: false`. Typed `outputs` auto-inject `complete`/`fail` tools with schema enforcement. Re-running `setup.sh` explicitly removes and recreates these demo agents, so their runtime state and timelines start clean.
 
 ### Design principles
 

--- a/skills/ap-demo/setup.sh
+++ b/skills/ap-demo/setup.sh
@@ -8,14 +8,21 @@
 
 set -e
 VENUE="${1:-http://localhost:8080}"
-API="$VENUE/api/v1/invoke"
+API="$VENUE/api/v1/run"
 DIR="$(cd "$(dirname "$0")/assets" && pwd -W 2>/dev/null || pwd)"
 
 # Write a {path, value} JSON file to the lattice
 write() { curl -sf -X POST "$API" -H "Content-Type: application/json" -d "{\"operation\":\"v/ops/covia/write\",\"input\":$(cat "$DIR/$1")}" > /dev/null; }
 
-# Create an agent from a JSON file
-agent() { curl -sf -X POST "$API" -H "Content-Type: application/json" -d "{\"operation\":\"v/ops/agent/create\",\"input\":$(cat "$DIR/$1")}" > /dev/null; }
+# Recreate an agent explicitly: ignore "not found" from delete, then create.
+agent() {
+  local name="$1"
+  local file="$2"
+  curl -s -X POST "$API" -H "Content-Type: application/json" \
+    -d "{\"operation\":\"v/ops/agent/delete\",\"input\":{\"agentId\":\"$name\",\"remove\":true}}" > /dev/null
+  curl -sf -X POST "$API" -H "Content-Type: application/json" \
+    -d "{\"operation\":\"v/ops/agent/create\",\"input\":$(cat "$DIR/$file")}" > /dev/null
+}
 
 echo "=== AP Demo Setup ==="
 echo "Venue: $VENUE"
@@ -37,15 +44,15 @@ echo "Storing pipeline..."
 write pipeline.json
 
 echo "Creating agents..."
-agent alice.json
-agent bob.json
-agent carol.json
-agent dave.json
+agent Alice alice.json
+agent Bob bob.json
+agent Carol carol.json
+agent Dave dave.json
 
 echo ""
 echo "=== Done ==="
 curl -sf -X POST "$API" -H "Content-Type: application/json" -d '{"operation":"v/ops/agent/list","input":{}}' | python -c "
 import json,sys
-for a in json.load(sys.stdin).get('output',{}).get('agents',[]):
+for a in json.load(sys.stdin).get('agents',[]):
     print(f'  {a[\"agentId\"]}: {a[\"status\"]}')
 " 2>/dev/null || echo "  (install python to see agent status)"

--- a/skills/test-agent/SKILL.md
+++ b/skills/test-agent/SKILL.md
@@ -79,8 +79,8 @@ The **conversation history** (`state/history`) is the most important diagnostic 
 Delete and recreate an agent to test from clean state:
 
 ```
-agent_delete  agentId=<name>
-agent_create  agentId=<name>  config={...}  overwrite=true
+agent_delete  agentId=<name>  remove=true
+agent_create  agentId=<name>  config={...}
 ```
 
 Or resume a suspended agent:

--- a/venue/docs/AGENT_LOOP.md
+++ b/venue/docs/AGENT_LOOP.md
@@ -155,15 +155,15 @@ and which operations may safely act on it. There are four states:
 | Status | Meaning | Run loop | Mutations allowed |
 |--------|---------|----------|-------------------|
 | `SLEEPING` | Idle, no transition active. Default after create or after a successful run with no remaining work. | Not running. `wakeAgent` triggers it. | All. Safe to update config in place. |
-| `RUNNING` | A transition is currently in flight on a virtual thread. Record mutations go through atomic cursor updates. | Running. New work is appended to `tasks`/`session.pending` and picked up on next iteration. | Task/session appends are allowed. In-place config mutation is rejected because the transition captured the old config; `agent:create overwrite:true` may instead halt the loop and replace the complete record. |
-| `SUSPENDED` | Last run failed with an error. Dormant — does not auto-retry. State, pending messages, sessions, and history are preserved; failed tasks are drained. | Not running. Resume via `tryResume` to keep the record, or replace it via `agent:create overwrite:true`. | All. Overwrite deletes the complete old record and creates a clean SLEEPING agent so no stale transition state can survive (#237). |
-| `TERMINATED` | Logically deleted. Slot still occupies the namespace key (so the ID is reserved) but the agent is dead. | Cannot run. `agent:request` / `agent:message` / `agent:trigger` all fail. | None — only `agent:create overwrite:true` revives the slot, which **wipes timeline, sessions, tasks, pending, error** and starts fresh. |
+| `RUNNING` | A transition is currently in flight on a virtual thread. Record mutations go through atomic cursor updates. | Running. New work is appended to `tasks`/`session.pending` and picked up on next iteration. | Task/session appends are allowed. In-place config mutation is rejected because the transition captured the old config; suspend it before updating, or delete it explicitly. |
+| `SUSPENDED` | Last run failed with an error. Dormant — does not auto-retry. State, pending messages, sessions, and history are preserved; failed tasks are drained. | Not running. Resume via `tryResume` to keep the record, or delete it with `remove:true` before creating a replacement. | All. |
+| `TERMINATED` | Logically deleted. Slot still occupies the namespace key (so the ID is reserved) but the agent is dead. | Cannot run. `agent:request` / `agent:message` / `agent:trigger` all fail. | None. Remove the record explicitly with `agent:delete remove:true` before reusing the ID. |
 
 **State transitions** are documented in §4: `create` (→SLEEPING), `wakeAgent`
 (SLEEPING→RUNNING via CAS, §4.6), run loop completion (RUNNING→SLEEPING or
 RUNNING→SUSPENDED, §4.4), `agent:resume` (SUSPENDED→SLEEPING, §4.5),
-`agent:delete` (any→TERMINATED, §4.5), and `agent:create overwrite:true`
-(any record→fresh SLEEPING replacement, halting an active loop first).
+and `agent:delete` (any→TERMINATED or absent, §4.5). Creating another agent
+with the same ID requires physical removal of the old record first.
 
 ---
 
@@ -523,48 +523,20 @@ functions.
 | `agentId` | yes | Identifier for the agent slot in the caller's `g/` namespace |
 | `config` | no | Framework-level config (typically just `{operation: "..."}`) |
 | `state` | no | Initial state (typically `{config: {systemPrompt, caps, tools, ...}}`) |
-| `overwrite` | no | If true, halt if necessary, then delete and recreate any occupied slot. A RUNNING agent cannot overwrite itself from inside its own transition. |
 
-**Outputs:** `{agentId, status, created: bool, updated: bool}`. `created` is true
-for a new or replaced record. `updated` is a deprecated compatibility field and
-is always false; use `agent:update` for history-preserving mutation. Both are
-false for an idempotent no-op.
+**Outputs:** `{agentId, status}` plus optional advisory `warnings`. Success means
+a new record was created, so no redundant `created`, `updated`, or `replaced`
+flag is returned.
 
-**Slot resolution.** What happens when the target slot already contains an
-agent depends on `overwrite` and the existing status:
+**Exclusive create.** The target slot must be empty. Any existing record,
+including a TERMINATED one, fails with `Agent already exists`. This keeps the
+lifecycle operations distinct and prevents create authority from deleting an
+existing agent.
 
-| `overwrite` | Existing status | Result | Side effect | `created` | `updated` |
-|---|---|---|---|---|---|
-| any           | (empty)      | **CREATED** | fresh record initialised at SLEEPING | `true`  | `false` |
-| absent / `false` | any state | **NOOP**    | record unchanged — idempotent re-run | `false` | `false` |
-| `true`        | `SLEEPING`   | **CREATED** | old record removed; fresh SLEEPING record; all runtime state/history wiped | `true` | `false` |
-| `true`        | `SUSPENDED`  | **CREATED** | old record removed; fresh SLEEPING record; stale transition/error/history wiped | `true` | `false` |
-| `true`        | `RUNNING`    | **CREATED** | fail pending callers; mark TERMINATED; cancel and await old loop; remove; create fresh SLEEPING record | `true` | `false` |
-| `true`        | `TERMINATED` | **CREATED** | `removeAgent` then fresh record — wipes timeline, sessions, tasks, pending, error | `true`  | `false` |
-
-**Why RUNNING is halted before replacement.** A transition currently in flight
-has already captured the old `config`. Overwrite therefore never mutates that
-record in place: it marks the old record TERMINATED, cancels and awaits its run
-loop, then deletes it before creating the replacement. Waiting prevents the
-old loop from writing into the reused ID. An agent cannot overwrite itself from
-inside its own running transition because awaiting that same loop would
-deadlock; an external caller may overwrite it.
-
-**Why SLEEPING / SUSPENDED are replaceable.** Both are dormant: no run loop is
-executing a transition. Replacement removes the complete record before
-initialising the new one, so stale config, state, queues, sessions, errors, and
-history cannot leak into the replacement. Use `agent:update` when preserving
-history is intentional.
-
-**Why TERMINATED wipes.** TERMINATED is the explicit "throw it all out" signal.
-All overwrite paths use the same delete-and-create rule. Reviving a TERMINATED
-slot therefore has the same semantics as replacing SLEEPING or SUSPENDED:
-SLEEPING with a fresh timeline.
-
-**Idempotent re-runs.** Without `overwrite`, calling `agent:create` on an
-existing slot is a no-op. This makes setup scripts safe to re-run after partial
-failures: the script does not need to track which agents already exist. To
-update an existing agent on re-run, the script must opt in with `overwrite: true`.
+To preserve history, use `agent:update`. To replace an agent completely, call
+`agent:delete` with `remove:true`, wait for it to complete, and then call
+`agent:create`. Delete owns the cancellation and removal semantics for RUNNING,
+SLEEPING, SUSPENDED, and TERMINATED records.
 
 ### 4.2 Request
 
@@ -723,14 +695,13 @@ the response visible to callers without querying agent state separately.
 
 | Operation | Trigger | Effect | Allowed status | New status |
 |-----------|---------|--------|----------------|------------|
-| **Replace** | `agent:create overwrite:true` | Halt an active loop if necessary, delete the complete old record, and create a clean one. Config, state, timeline, sessions, tasks, pending work, inbox, and errors are wiped. See §4.1 slot resolution table. | any; self-overwrite while RUNNING rejected | SLEEPING |
 | **Suspend** | run loop error (§4.4) | Set `error`, set status → SUSPENDED. State, tasks, pending, sessions unchanged. | RUNNING (internal) | SUSPENDED |
 | **Resume** | `agent:resume` | CAS SUSPENDED→SLEEPING via `tryResume`, clear `error`. Then wake via §4.6 if there is work. | SUSPENDED only | SLEEPING |
 | **Suspend (manual)** | `agent:suspend` | Set status → SUSPENDED with caller-supplied reason. Stops the agent from being woken. | SLEEPING | SUSPENDED |
 | **Trigger** | `agent:trigger` | Wake the agent and (optionally) wait for the run loop to drain. Fails on TERMINATED. See §4.6. | SLEEPING, RUNNING | RUNNING then SLEEPING |
 | **Cancel task** | `agent:cancelTask` | Remove a pending task from the agent's `tasks` index. Does not affect the run loop directly. | any except TERMINATED | unchanged |
 | **Delete** | `agent:delete` | Accepts exactly one `agentId` or an exact `agentIds` list (maximum 100; no prefixes/wildcards). One Job halts each named agent. Default: set status → TERMINATED (record retained for audit). With `remove:true`: physically remove each lattice slot, making unreachable storage eligible for Etch GC. The full list is validated before deletion starts. | any | TERMINATED (or absent) |
-| **Fork** | `agent:fork` | Create a NEW agent at a different `agentId` from this one's config + optional state + optional timeline. The source is untouched; the target slot must be empty unless `overwrite:true` and TERMINATED. | source must not be TERMINATED | new agent SLEEPING |
+| **Fork** | `agent:fork` | Create a NEW agent at a different `agentId` from this one's config + optional state + optional timeline. The source is untouched and the target slot must be empty. | source must not be TERMINATED | new agent SLEEPING |
 
 **All mutations are atomic.** Each operation is a single compare-and-swap
 on the agent's lattice cell, so concurrent operations against the same
@@ -741,16 +712,15 @@ mutations is handled by reading the current record inside the merge
 
 **Status invariants:**
 
-- Once an agent is TERMINATED, it cannot transition to any other status without
-  going through `agent:create overwrite:true`, which wipes the record. There is
-  no "un-terminate".
+- Once an agent is TERMINATED, it cannot transition to another status. Remove
+  the record with `agent:delete remove:true` before creating a new agent with
+  the same ID; there is no "un-terminate".
 - RUNNING is a transient state held only while the run loop's transition function
   is executing or its merge step is pending. It is the only status under which
   config mutations are rejected.
 - SUSPENDED preserves session/history state but failed transition tasks and
   cycle claims are settled before suspension. `agent:resume` preserves that
-  record; `agent:create overwrite:true` deliberately deletes it and creates a
-  clean SLEEPING replacement.
+  record; explicit delete with `remove:true` discards it.
 
 ### 4.6 Scheduling — `wakeAgent`
 

--- a/venue/docs/AGENT_TEMPLATES.md
+++ b/venue/docs/AGENT_TEMPLATES.md
@@ -359,7 +359,7 @@ the handoff caps are mandatory, not optional.
 - Copies config and state from source; optional `includeTimeline: true` copies run history
 - Resets status to SLEEPING; tasks, pending, and sessions are fresh
 - Optional `config` override (inline map or string reference) is merged on top of source config per-field
-- Source must exist and not be TERMINATED; target must not already exist (unless `overwrite: true` and target is TERMINATED)
+- Source must exist and not be TERMINATED; target must not already exist
 - Implementation: `User.forkAgent` + `AgentState.initialiseFromFork`
 
 ### Phase 3a: Ship standard templates ✓ DONE

--- a/venue/src/main/java/covia/adapter/AgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/AgentAdapter.java
@@ -471,6 +471,19 @@ public class AgentAdapter extends AAdapter {
 	private void handleCreate(Job job, ACell input, RequestContext ctx) {
 		AString agentId = RT.ensureString(RT.getIn(input, Fields.AGENT_ID));
 		if (agentId == null) { job.fail("agentId is required"); return; }
+		if (RT.getIn(input, Fields.OVERWRITE) != null) {
+			job.fail("agent:create no longer supports overwrite; delete the existing agent "
+				+ "with remove=true, then create it again");
+			return;
+		}
+		Users users = engine.getVenueState().users();
+		User user = users.ensure(ctx.getUserDID());
+		AgentState existing = user.agent(agentId);
+		if (existing != null && existing.exists()) {
+			job.fail("Agent already exists: " + agentId
+				+ "; update it, or delete it with remove=true before creating it again");
+			return;
+		}
 
 		ACell configArg = RT.getIn(input, Fields.CONFIG);
 		AMap<AString, ACell> config;
@@ -569,25 +582,11 @@ public class AgentAdapter extends AAdapter {
 			config = config.assoc(K_LLM_OPERATION, engine.config().getDefaultLlmOperation());
 		}
 
-		boolean overwrite = CVMBool.TRUE.equals(RT.getIn(input, Fields.OVERWRITE));
-		Users users = engine.getVenueState().users();
-		User user = users.ensure(ctx.getUserDID());
-
-		// Resolve what to do with the target slot. See resolveCreateSlot for the
-		// full state machine — overwrite means replacement, while its absence is
-		// an idempotent no-op for an occupied slot.
-		SlotResult slot = resolveCreateSlot(job, user, agentId, overwrite, ctx);
-		if (slot == SlotResult.FAILED) return;
-
-		// ensureAgent is a no-op for NOOP slots; CREATED slots are empty because
-		// resolveCreateSlot removed any record selected for replacement.
 		AgentState agent = user.ensureAgent(agentId, config, initialState);
 
 		AMap<AString, ACell> result = Maps.of(
 			Fields.AGENT_ID, agentId,
-			Fields.STATUS, agent.getStatus(),
-			Fields.CREATED, CVMBool.of(slot == SlotResult.CREATED),
-			Fields.UPDATED, CVMBool.FALSE);
+			Fields.STATUS, agent.getStatus());
 
 		// Advisory only: surface anything that looks misconfigured but doesn't
 		// warrant failing create (#205). Emitted as a vector so several checks can
@@ -766,45 +765,6 @@ public class AgentAdapter extends AAdapter {
 		return null;
 	}
 
-	/** Outcome of resolving the target slot for {@code agent:create}. */
-	private enum SlotResult { CREATED, NOOP, FAILED }
-
-	/**
-	 * State machine for {@code agent:create}'s target slot. Determines whether
-	 * to create a fresh record, replace an existing one, no-op, or fail.
-	 *
-	 * <table>
-	 *   <caption>Slot resolution matrix</caption>
-	 *   <tr><th>{@code overwrite}</th><th>Existing status</th><th>Result</th><th>Side effect</th></tr>
-	 *   <tr><td>any</td>            <td>(empty)</td>      <td>CREATED</td><td>none — caller initialises</td></tr>
-	 *   <tr><td>false</td>          <td>any</td>          <td>NOOP</td>   <td>none — idempotent</td></tr>
-	 *   <tr><td>true</td>           <td>TERMINATED</td>   <td>CREATED</td><td>removeAgent — fresh start</td></tr>
-	 *   <tr><td>true</td>           <td>SLEEPING</td>     <td>CREATED</td><td>removeAgent — fresh start</td></tr>
-	 *   <tr><td>true</td>           <td>SUSPENDED</td>    <td>CREATED</td><td>removeAgent — fresh start</td></tr>
-	 *   <tr><td>true</td>           <td>RUNNING</td>      <td>CREATED</td><td>terminate, cancel and await old loop; then fresh start</td></tr>
-	 * </table>
-	 *
-	 * <p>A running agent is halted before replacement: pending callers are
-	 * failed, status is set to TERMINATED, the active transition is cancelled,
-	 * and the old loop is awaited before its record is removed. Self-overwrite
-	 * from inside that same loop is rejected to avoid waiting on itself.</p>
-	 */
-	private SlotResult resolveCreateSlot(
-			Job job, User user, AString agentId, boolean overwrite, RequestContext ctx) {
-		AgentState existing = user.agent(agentId);
-		if (existing == null || !existing.exists()) return SlotResult.CREATED;
-
-		if (!overwrite) return SlotResult.NOOP;
-
-		if (!haltAgent(job, user, existing, agentId, ctx,
-				"Agent overwritten: " + agentId, "overwrite")) return SlotResult.FAILED;
-		// A true overwrite is delete + create. This deliberately wipes config,
-		// state, timeline, sessions, tasks, pending, inbox and errors (#237).
-		// Callers that need history-preserving mutation use agent:update instead.
-		user.removeAgent(agentId);
-		return SlotResult.CREATED;
-	}
-
 	/** Stops an agent and waits for its run loop before its record may be reused. */
 	private boolean haltAgent(Job job, User user, AgentState agent, AString agentId,
 			RequestContext ctx, String pendingError, String action) {
@@ -843,6 +803,11 @@ public class AgentAdapter extends AAdapter {
 
 		AString agentId = RT.ensureString(RT.getIn(input, Fields.AGENT_ID));
 		if (agentId == null) { job.fail("agentId is required"); return; }
+		if (RT.getIn(input, Fields.OVERWRITE) != null) {
+			job.fail("agent:fork no longer supports overwrite; delete the target agent "
+				+ "with remove=true, then fork it again");
+			return;
+		}
 
 		Users users = engine.getVenueState().users();
 		User user = users.ensure(ctx.getUserDID());
@@ -871,18 +836,19 @@ public class AgentAdapter extends AAdapter {
 		AVector<ACell> sourceTimeline = CVMBool.TRUE.equals(RT.getIn(input, K_INCLUDE_TIMELINE))
 			? source.getTimeline() : null;
 
-		// Fork must write into an empty slot — fail if the target still exists
-		boolean overwrite = CVMBool.TRUE.equals(RT.getIn(input, Fields.OVERWRITE));
-		Boolean stillOccupied = applyOverwrite(job, user, agentId, overwrite);
-		if (stillOccupied == null) return;
-		if (stillOccupied) { job.fail("Target agent already exists: " + agentId); return; }
+		// Fork is an exclusive create: replacement is delete(remove=true) + fork.
+		AgentState existing = user.agent(agentId);
+		if (existing != null && existing.exists()) {
+			job.fail("Target agent already exists: " + agentId
+				+ "; delete it with remove=true before forking into this name");
+			return;
+		}
 
 		AgentState target = user.forkAgent(agentId, forkConfig, sourceState, sourceTimeline);
 
 		AMap<AString, ACell> result = Maps.of(
 			Fields.AGENT_ID, agentId,
 			Fields.STATUS, target.getStatus(),
-			Fields.CREATED, CVMBool.TRUE,
 			K_FORKED_FROM, sourceId);
 
 		job.setStatus(Status.STARTED);
@@ -1558,8 +1524,8 @@ public class AgentAdapter extends AAdapter {
 			// restarts it under the new config. This is the kill-switch pattern —
 			// the caller halts, then updates.
 			job.fail("Cannot update agent " + agentId + ": currently RUNNING. "
-				+ "Suspend it first (agent:suspend) to halt the run, then update and "
-				+ "resume; or replace it with agent:create overwrite=true.");
+				+ "Suspend it first (agent:suspend) to halt the run, then update and resume; "
+				+ "or delete it with remove=true before creating a replacement.");
 			return;
 		}
 
@@ -3274,34 +3240,6 @@ public class AgentAdapter extends AAdapter {
 			throw new IllegalArgumentException("Could not resolve config reference: " + ref);
 		}
 		return resolved;
-	}
-
-	/**
-	 * Processes the {@code overwrite} flag for a target agent slot. If the slot
-	 * is occupied by a TERMINATED agent and {@code overwrite} is true, the
-	 * existing agent is removed. If the slot is occupied by a non-TERMINATED
-	 * agent and {@code overwrite} is true, the job is failed.
-	 *
-	 * <p>When {@code overwrite} is false and the slot is occupied, this method
-	 * does nothing — callers decide whether that's an error (fork) or idempotent
-	 * (create).</p>
-	 *
-	 * @return the slot occupancy AFTER this call — {@link Boolean#TRUE} if still
-	 *         occupied, {@link Boolean#FALSE} if free, or {@code null} if the
-	 *         job was failed by this method
-	 */
-	private Boolean applyOverwrite(Job job, User user, AString agentId, boolean overwrite) {
-		AgentState existing = user.agent(agentId);
-		if (existing == null || !existing.exists()) return Boolean.FALSE;
-
-		if (!overwrite) return Boolean.TRUE;
-
-		if (AgentState.TERMINATED.equals(existing.getStatus())) {
-			user.removeAgent(agentId);
-			return Boolean.FALSE;
-		}
-		job.fail("Cannot overwrite agent that is not TERMINATED (status: " + existing.getStatus() + ")");
-		return null;
 	}
 
 	/**

--- a/venue/src/main/resources/adapters/agent/create.json
+++ b/venue/src/main/resources/adapters/agent/create.json
@@ -1,6 +1,6 @@
 {
 	"name": "Create Agent",
-	"description": "Creates an agent at g/<agentId> in the caller's namespace. Idempotent on empty slots — call again with the same agentId without overwrite=true and you get a no-op success.\n\nOmit config for the recommended skilled default: read/list tools plus skills loaded on demand, using the venue's default transition and LLM provider. Pass config={} only when you intentionally want an explicit minimal configuration.\n\nWith overwrite=true, any occupied slot is deleted and recreated as a clean SLEEPING agent. A RUNNING agent is first marked TERMINATED, its pending callers are failed, and its active transition is cancelled and awaited. Config, state, timeline, sessions, tasks, pending work, inbox, and errors are wiped. An agent cannot overwrite itself from inside its own running transition. Use agent:update when history-preserving config mutation is intended.\n\nCustom example: agent_create(agentId='Helper', config={operation: 'v/ops/llmagent/chat', systemPrompt: 'You summarise documents.'}). The 'operation' field must be a resolvable lattice path (e.g. 'v/ops/llmagent/chat' for plain persona chat, 'v/ops/goaltree/chat' for goal-decomposing planners) — bare adapter shorthand like 'llmagent:chat' will not resolve. To use a different provider, set llmOperation in config (e.g. 'v/ops/langchain/anthropic' for Claude, 'v/ops/langchain/ollama' for local models); each provider op resolves its API key from the user's secret store via its own default secretKey, or you can override with apiKey='s/<SECRET_NAME>'. After creation, send work via agent_request and inspect via agent_info.",
+	"description": "Creates a new agent at g/<agentId> in the caller's namespace. The name must be unused; an existing agent is an error. To replace an agent, explicitly call agent:delete with remove=true and then create the new agent. Use agent:update for history-preserving config or state changes.\n\nOmit config for the recommended skilled default: read/list tools plus skills loaded on demand, using the venue's default transition and LLM provider. Pass config={} only when you intentionally want an explicit minimal configuration.\n\nCustom example: agent_create(agentId='Helper', config={operation: 'v/ops/llmagent/chat', systemPrompt: 'You summarise documents.'}). The 'operation' field must be a resolvable lattice path (e.g. 'v/ops/llmagent/chat' for plain persona chat, 'v/ops/goaltree/chat' for goal-decomposing planners) — bare adapter shorthand like 'llmagent:chat' will not resolve. To use a different provider, set llmOperation in config (e.g. 'v/ops/langchain/anthropic' for Claude, 'v/ops/langchain/ollama' for local models); each provider op resolves its API key from the user's secret store via its own default secretKey, or you can override with apiKey='s/<SECRET_NAME>'. After creation, send work via agent_request and inspect via agent_info.",
 	"dateCreated": "2026-02-27T00:00:00Z",
 	"operation": {
 		"adapter": "agent:create",
@@ -27,8 +27,7 @@
 						{ "type": "string", "description": "Reference to a config map stored in workspace, assets, or elsewhere" }
 					]
 				},
-				"definition": { "type": "string", "description": "Asset ID of an agent definition using the legacy nested format (meta.agent.config). For the unified approach, pass the reference directly in 'config'." },
-				"overwrite": { "type": "boolean", "description": "If true, halt if necessary, then delete and recreate any occupied slot as a clean SLEEPING agent. All old runtime state and history are discarded. A RUNNING agent cannot overwrite itself from inside its own transition. Use agent:update for history-preserving config changes. If false (default), an occupied slot is a no-op." }
+				"definition": { "type": "string", "description": "Asset ID of an agent definition using the legacy nested format (meta.agent.config). For the unified approach, pass the reference directly in 'config'." }
 			},
 			"required": ["agentId"]
 		},
@@ -37,8 +36,6 @@
 			"properties": {
 				"agentId": { "type": "string" },
 				"status": { "type": "string", "description": "Current status of the agent: SLEEPING, RUNNING, SUSPENDED, or TERMINATED" },
-				"created": { "type": "boolean", "description": "True if a new record was written, including replacement via overwrite=true" },
-				"updated": { "type": "boolean", "deprecated": true, "description": "Deprecated compatibility field; always false because agent:create no longer updates occupied records in place. Use agent:update for history-preserving mutation." },
 				"warnings": { "type": "array", "items": { "type": "string" }, "description": "Optional non-fatal advisories; present and non-empty only when the config looks misconfigured but create still succeeded. Each entry is a human-readable message. Currently the only advisory: the agent declares tools on an Ollama model whose tool-calling support could not be confirmed (no 'tools' capability, or the model is not installed/reachable). Absent when there is nothing to flag." }
 			}
 		}

--- a/venue/src/main/resources/adapters/agent/fork.json
+++ b/venue/src/main/resources/adapters/agent/fork.json
@@ -9,12 +9,11 @@
 			"type": "object",
 			"properties": {
 				"sourceId": { "type": "string", "description": "Agent ID to fork from (must exist and not be TERMINATED)" },
-				"agentId": { "type": "string", "description": "New agent ID for the fork (must not already exist, unless overwrite=true and the existing agent is TERMINATED)" },
+				"agentId": { "type": "string", "description": "New agent ID for the fork; must not already exist" },
 				"config": {
 					"description": "Optional config overrides — inline map or string reference (workspace path, asset ref, DID URL). Merged on top of the source agent's config."
 				},
-				"includeTimeline": { "type": "boolean", "description": "If true, copy the source agent's timeline (run history). Default false." },
-				"overwrite": { "type": "boolean", "description": "If true, replace an existing TERMINATED agent at agentId. Default false." }
+				"includeTimeline": { "type": "boolean", "description": "If true, copy the source agent's timeline (run history). Default false." }
 			},
 			"required": ["sourceId", "agentId"]
 		},
@@ -23,7 +22,6 @@
 			"properties": {
 				"agentId": { "type": "string" },
 				"status": { "type": "string" },
-				"created": { "type": "boolean" },
 				"forkedFrom": { "type": "string", "description": "The sourceId this agent was forked from" }
 			}
 		}

--- a/venue/src/main/resources/adapters/agent/update.json
+++ b/venue/src/main/resources/adapters/agent/update.json
@@ -1,6 +1,6 @@
 {
 	"name": "Update Agent",
-	"description": "Update a non-running agent's configuration and/or runtime state while preserving its history. `config` and `state` are each shallow-merged into their existing values, so partial updates preserve sibling fields. Agent configuration has one home: pass model, tools, caps, outputs, and systemPrompt under `config`; `state.config` is rejected. Framework-managed fields (status, tasks, inbox, timeline) are never affected. RUNNING is rejected because its active transition already captured the old config; wait for it to finish or use agent:create overwrite=true to halt and replace it.",
+	"description": "Update a non-running agent's configuration and/or runtime state while preserving its history. `config` and `state` are each shallow-merged into their existing values, so partial updates preserve sibling fields. Agent configuration has one home: pass model, tools, caps, outputs, and systemPrompt under `config`; `state.config` is rejected. Framework-managed fields (status, tasks, inbox, timeline) are never affected. RUNNING is rejected because its active transition already captured the old config; suspend it before updating, or explicitly delete it with remove=true and create a replacement.",
 	"dateCreated": "2026-03-07T00:00:00Z",
 	"operation": {
 		"adapter": "agent:update",

--- a/venue/src/test/java/covia/adapter/AgentAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/AgentAdapterTest.java
@@ -318,7 +318,9 @@ public class AgentAdapterTest {
 			Maps.of(Fields.AGENT_ID, "tool-made",
 				Fields.CONFIG, Maps.of("llmOperation", "v/test/ops/llm")),
 			RequestContext.of(ALICE_DID)).get(5, java.util.concurrent.TimeUnit.SECONDS);
-		assertEquals(CVMBool.TRUE, RT.getIn(created, Strings.create("created")));
+		assertEquals(Strings.create("tool-made"), RT.getIn(created, Fields.AGENT_ID));
+		assertNull(RT.getIn(created, Fields.CREATED),
+			"successful create needs no redundant created flag");
 
 		// Job-worthy: the create is on the record as a persisted Job.
 		boolean createJobFound = false;
@@ -709,8 +711,8 @@ public class AgentAdapterTest {
 	}
 
 	@Test
-	public void testCreateIdempotent() {
-		ACell input = Maps.of(Fields.AGENT_ID, "idempotent-agent");
+	public void testCreateRejectsExistingAgent() {
+		ACell input = Maps.of(Fields.AGENT_ID, "exclusive-agent");
 
 		Job job1 = engine.jobs().invokeOperation(
 			"v/ops/agent/create", input, RequestContext.of(ALICE_DID));
@@ -718,10 +720,28 @@ public class AgentAdapterTest {
 
 		Job job2 = engine.jobs().invokeOperation(
 			"v/ops/agent/create", input, RequestContext.of(ALICE_DID));
-		ACell result2 = job2.awaitResult(5000);
+		try {
+			job2.awaitResult(5000);
+			fail("agent:create must fail when the name is already occupied");
+		} catch (covia.exception.JobFailedException expected) {
+			assertTrue(job2.getErrorMessage().contains("already exists"));
+		}
+	}
 
-		assertNotNull(result2);
-		assertEquals(Strings.create("idempotent-agent"), RT.getIn(result2, Fields.AGENT_ID));
+	@Test
+	public void testCreateRejectsRemovedOverwriteParameter() {
+		Job job = engine.jobs().invokeOperation(
+			"v/ops/agent/create",
+			Maps.of(Fields.AGENT_ID, "legacy-overwrite",
+				Fields.OVERWRITE, CVMBool.TRUE),
+			RequestContext.of(ALICE_DID));
+		try {
+			job.awaitResult(5000);
+			fail("removed overwrite parameter must fail loudly");
+		} catch (covia.exception.JobFailedException expected) {
+			assertTrue(job.getErrorMessage().contains("no longer supports overwrite"));
+		}
+		assertNull(engine.getVenueState().users().get(ALICE_DID).agent("legacy-overwrite"));
 	}
 
 	// ========== agent:fork ==========
@@ -750,7 +770,7 @@ public class AgentAdapterTest {
 
 		assertNotNull(result);
 		assertEquals(Strings.create("fork-agent"), RT.getIn(result, Fields.AGENT_ID));
-		assertEquals(CVMBool.TRUE, RT.getIn(result, Fields.CREATED));
+		assertNull(RT.getIn(result, Fields.CREATED));
 		assertEquals(Strings.create("source-agent"), RT.getIn(result, Strings.create("forkedFrom")));
 		assertEquals(AgentState.SLEEPING, RT.getIn(result, Fields.STATUS));
 
@@ -909,6 +929,26 @@ public class AgentAdapterTest {
 			fail("Should fail when target already exists");
 		} catch (Exception e) {
 			assertEquals(Status.FAILED, job.getStatus());
+		}
+	}
+
+	@Test
+	public void testForkRejectsRemovedOverwriteParameter() {
+		engine.jobs().invokeOperation("v/ops/agent/create",
+			Maps.of(Fields.AGENT_ID, "fork-source"),
+			RequestContext.of(ALICE_DID)).awaitResult(5000);
+
+		Job job = engine.jobs().invokeOperation(
+			"v/ops/agent/fork",
+			Maps.of(Strings.create("sourceId"), "fork-source",
+				Fields.AGENT_ID, "fork-target",
+				Fields.OVERWRITE, CVMBool.TRUE),
+			RequestContext.of(ALICE_DID));
+		try {
+			job.awaitResult(5000);
+			fail("removed overwrite parameter must fail loudly");
+		} catch (covia.exception.JobFailedException expected) {
+			assertTrue(job.getErrorMessage().contains("no longer supports overwrite"));
 		}
 	}
 
@@ -3813,14 +3853,17 @@ public class AgentAdapterTest {
 			Maps.of(Fields.AGENT_ID, "reuse-agent"),
 			RequestContext.of(ALICE_DID)).awaitResult(5000);
 
-		// Create again without overwrite — idempotent no-op, created=false
+		// Logical deletion preserves the record and therefore reserves the name.
 		Job job2 = engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "reuse-agent"),
 			RequestContext.of(ALICE_DID));
-		ACell result2 = job2.awaitResult(5000);
-		assertEquals(CVMBool.FALSE, RT.getIn(result2, Fields.CREATED));
-		assertEquals(AgentState.TERMINATED, RT.getIn(result2, Fields.STATUS));
+		try {
+			job2.awaitResult(5000);
+			fail("a TERMINATED record must still block exclusive create");
+		} catch (covia.exception.JobFailedException expected) {
+			assertTrue(job2.getErrorMessage().contains("already exists"));
+		}
 	}
 
 	@Test
@@ -3836,20 +3879,20 @@ public class AgentAdapterTest {
 			Maps.of(Fields.AGENT_ID, "clean-agent", Fields.REMOVE, CVMBool.TRUE),
 			RequestContext.of(ALICE_DID)).awaitResult(5000);
 
-		// Recreate — should succeed with created=true
+		// Physical removal frees the name for a new create.
 		Job job2 = engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "clean-agent"),
 			RequestContext.of(ALICE_DID));
 		ACell result2 = job2.awaitResult(5000);
-		assertEquals(CVMBool.TRUE, RT.getIn(result2, Fields.CREATED));
+		assertNull(RT.getIn(result2, Fields.CREATED));
 		assertEquals(AgentState.SLEEPING, RT.getIn(result2, Fields.STATUS));
 	}
 
-	// ========== agent:create with overwrite ==========
+	// ========== explicit delete + recreate ==========
 
 	@Test
-	public void testCreateOverwriteTerminated() {
+	public void testRemoveTerminatedThenRecreate() {
 		engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "ow-agent",
@@ -3862,16 +3905,20 @@ public class AgentAdapterTest {
 			Maps.of(Fields.AGENT_ID, "ow-agent"),
 			RequestContext.of(ALICE_DID)).awaitResult(5000);
 
-		// Overwrite with new config
+		// A logical delete reserves the name; remove it explicitly before reuse.
+		engine.jobs().invokeOperation(
+			"v/ops/agent/delete",
+			Maps.of(Fields.AGENT_ID, "ow-agent", Fields.REMOVE, CVMBool.TRUE),
+			RequestContext.of(ALICE_DID)).awaitResult(5000);
+
 		Job job = engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "ow-agent",
-				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/taskcomplete"),
-				Fields.OVERWRITE, CVMBool.TRUE),
+				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/taskcomplete")),
 			RequestContext.of(ALICE_DID));
 		ACell result = job.awaitResult(5000);
 
-		assertEquals(CVMBool.TRUE, RT.getIn(result, Fields.CREATED));
+		assertNull(RT.getIn(result, Fields.CREATED));
 		assertEquals(AgentState.SLEEPING, RT.getIn(result, Fields.STATUS));
 
 		// Config should be the new one
@@ -3882,9 +3929,9 @@ public class AgentAdapterTest {
 	}
 
 	@Test
-	public void testCreateOverwriteSleepingReplacesRecord() {
-		// Create a SLEEPING agent with old-only config and runtime state. A true
-		// overwrite must discard all of it; agent:update owns merge semantics.
+	public void testRemoveSleepingThenRecreateClearsRecord() {
+		// Create a SLEEPING agent with old-only config and runtime state. Explicit
+		// removal must discard all of it; agent:update owns merge semantics.
 		engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "live-ow",
@@ -3900,17 +3947,21 @@ public class AgentAdapterTest {
 		pre.ensureSession(owSid, ALICE_DID);
 		pre.appendSessionPending(owSid, Strings.create("hello"));
 
-		// Overwrite a SLEEPING agent — delete the old record and create fresh.
+		engine.jobs().invokeOperation(
+			"v/ops/agent/delete",
+			Maps.of(Fields.AGENT_ID, "live-ow", Fields.REMOVE, CVMBool.TRUE),
+			RequestContext.of(ALICE_DID)).awaitResult(5000);
+
+		// Create a fresh agent in the now-empty slot.
 		Job job = engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "live-ow",
-				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/taskcomplete"),
-				Fields.OVERWRITE, CVMBool.TRUE),
+				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/taskcomplete")),
 			RequestContext.of(ALICE_DID));
 		ACell result = job.awaitResult(5000);
 
-		assertEquals(CVMBool.TRUE, RT.getIn(result, Fields.CREATED));
-		assertEquals(CVMBool.FALSE, RT.getIn(result, Fields.UPDATED));
+		assertNull(RT.getIn(result, Fields.CREATED));
+		assertNull(RT.getIn(result, Fields.UPDATED));
 		assertEquals(AgentState.SLEEPING, RT.getIn(result, Fields.STATUS));
 
 		// Config and runtime record are replacements, not shallow merges.
@@ -3923,7 +3974,7 @@ public class AgentAdapterTest {
 	}
 
 	@Test
-	public void testCreateOverwriteSuspendedRecoversWithNewConfig() {
+	public void testRemoveSuspendedThenRecreateWithNewConfig() {
 		// Reproduce #237: the old transition fails and suspends the agent.
 		engine.jobs().invokeOperation(
 			"v/ops/agent/create",
@@ -3951,25 +4002,28 @@ public class AgentAdapterTest {
 		long timelineBefore = suspended.getTimeline().count();
 		assertEquals(1, timelineBefore, "failed transition should remain in history");
 
-		// Overwrite with a working transition. This must recover the slot rather
-		// than leave it poisoned by the old provider/configuration.
+		// Remove the failed record, then create a clean replacement.
+		engine.jobs().invokeOperation(
+			"v/ops/agent/delete",
+			Maps.of(Fields.AGENT_ID, "susp-ow", Fields.REMOVE, CVMBool.TRUE),
+			RequestContext.of(ALICE_DID)).awaitResult(5000);
+
 		ACell result = engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "susp-ow",
-				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/taskcomplete"),
-				Fields.OVERWRITE, CVMBool.TRUE),
+				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/taskcomplete")),
 			RequestContext.of(ALICE_DID)).awaitResult(5000);
 
-		assertEquals(CVMBool.TRUE, RT.getIn(result, Fields.CREATED));
-		assertEquals(CVMBool.FALSE, RT.getIn(result, Fields.UPDATED));
+		assertNull(RT.getIn(result, Fields.CREATED));
+		assertNull(RT.getIn(result, Fields.UPDATED));
 		assertEquals(AgentState.SLEEPING, RT.getIn(result, Fields.STATUS));
 
 		AgentState post = user.agent("susp-ow");
 		assertEquals(Strings.create("v/test/ops/taskcomplete"), post.getConfig().get(Fields.OPERATION));
 		assertEquals(AgentState.SLEEPING, post.getStatus());
-		assertNull(post.getError(), "overwrite must clear the stale provider error");
+		assertNull(post.getError(), "replacement must clear the stale provider error");
 		assertEquals(0, post.getTimeline().count(),
-			"overwrite must replace the old runtime record and timeline");
+			"delete + create must replace the old runtime record and timeline");
 
 		// A new request must execute the replacement operation. Replaying the old
 		// error transition here is the original #237 failure mode.
@@ -3987,7 +4041,7 @@ public class AgentAdapterTest {
 	}
 
 	@Test
-	public void testCreateOverwriteRunningHaltsAndReplaces() throws Exception {
+	public void testRemoveRunningThenRecreate() throws Exception {
 		// A never-completing transition makes halt-before-replace observable.
 		engine.jobs().invokeOperation(
 			"v/ops/agent/create",
@@ -4022,16 +4076,20 @@ public class AgentAdapterTest {
 		assertEquals(Strings.create("v/test/ops/never"),
 			old.getConfig().get(Fields.OPERATION));
 
-		// Overwrite halts and settles the old loop before installing the replacement.
+		// Delete halts and settles the old loop before a replacement is created.
+		engine.jobs().invokeOperation(
+			"v/ops/agent/delete",
+			Maps.of(Fields.AGENT_ID, "run-ow", Fields.REMOVE, CVMBool.TRUE),
+			RequestContext.of(ALICE_DID)).awaitResult(5000);
+
 		Job job = engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "run-ow",
-				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/taskcomplete"),
-				Fields.OVERWRITE, CVMBool.TRUE),
+				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/taskcomplete")),
 			RequestContext.of(ALICE_DID));
 		ACell replaced = job.awaitResult(5000);
-		assertEquals(CVMBool.TRUE, RT.getIn(replaced, Fields.CREATED));
-		assertEquals(CVMBool.FALSE, RT.getIn(replaced, Fields.UPDATED));
+		assertNull(RT.getIn(replaced, Fields.CREATED));
+		assertNull(RT.getIn(replaced, Fields.UPDATED));
 		assertEquals(AgentState.SLEEPING, RT.getIn(replaced, Fields.STATUS));
 		try {
 			stuck.awaitResult(5000);
@@ -4039,7 +4097,7 @@ public class AgentAdapterTest {
 		} catch (covia.exception.JobFailedException expected) {
 			// expected
 		}
-		assertTrue(stuck.getErrorMessage().contains("overwritten"));
+		assertTrue(stuck.getErrorMessage().contains("deleted"));
 
 		AgentState fresh = user.agent("run-ow");
 		assertEquals(Strings.create("v/test/ops/taskcomplete"),
@@ -4053,22 +4111,25 @@ public class AgentAdapterTest {
 	}
 
 	@Test
-	public void testCreateOverwriteFalseIsNoOp() {
+	public void testCreateExistingDoesNotChangeConfig() {
 		engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "no-ow",
 				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/echo")),
 			RequestContext.of(ALICE_DID)).awaitResult(5000);
 
-		// Without overwrite — idempotent no-op
+		// Exclusive create fails and leaves the original untouched.
 		Job job = engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "no-ow",
 				Fields.CONFIG, Maps.of(Fields.OPERATION, "v/test/ops/taskcomplete")),
 			RequestContext.of(ALICE_DID));
-		ACell result = job.awaitResult(5000);
-
-		assertEquals(CVMBool.FALSE, RT.getIn(result, Fields.CREATED));
+		try {
+			job.awaitResult(5000);
+			fail("duplicate create must fail");
+		} catch (covia.exception.JobFailedException expected) {
+			assertTrue(job.getErrorMessage().contains("already exists"));
+		}
 
 		// Config should still be original
 		User user = engine.getVenueState().users().get(ALICE_DID);
@@ -4370,7 +4431,6 @@ public class AgentAdapterTest {
 		// Create agent with full config — record.config is the single slot (#144)
 		ACell createInput = Maps.of(
 			Fields.AGENT_ID, "merge-test",
-			Strings.create("overwrite"), convex.core.data.prim.CVMBool.TRUE,
 			Fields.CONFIG, Maps.of(
 				Strings.create("model"), Strings.create("gpt-4.1-mini"),
 				Strings.create("systemPrompt"), Strings.create("You are a test agent"),
@@ -4423,11 +4483,10 @@ public class AgentAdapterTest {
 	public void testUpdateNullValueDocumentsCurrentBehaviour() {
 		// Document current behaviour: setting a config field to null via update
 		// stores null at that key — it does NOT remove the key. To remove a field,
-		// recreate the agent with overwrite:true. This test pins down the
-		// behaviour so any change to it shows up in the diff.
+		// explicitly delete the agent with remove=true and create it again. This
+		// test pins down the behaviour so any change shows up in the diff.
 		ACell createInput = Maps.of(
 			Fields.AGENT_ID, "null-test",
-			Strings.create("overwrite"), CVMBool.TRUE,
 			Fields.CONFIG, Maps.of(
 				Strings.create("model"), Strings.create("gpt-4o"),
 				Strings.create("systemPrompt"), Strings.create("Original prompt")));
@@ -4447,7 +4506,7 @@ public class AgentAdapterTest {
 		assertTrue(configMap.containsKey(Strings.create("systemPrompt")),
 			"key should still exist after setting to null (current behaviour)");
 		assertNull(configMap.get(Strings.create("systemPrompt")),
-			"value should be null (current behaviour — to fully remove, recreate with overwrite:true)");
+			"value should be null (current behaviour — delete + create to remove the key)");
 	}
 
 	// ========== Templates as lattice data (v/agents/templates/) ==========

--- a/venue/src/test/java/covia/adapter/AssetAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/AssetAdapterTest.java
@@ -740,7 +740,8 @@ public class AssetAdapterTest {
 		Job createJob = engine.jobs().invokeOperation("v/ops/agent/create", createInput, RequestContext.of(ALICE_DID));
 		ACell createResult = createJob.awaitResult(5000);
 
-		assertEquals(CVMBool.TRUE, RT.getIn(createResult, Fields.CREATED));
+		assertNull(RT.getIn(createResult, Fields.CREATED));
+		assertEquals(Strings.create("DefAgent"), RT.getIn(createResult, Fields.AGENT_ID));
 		assertEquals(Strings.create("SLEEPING"), RT.getIn(createResult, Fields.STATUS));
 
 		// Query agent and verify config was populated from definition
@@ -780,7 +781,8 @@ public class AssetAdapterTest {
 		Job job = engine.jobs().invokeOperation("v/ops/agent/create", input, RequestContext.of(ALICE_DID));
 		ACell result = job.awaitResult(5000);
 
-		assertEquals(CVMBool.TRUE, RT.getIn(result, Fields.CREATED));
+		assertNull(RT.getIn(result, Fields.CREATED));
+		assertEquals(Strings.create("InlineAgent"), RT.getIn(result, Fields.AGENT_ID));
 	}
 
 	@Test


### PR DESCRIPTION
Summary:
- make agent:create and agent:fork fail when the target name already exists
- remove overwrite and redundant created/updated result flags; replacement is agent:delete with remove=true followed by create/fork
- update lifecycle docs, bundled skills, demo setup, and regression coverage

Tests: mvn test (all seven modules)

Closes #329