### PR TITLE
Preserve typed agent tool results and update A2A SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,10 @@ mvn test -pl covia-core
 |------------|---------|---------|
 | Convex | 0.8.10 | Lattice platform, immutable data, cryptography |
 | Javalin | 7.2.2 | HTTP server with OpenAPI/Swagger/ReDoc |
-| LangChain4j | 1.18.0 | LLM orchestration (OpenAI, Ollama, Gemini, DeepSeek) |
+| LangChain4j | 1.18.1 | LLM orchestration (OpenAI, Ollama, Gemini, DeepSeek) |
 | MCP SDK | 2.0.0 | Model Context Protocol |
-| A2A | 1.1.0.Final | Agent-to-Agent protocol |
-| JUnit | 6.1.1 | Testing |
+| A2A | 1.2.0.Final | Agent-to-Agent protocol |
+| JUnit | 6.1.3 | Testing |
 | SLF4J/Logback | 2.0.18/1.6.0 | Logging |
 
 ## Architecture Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Changed
+- Updated JUnit to 6.1.3 and the A2A Java SDK to 1.2.0.Final; A2A streaming
+  responses use the SDK's declared union serializer and omitted cancel metadata
+  is normalised to the SDK's empty-map default
+
 ## [0.8.0] - 2026-07-31
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 	<properties>
 		<maven.compiler.release>21</maven.compiler.release>
 		<maven.compiler.source>21</maven.compiler.source>
-		<junit.version>6.1.2</junit.version>
+		<junit.version>6.1.3</junit.version>
 		<convex.version>0.8.10</convex.version>
 		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -53,7 +53,7 @@
 		<javalin.version>7.2.2</javalin.version>
 		<langchain.version>1.18.1</langchain.version>
 		<mcp.version>2.0.0</mcp.version>
-		<a2a.version>1.1.0.Final</a2a.version>
+		<a2a.version>1.2.0.Final</a2a.version>
 	</properties>
 
 	<modules>

