### PR TITLE
Fix nested collection results in agent tool loops

### DIFF
--- a/venue/src/main/java/covia/adapter/TestAdapter.java
+++ b/venue/src/main/java/covia/adapter/TestAdapter.java
@@ -420,12 +420,25 @@ public class TestAdapter extends AAdapter {
             // the arguments
             String escaped = lastUserMsg.replace("\\", "\\\\").replace("\"", "\\\"")
                 .replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t");
+            String toolName = "v/test/ops/echo";
+            String arguments = "{\"echo\":\"" + escaped + "\"}";
+            // #334 regression fixture: exercise real covia collection reads
+            // through the agent tool loop while keeping the L3 provider fully
+            // deterministic. The second call above only accepts textual
+            // role:tool content, just like an external model provider.
+            if (lastUserMsg.contains("issue-334-read")) {
+                toolName = "covia_read";
+                arguments = "{\"path\":\"w/issue-334/signals\"}";
+            } else if (lastUserMsg.contains("issue-334-list")) {
+                toolName = "covia_list";
+                arguments = "{\"path\":\"w/issue-334/sources\",\"fields\":[\"status\"]}";
+            }
             return Maps.of(
                 "role", Strings.create("assistant"),
                 "toolCalls", Vectors.of(Maps.of(
                     "id", Strings.create("call_1"),
-                    "name", Strings.create("v/test/ops/echo"),
-                    "arguments", Strings.create("{\"echo\":\"" + escaped + "\"}")
+                    "name", Strings.create(toolName),
+                    "arguments", Strings.create(arguments)
                 ))
             );
         }

--- a/venue/src/main/java/covia/adapter/agent/AbstractLLMAdapter.java
+++ b/venue/src/main/java/covia/adapter/agent/AbstractLLMAdapter.java
@@ -18,6 +18,7 @@ import convex.core.data.Strings;
 import convex.core.data.Vectors;
 import convex.core.data.prim.CVMLong;
 import convex.core.lang.RT;
+import convex.core.util.JSON;
 import covia.adapter.AAdapter;
 import covia.api.Fields;
 import covia.exception.JobFailedException;
@@ -583,6 +584,14 @@ public abstract class AbstractLLMAdapter extends AAdapter implements ContextInsp
 
 	/**
 	 * Creates a tool result message in the Level 3 message format.
+	 *
+	 * <p>Provider tool-result messages have one wire shape: textual
+	 * {@code content}. Structured Covia results are therefore rendered to JSON
+	 * here, at the agent/tool boundary, rather than carried as live Convex
+	 * collections in an MCP-style {@code structuredContent} field. Apart from
+	 * matching the OpenAI/Anthropic message contract, this prevents lazy nested
+	 * collection traversal from being deferred into the next provider call
+	 * (covia-ai/covia#334).</p>
 	 */
 	protected static AMap<AString, ACell> toolResultMessage(
 			AString toolCallId, String toolName, ACell result) {
@@ -590,13 +599,8 @@ public abstract class AbstractLLMAdapter extends AAdapter implements ContextInsp
 			K_ROLE, ROLE_TOOL,
 			K_ID, toolCallId,
 			K_NAME, Strings.create(toolName));
-		if (result instanceof AMap || result instanceof AVector) {
-			msg = msg.assoc(K_STRUCTURED_CONTENT, result);
-		} else {
-			AString content = RT.ensureString(result);
-			msg = msg.assoc(K_CONTENT, (content != null) ? content : Strings.create(result.toString()));
-		}
-		return msg;
+		AString content = RT.ensureString(result);
+		return msg.assoc(K_CONTENT, (content != null) ? content : JSON.print(result));
 	}
 
 	// ========== Tool-call argument parsing (the LLM wire boundary) ==========

--- a/venue/src/main/java/covia/adapter/agent/LLMAgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/agent/LLMAgentAdapter.java
@@ -675,9 +675,9 @@ public class LLMAgentAdapter extends AbstractLLMAdapter {
 						Fields.ERROR, Strings.create(failure)));
 				}
 
-				// Append tool result message via the shared base helper
-				// (parent rule: AMap/AVector → structuredContent, else stringify
-				// into content). Synthesises a stand-in name when the LLM omits
+				// Append tool result message via the shared base helper. All results
+				// cross the provider boundary as textual content; structured values
+				// are JSON-rendered there. Synthesises a stand-in name when the LLM omits
 				// it — the message format requires a non-null name.
 				String toolNameForMsg = (name != null) ? name.toString() : "unknown";
 				newMessages = newMessages.conj(toolResultMessage(id, toolNameForMsg, toolResult));
@@ -706,7 +706,7 @@ public class LLMAgentAdapter extends AbstractLLMAdapter {
 	 * Executes a tool call, dispatching to built-in handlers or grid operations.
 	 * Returns ACell — either an AString (for errors/simple text) or a structured
 	 * AMap/AVector. The caller converts structured results to JSON strings for
-	 * the tool message content.
+	 * the provider-compatible tool message content.
 	 */
 	private ACell executeToolCall(String toolName, ACell input, RequestContext ctx, ToolContext toolCtx) {
 		// Built-in task tools (must mutate ToolContext directly) — always allowed

--- a/venue/src/test/java/covia/adapter/LangChainAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/LangChainAdapterTest.java
@@ -310,6 +310,24 @@ public class LangChainAdapterTest {
 		assertInstanceOf(ToolExecutionResultMessage.class, result.get(0));
 	}
 
+	@Test
+	public void testToChatMessagesReadsLegacyStructuredToolResult() {
+		// New agent turns always carry JSON text in content (#334), but sessions
+		// persisted by an older venue may still contain structuredContent. Keep
+		// that read path lossless so an upgrade does not poison the next turn.
+		ACell nested = Maps.of("results", Vectors.of(
+			Maps.of("source", Maps.of("name", "kyc")),
+			Maps.of("source", Maps.of("name", "sanctions"))));
+		var messages = Vectors.of(
+			Maps.of("role", "tool", "id", "call_old", "name", "covia_read",
+				"structuredContent", nested));
+
+		List<ChatMessage> result = LangChainAdapter.toChatMessages(messages);
+		ToolExecutionResultMessage tool = assertInstanceOf(
+			ToolExecutionResultMessage.class, result.get(0));
+		assertEquals(JSON.toString(nested), tool.text());
+	}
+
 	// ========== Asset-referenced images (covia#198) ==========
 
 	@Test

--- a/venue/src/test/java/covia/adapter/agent/AbstractLLMAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/agent/AbstractLLMAdapterTest.java
@@ -144,25 +144,34 @@ public class AbstractLLMAdapterTest {
 	@Test
 	public void testToolResultMessageMap() {
 		AMap<AString, ACell> data = Maps.of(
-			Strings.create("status"), Strings.create("ok"));
+			Strings.create("status"), Strings.create("ok"),
+			Strings.create("nested"), Maps.of(
+				Strings.create("items"), Vectors.of(
+					Maps.of(Strings.create("risk"), Strings.create("high")))));
 		AMap<AString, ACell> msg = AbstractLLMAdapter.toolResultMessage(
 			Strings.create("call_2"), "covia_read", data);
 
 		assertEquals("tool", RT.ensureString(msg.get(AbstractLLMAdapter.K_ROLE)).toString());
-		// Map result goes into structuredContent
-		assertNotNull(msg.get(AbstractLLMAdapter.K_STRUCTURED_CONTENT));
-		assertNull(msg.get(AbstractLLMAdapter.K_CONTENT));
+		AString content = RT.ensureString(msg.get(AbstractLLMAdapter.K_CONTENT));
+		assertNotNull(content, "nested maps must cross the provider boundary as JSON text");
+		assertEquals(data, convex.core.util.JSON.parse(content));
+		assertNull(msg.get(AbstractLLMAdapter.K_STRUCTURED_CONTENT));
 	}
 
 	@Test
 	public void testToolResultMessageVector() {
-		AVector<ACell> data = Vectors.of(Strings.create("a"), Strings.create("b"));
+		AVector<ACell> data = Vectors.of(
+			Maps.of(Strings.create("source"), Maps.of(
+				Strings.create("name"), Strings.create("kyc"))),
+			Maps.of(Strings.create("source"), Maps.of(
+				Strings.create("name"), Strings.create("sanctions"))));
 		AMap<AString, ACell> msg = AbstractLLMAdapter.toolResultMessage(
 			Strings.create("call_3"), "covia_list", data);
 
-		// Vector result goes into structuredContent
-		assertNotNull(msg.get(AbstractLLMAdapter.K_STRUCTURED_CONTENT));
-		assertNull(msg.get(AbstractLLMAdapter.K_CONTENT));
+		AString content = RT.ensureString(msg.get(AbstractLLMAdapter.K_CONTENT));
+		assertNotNull(content, "vectors of maps must cross the provider boundary as JSON text");
+		assertEquals(data, convex.core.util.JSON.parse(content));
+		assertNull(msg.get(AbstractLLMAdapter.K_STRUCTURED_CONTENT));
 	}
 
 	// ========== getLLMOperation ==========

--- a/venue/src/test/java/covia/adapter/agent/LLMAgentAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/agent/LLMAgentAdapterTest.java
@@ -511,6 +511,57 @@ public class LLMAgentAdapterTest {
 		assertEquals("tool", RT.getIn(turns.get(1), "role").toString());
 	}
 
+	@Test
+	public void testNestedCoviaCollectionsReturnThroughToolLoop() throws Exception {
+		// #334: direct covia reads were fast, but the same tiny nested values
+		// stayed RUNNING indefinitely when returned as an agent tool result.
+		// Exercise the real read/list operations and the complete two-call L3
+		// loop with a deterministic provider. A wall-clock bound makes the
+		// original failure mode an explicit regression, not a suite hang.
+		RequestContext ctx = RequestContext.of(ALICE_DID);
+		engine.jobs().invokeOperation("v/ops/covia/write", Maps.of(
+			Fields.PATH, "w/issue-334/signals",
+			Fields.VALUE, Vectors.of(
+				Maps.of("kind", "kyc", "score", 8L),
+				Maps.of("kind", "sanctions", "score", 3L))), ctx).awaitResult(5000);
+		engine.jobs().invokeOperation("v/ops/covia/write", Maps.of(
+			Fields.PATH, "w/issue-334/sources",
+			Fields.VALUE, Maps.of(
+				"kyc", Maps.of("status", "clear", "provider", "acme"),
+				"sanctions", Maps.of("status", "review", "provider", "globex"))),
+			ctx).awaitResult(5000);
+
+		LLMAgentAdapter adapter = (LLMAgentAdapter) engine.getAdapter("llmagent");
+		AMap<AString, ACell> config = Maps.of(
+			"llmOperation", "v/test/ops/toolllm",
+			"defaultTools", false,
+			"tools", Vectors.of("v/ops/covia/read", "v/ops/covia/list"));
+
+		for (String prompt : new String[] {"issue-334-read", "issue-334-list"}) {
+			ACell output = java.util.concurrent.CompletableFuture.supplyAsync(() ->
+				adapter.processChat(ctx, Maps.of(
+					Fields.AGENT_ID, "issue-334-agent",
+					AgentState.KEY_CONFIG, config,
+					Fields.MESSAGES, Vectors.of(Maps.of("content", prompt)))))
+				.get(10, java.util.concurrent.TimeUnit.SECONDS);
+
+			AString response = RT.ensureString(RT.getIn(output, Fields.RESPONSE));
+			assertNotNull(response);
+			assertTrue(response.toString().startsWith("Tool returned: {"),
+				"the provider must receive a JSON text tool result, not deferred structuredContent: "
+					+ response);
+			if (prompt.endsWith("read")) {
+				assertTrue(response.toString().contains("\"score\":8"),
+					"covia/read must preserve the vector's nested maps: " + response);
+			} else {
+				assertTrue(response.toString().contains("\"values\""),
+					"covia/list field projection must preserve its nested values map: " + response);
+				assertTrue(response.toString().contains("\"review\""),
+					"covia/list projected values must reach the provider intact: " + response);
+			}
+		}
+	}
+
 	// ========== Skills index (config.skills — SKILLS.md §4) ==========
 
 	@Test


### PR DESCRIPTION
Closes #334.\n\nAgent tool-result messages now normalize structured Covia values to JSON text at the agent/provider boundary instead of carrying live maps and vectors in MCP-style structuredContent. This matches the provider message contract and avoids deferring nested collection traversal into the next model call. Older persisted structuredContent turns remain readable.\n\nRegression coverage exercises real covia/read (vector of maps) and covia/list (nested field projection) through the complete two-call llmagent loop with a 10-second bound and exact nested payload assertions.\n\nTests:\n- focused agent/LangChain suite: 193 tests\n- full mvn test: all 7 modules green