--- a/venue/src/main/java/covia/adapter/LangChainAdapter.java
+++ b/venue/src/main/java/covia/adapter/LangChainAdapter.java
@@ -239,6 +239,13 @@ public class LangChainAdapter extends AAdapter {
 		@SuppressWarnings("unchecked")
 		AVector<ACell> tools = (AVector<ACell>) ((RT.getIn(input, K_TOOLS) instanceof AVector) ? RT.getIn(input, K_TOOLS) : null);
 
+		// LangChain4j's provider messages require tool results as text. Build a
+		// provider-only copy here, before handing work to the provider worker.
+		// The canonical agent messages retain their exact structuredContent for
+		// session persistence; this narrow conversion also avoids #334's hang
+		// when nested Convex collections reached the Anthropic worker unchanged.
+		final AVector<ACell> providerMessages = serialiseToolResultsForProvider(messages);
+
 		// Response format: "json", "text", or {name, schema} map
 		ACell responseFormatCell = RT.getIn(input, K_RESPONSE_FORMAT);
 
@@ -259,7 +266,7 @@ public class LangChainAdapter extends AAdapter {
 			try {
 				// Resolve asset-referenced image blocks to inline data (covia#198):
 				// the job record keeps the ~tiny reference, not the image bytes.
-				AVector<ACell> resolvedMessages = resolveImageRefs(messages, rctx);
+				AVector<ACell> resolvedMessages = resolveImageRefs(providerMessages, rctx);
 				ACell result;
 				try {
 					result = callModel(provider, chatModel, resolvedMessages, tools, responseFormatCell);
@@ -851,6 +858,38 @@ public class LangChainAdapter extends AAdapter {
 	// ========== Message conversion ==========
 
 	/**
+	 * Returns the LangChain/provider view of a message vector.
+	 *
+	 * <p>LangChain4j models tool results as text, whereas Covia keeps structured
+	 * operation results typed in canonical agent turns. Tool messages carrying
+	 * structured content are copied; absent text is rendered as JSON, and the
+	 * provider copy drops the structured field. The input vector and its maps
+	 * are never mutated. Conversion happens before the provider worker is
+	 * started because handing the nested Convex value to that worker triggered
+	 * the collection-result stall reported in #334.</p>
+	 */
+	@SuppressWarnings("unchecked")
+	static AVector<ACell> serialiseToolResultsForProvider(AVector<ACell> messages) {
+		AVector<ACell> result = messages;
+		for (long i = 0; i < messages.count(); i++) {
+			ACell entry = messages.get(i);
+			if (!(entry instanceof AMap)) continue;
+			AString role = RT.ensureString(RT.getIn(entry, K_ROLE));
+			if (!ROLE_TOOL.equals(role)) continue;
+			ACell structured = RT.getIn(entry, K_STRUCTURED_CONTENT);
+			if (structured == null) continue;
+
+			AMap<AString, ACell> providerEntry = (AMap<AString, ACell>) entry;
+			if (RT.getIn(entry, K_CONTENT) == null) {
+				providerEntry = providerEntry.assoc(K_CONTENT, JSON.print(structured));
+			}
+			providerEntry = providerEntry.dissoc(K_STRUCTURED_CONTENT);
+			result = result.assoc(i, providerEntry);
+		}
+		return result;
+	}
+
+	/**
 	 * Converts a user message's content-block array to LangChain4j contents
 	 * (vision support, covia#198). Recognised blocks:
 	 * <ul>
@@ -1045,14 +1084,7 @@ public class LangChainAdapter extends AAdapter {
 				case "tool": {
 					AString id = RT.ensureString(RT.getIn(entry, K_ID));
 					AString name = RT.ensureString(RT.getIn(entry, K_NAME));
-					// Text content or structured content (serialised to JSON)
 					AString content = RT.ensureString(RT.getIn(entry, K_CONTENT));
-					if (content == null) {
-						ACell structured = RT.getIn(entry, K_STRUCTURED_CONTENT);
-						if (structured != null) {
-							content = Strings.create(JSON.toString(structured));
-						}
-					}
 					if (name != null && content != null) {
 						String idStr = (id != null) ? id.toString() : name.toString();
 						result.add(new ToolExecutionResultMessage(

--- a/venue/src/main/java/covia/adapter/TestAdapter.java
+++ b/venue/src/main/java/covia/adapter/TestAdapter.java
@@ -399,6 +399,10 @@ public class TestAdapter extends AAdapter {
                 if (role != null && "tool".equals(role.toString())) {
                     // Tool results present — return a text response
                     AString toolContent = RT.ensureString(RT.getIn(messages.get(i), "content"));
+					if (toolContent == null) {
+						ACell structured = RT.getIn(messages.get(i), "structuredContent");
+						if (structured != null) toolContent = convex.core.util.JSON.print(structured);
+					}
                     return Maps.of(
                         "role", Strings.create("assistant"),
                         "content", Strings.create("Tool returned: " + toolContent)
@@ -424,8 +428,8 @@ public class TestAdapter extends AAdapter {
             String arguments = "{\"echo\":\"" + escaped + "\"}";
             // #334 regression fixture: exercise real covia collection reads
             // through the agent tool loop while keeping the L3 provider fully
-            // deterministic. The second call above only accepts textual
-            // role:tool content, just like an external model provider.
+            // deterministic. LangChain's provider boundary has separate tests
+            // for its provider-only JSON rendering.
             if (lastUserMsg.contains("issue-334-read")) {
                 toolName = "covia_read";
                 arguments = "{\"path\":\"w/issue-334/signals\"}";

--- a/venue/src/main/java/covia/adapter/agent/AbstractLLMAdapter.java
+++ b/venue/src/main/java/covia/adapter/agent/AbstractLLMAdapter.java
@@ -585,13 +585,12 @@ public abstract class AbstractLLMAdapter extends AAdapter implements ContextInsp
 	/**
 	 * Creates a tool result message in the Level 3 message format.
 	 *
-	 * <p>Provider tool-result messages have one wire shape: textual
-	 * {@code content}. Structured Covia results are therefore rendered to JSON
-	 * here, at the agent/tool boundary, rather than carried as live Convex
-	 * collections in an MCP-style {@code structuredContent} field. Apart from
-	 * matching the OpenAI/Anthropic message contract, this prevents lazy nested
-	 * collection traversal from being deferred into the next provider call
-	 * (covia-ai/covia#334).</p>
+	 * <p>This is the canonical agent turn, and may be persisted under the
+	 * session's {@code g/...} state. Keep collection results as their original
+	 * Convex value in {@code structuredContent}; provider adapters that require
+	 * textual tool results are responsible for rendering a temporary wire copy.
+	 * That boundary is deliberately provider-specific so durable agent state
+	 * does not silently lose types.</p>
 	 */
 	protected static AMap<AString, ACell> toolResultMessage(
 			AString toolCallId, String toolName, ACell result) {
@@ -599,8 +598,12 @@ public abstract class AbstractLLMAdapter extends AAdapter implements ContextInsp
 			K_ROLE, ROLE_TOOL,
 			K_ID, toolCallId,
 			K_NAME, Strings.create(toolName));
+		if (result instanceof AMap || result instanceof AVector) {
+			return msg.assoc(K_STRUCTURED_CONTENT, result);
+		}
 		AString content = RT.ensureString(result);
-		return msg.assoc(K_CONTENT, (content != null) ? content : JSON.print(result));
+		return msg.assoc(K_CONTENT,
+			(content != null) ? content : Strings.create(result.toString()));
 	}
 
 	// ========== Tool-call argument parsing (the LLM wire boundary) ==========

--- a/venue/src/main/java/covia/venue/api/A2A.java
+++ b/venue/src/main/java/covia/venue/api/A2A.java
@@ -864,6 +864,11 @@ public class A2A extends ACoviaAPI {
 			@SuppressWarnings("unchecked")
 			Map<String, Object> mutable = new LinkedHashMap<>((Map<String, Object>) m);
 			mutable.putIfAbsent("tenant", "");
+			// A2A SDK 1.2 documents CancelTaskParams.metadata as optional, but
+			// its canonical record constructor defensively copies a non-null map.
+			// Gson invokes that constructor directly, so normalise an omitted
+			// wire field to the SDK builder's own empty-map default.
+			if (cls == CancelTaskParams.class) mutable.putIfAbsent("metadata", Map.of());
 			raw = mutable;
 		}
 		String json = JsonUtil.OBJECT_MAPPER.toJson(raw);

--- a/venue/src/main/java/covia/venue/api/A2ACodec.java
+++ b/venue/src/main/java/covia/venue/api/A2ACodec.java
@@ -197,7 +197,7 @@ public class A2ACodec {
 			case TASK_STATE_REJECTED       -> Status.REJECTED;
 			case TASK_STATE_INPUT_REQUIRED -> Status.INPUT_REQUIRED;
 			case TASK_STATE_AUTH_REQUIRED  -> Status.AUTH_REQUIRED;
-			case UNRECOGNIZED              -> Status.FAILED;
+			case TASK_STATE_UNSPECIFIED    -> Status.FAILED;
 		};
 	}
 
@@ -219,7 +219,7 @@ public class A2ACodec {
 		if (Status.INPUT_REQUIRED.equals(coviaStatus)) return TaskState.TASK_STATE_INPUT_REQUIRED;
 		if (Status.AUTH_REQUIRED.equals(coviaStatus)) return TaskState.TASK_STATE_AUTH_REQUIRED;
 		if (Status.PAUSED.equals(coviaStatus)) return TaskState.TASK_STATE_WORKING;
-		return TaskState.UNRECOGNIZED;
+		return TaskState.TASK_STATE_UNSPECIFIED;
 	}
 
 	// ==================== Task construction ====================

--- a/venue/src/main/java/covia/venue/api/A2ASseSession.java
+++ b/venue/src/main/java/covia/venue/api/A2ASseSession.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import org.a2aproject.sdk.jsonrpc.common.json.JsonUtil;
+import org.a2aproject.sdk.spec.StreamingEventKind;
 import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.slf4j.Logger;
@@ -132,11 +133,16 @@ public class A2ASseSession {
 	 * gson's type-hierarchy adapter serialises the concrete payload with its
 	 * discriminator ({@code "task"}, {@code "statusUpdate"}, etc.) already.
 	 */
-	private void sendFrame(Object payload) {
+	private void sendFrame(StreamingEventKind payload) {
 		Map<String, Object> envelope = new LinkedHashMap<>();
 		envelope.put("jsonrpc", "2.0");
 		envelope.put("id", rpcRequestId);
-		envelope.put("result", payload);
+		// The 1.2 SDK deliberately registers its streaming union adapter for
+		// the StreamingEventKind interface, not each concrete record. Supplying
+		// the declared type preserves the protocol's {task: ...},
+		// {statusUpdate: ...} discriminator wrapper inside result.
+		envelope.put("result", JsonUtil.OBJECT_MAPPER.toJsonTree(
+			payload, StreamingEventKind.class));
 		String json = JsonUtil.OBJECT_MAPPER.toJson(envelope);
 		sseClient.sendEvent(json);
 	}

--- a/venue/src/test/java/covia/adapter/LangChainAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/LangChainAdapterTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import convex.core.data.ACell;
 import convex.core.data.AMap;
 import convex.core.data.AString;
+import convex.core.data.AVector;
 import convex.core.data.Maps;
 import convex.core.data.Strings;
 import convex.core.data.Vectors;
@@ -311,21 +312,44 @@ public class LangChainAdapterTest {
 	}
 
 	@Test
-	public void testToChatMessagesReadsLegacyStructuredToolResult() {
-		// New agent turns always carry JSON text in content (#334), but sessions
-		// persisted by an older venue may still contain structuredContent. Keep
-		// that read path lossless so an upgrade does not poison the next turn.
+	public void testProviderCopyMakesStructuredToolResultConsumable() {
 		ACell nested = Maps.of("results", Vectors.of(
 			Maps.of("source", Maps.of("name", "kyc")),
 			Maps.of("source", Maps.of("name", "sanctions"))));
-		var messages = Vectors.of(
+		var canonical = Vectors.of(
 			Maps.of("role", "tool", "id", "call_old", "name", "covia_read",
 				"structuredContent", nested));
+		var messages = LangChainAdapter.serialiseToolResultsForProvider(canonical);
 
 		List<ChatMessage> result = LangChainAdapter.toChatMessages(messages);
 		ToolExecutionResultMessage tool = assertInstanceOf(
 			ToolExecutionResultMessage.class, result.get(0));
 		assertEquals(JSON.toString(nested), tool.text());
+	}
+
+	@Test
+	public void testProviderToolResultCopyIsTextWithoutChangingCanonicalTurn() {
+		ACell nested = Maps.of("results", Vectors.of(
+			Maps.of("source", Maps.of("name", "kyc")),
+			Maps.of("source", Maps.of("name", "sanctions"))));
+		AMap<AString, ACell> canonicalTool = Maps.of(
+			"role", "tool", "id", "call_334", "name", "covia_read",
+			"structuredContent", nested);
+		AVector<ACell> canonical = Vectors.of(
+			Maps.of("role", "user", "content", "inspect sources"), canonicalTool);
+
+		AVector<ACell> provider = LangChainAdapter.serialiseToolResultsForProvider(canonical);
+		ACell providerTool = provider.get(1);
+
+		assertSame(canonicalTool, canonical.get(1),
+			"provider preparation must not replace the durable message");
+		assertSame(nested, RT.getIn(canonical.get(1), "structuredContent"),
+			"canonical structured value must retain its exact Convex type and identity");
+		assertNull(RT.getIn(canonical.get(1), "content"));
+		assertNull(RT.getIn(providerTool, "structuredContent"));
+		AString providerText = RT.ensureString(RT.getIn(providerTool, "content"));
+		assertNotNull(providerText);
+		assertEquals(nested, JSON.parse(providerText));
 	}
 
 	// ========== Asset-referenced images (covia#198) ==========

--- a/venue/src/test/java/covia/adapter/agent/AbstractLLMAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/agent/AbstractLLMAdapterTest.java
@@ -152,10 +152,9 @@ public class AbstractLLMAdapterTest {
 			Strings.create("call_2"), "covia_read", data);
 
 		assertEquals("tool", RT.ensureString(msg.get(AbstractLLMAdapter.K_ROLE)).toString());
-		AString content = RT.ensureString(msg.get(AbstractLLMAdapter.K_CONTENT));
-		assertNotNull(content, "nested maps must cross the provider boundary as JSON text");
-		assertEquals(data, convex.core.util.JSON.parse(content));
-		assertNull(msg.get(AbstractLLMAdapter.K_STRUCTURED_CONTENT));
+		assertSame(data, msg.get(AbstractLLMAdapter.K_STRUCTURED_CONTENT),
+			"the canonical agent turn must retain the exact operation result");
+		assertNull(msg.get(AbstractLLMAdapter.K_CONTENT));
 	}
 
 	@Test
@@ -168,10 +167,9 @@ public class AbstractLLMAdapterTest {
 		AMap<AString, ACell> msg = AbstractLLMAdapter.toolResultMessage(
 			Strings.create("call_3"), "covia_list", data);
 
-		AString content = RT.ensureString(msg.get(AbstractLLMAdapter.K_CONTENT));
-		assertNotNull(content, "vectors of maps must cross the provider boundary as JSON text");
-		assertEquals(data, convex.core.util.JSON.parse(content));
-		assertNull(msg.get(AbstractLLMAdapter.K_STRUCTURED_CONTENT));
+		assertSame(data, msg.get(AbstractLLMAdapter.K_STRUCTURED_CONTENT),
+			"the canonical agent turn must retain the exact operation result");
+		assertNull(msg.get(AbstractLLMAdapter.K_CONTENT));
 	}
 
 	// ========== getLLMOperation ==========

--- a/venue/src/test/java/covia/adapter/agent/LLMAgentAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/agent/LLMAgentAdapterTest.java
@@ -519,11 +519,12 @@ public class LLMAgentAdapterTest {
 		// loop with a deterministic provider. A wall-clock bound makes the
 		// original failure mode an explicit regression, not a suite hang.
 		RequestContext ctx = RequestContext.of(ALICE_DID);
+		AVector<ACell> signals = Vectors.of(
+			Maps.of("kind", "kyc", "score", 8L),
+			Maps.of("kind", "sanctions", "score", 3L));
 		engine.jobs().invokeOperation("v/ops/covia/write", Maps.of(
 			Fields.PATH, "w/issue-334/signals",
-			Fields.VALUE, Vectors.of(
-				Maps.of("kind", "kyc", "score", 8L),
-				Maps.of("kind", "sanctions", "score", 3L))), ctx).awaitResult(5000);
+			Fields.VALUE, signals), ctx).awaitResult(5000);
 		engine.jobs().invokeOperation("v/ops/covia/write", Maps.of(
 			Fields.PATH, "w/issue-334/sources",
 			Fields.VALUE, Maps.of(
@@ -548,8 +549,16 @@ public class LLMAgentAdapterTest {
 			AString response = RT.ensureString(RT.getIn(output, Fields.RESPONSE));
 			assertNotNull(response);
 			assertTrue(response.toString().startsWith("Tool returned: {"),
-				"the provider must receive a JSON text tool result, not deferred structuredContent: "
+				"the provider must be able to consume the nested tool result: "
 					+ response);
+			AVector<ACell> turns = RT.ensureVector(RT.getIn(output, Fields.TURNS));
+			assertNotNull(turns);
+			ACell durableToolTurn = turns.get(1);
+			assertEquals("tool", RT.getIn(durableToolTurn, "role").toString());
+			assertNotNull(RT.getIn(durableToolTurn, "structuredContent"),
+				"the emitted session turn must retain the typed operation result");
+			assertNull(RT.getIn(durableToolTurn, "content"),
+				"provider text rendering must not leak back into the durable turn");
 			if (prompt.endsWith("read")) {
 				assertTrue(response.toString().contains("\"score\":8"),
 					"covia/read must preserve the vector's nested maps: " + response);
@@ -560,6 +569,32 @@ public class LLMAgentAdapterTest {
 					"covia/list projected values must reach the provider intact: " + response);
 			}
 		}
+
+		// Exercise the framework persistence path too: Fields.TURNS is appended
+		// to frames[0].conversation under g/... and must remain typed there.
+		engine.jobs().invokeOperation("v/ops/agent/create", Maps.of(
+			Fields.AGENT_ID, "issue-334-persist-agent",
+			Fields.CONFIG, Maps.of(
+				Fields.OPERATION, "v/ops/llmagent/chat",
+				"llmOperation", "v/test/ops/toolllm",
+				"defaultTools", false,
+				"tools", Vectors.of("v/ops/covia/read"))), ctx).awaitResult(5000);
+		ACell chatResult = engine.jobs().invokeOperation("v/ops/agent/chat", Maps.of(
+			Fields.AGENT_ID, "issue-334-persist-agent",
+			Fields.MESSAGE, "issue-334-read"), ctx).awaitResult(10000);
+		AString sid = RT.ensureString(RT.getIn(chatResult, Fields.SESSION_ID));
+		assertNotNull(sid);
+		AgentState persistedAgent = engine.getVenueState().users().get(ALICE_DID)
+			.agent("issue-334-persist-agent");
+		AMap<AString, ACell> session = persistedAgent.getSession(Blob.fromHex(sid.toString()));
+		AVector<ACell> frames = RT.ensureVector(RT.getIn(session, Fields.FRAMES));
+		AVector<ACell> conversation = RT.ensureVector(
+			RT.getIn(frames.get(0), AgentState.KEY_CONVERSATION));
+		ACell persistedToolTurn = conversation.get(2);
+		assertEquals("tool", RT.getIn(persistedToolTurn, "role").toString());
+		assertEquals(signals,
+			RT.getIn(persistedToolTurn, "structuredContent", Fields.VALUE));
+		assertNull(RT.getIn(persistedToolTurn, "content"));
 	}
 
 	// ========== Skills index (config.skills — SKILLS.md §4) ==========

--- a/venue/src/test/java/covia/venue/api/A2ACodecTest.java
+++ b/venue/src/test/java/covia/venue/api/A2ACodecTest.java
@@ -82,8 +82,15 @@ public class A2ACodecTest {
 	}
 
 	@Test
-	public void taskStateMapping_unknownStatusIsUnrecognized() {
-		assertEquals(TaskState.UNRECOGNIZED, A2ACodec.toTaskState(Strings.create("BOGUS")));
+	public void taskStateMapping_unknownStatusIsUnspecified() {
+		assertEquals(TaskState.TASK_STATE_UNSPECIFIED,
+			A2ACodec.toTaskState(Strings.create("BOGUS")));
+	}
+
+	@Test
+	public void taskStateMapping_unspecifiedInboundFailsSafe() {
+		assertEquals(Status.FAILED,
+			A2ACodec.fromTaskState(TaskState.TASK_STATE_UNSPECIFIED));
 	}
 
 	// ======== Task construction ========


### PR DESCRIPTION
## Summary
- preserve canonical agent tool results as typed structuredContent in durable session history
- render a temporary JSON text copy only at the LangChain provider boundary for the #334 workaround
- update JUnit to 6.1.3 and A2A Java SDK to 1.2.0.Final
- migrate A2A unspecified task state, streaming union serialization, and omitted cancel metadata handling

## Tests
- focused agent/provider regressions: 194 passed
- focused A2A suite: 64 passed
- full seven-module mvn test: passed