### PR TITLE
Fix asset content diagnostics and bounded agent shutdown

### DIFF
--- a/venue/src/main/java/covia/adapter/AgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/AgentAdapter.java
@@ -92,6 +92,8 @@ public class AgentAdapter extends AAdapter {
 
 	/** Maximum run loop iterations before forced exit (safety net) */
 	private static final int MAX_LOOP_ITERATIONS = 20;
+	/** Administrative shutdown must never wait forever on a wedged run loop. */
+	static final long HALT_TIMEOUT_MS = 5_000;
 
 	/**
 	 * Per-agent launcher slot. Presence of a non-done entry means a virtual
@@ -781,13 +783,30 @@ public class AgentAdapter extends AAdapter {
 		cancelActiveTransition(key);
 		if (oldLoop != null && !oldLoop.isDone()) {
 			try {
-				oldLoop.join();
-			} catch (java.util.concurrent.CompletionException
-					| java.util.concurrent.CancellationException ignored) {
+				awaitLoopExit(oldLoop, HALT_TIMEOUT_MS);
+			} catch (TimeoutException e) {
+				job.fail("Agent " + agentId + " did not stop within "
+					+ HALT_TIMEOUT_MS + " ms");
+				return false;
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				job.fail("Interrupted while waiting for agent " + agentId + " to stop");
+				return false;
+			} catch (java.util.concurrent.CancellationException ignored) {
 				// The requested terminal state is already set; only loop exit matters.
 			}
 		}
 		return true;
+	}
+
+	/** Bounded wait seam kept package-visible for deterministic regression tests. */
+	static void awaitLoopExit(CompletableFuture<?> loop, long timeoutMs)
+			throws TimeoutException, InterruptedException {
+		try {
+			loop.get(timeoutMs, TimeUnit.MILLISECONDS);
+		} catch (java.util.concurrent.ExecutionException ignored) {
+			// Exceptional completion still means the run loop exited.
+		}
 	}
 
 	/**
@@ -2415,7 +2434,7 @@ public class AgentAdapter extends AAdapter {
 				// (after the put, so one side always sees the other's write)
 				// and cancel locally rather than blocking on a doomed cycle.
 				AgentState recheck = getAgent(ownerDID, agentId);
-				if (recheck == null || AgentState.SUSPENDED.equals(recheck.getStatus())) {
+				if (shouldCancelRegisteredTransition(recheck)) {
 					cancelToken.set(true);
 					transitionFuture.cancel(true);
 				}
@@ -2510,6 +2529,13 @@ public class AgentAdapter extends AAdapter {
 				wakeAgent(ownerDID, agentId, false);
 			}
 		}
+	}
+
+	/** Close the administrative-stop/transition-registration race. */
+	static boolean shouldCancelRegisteredTransition(AgentState agent) {
+		if (agent == null) return true;
+		AString status = agent.getStatus();
+		return AgentState.SUSPENDED.equals(status) || AgentState.TERMINATED.equals(status);
 	}
 
 	/**

--- a/venue/src/main/java/covia/adapter/AssetAdapter.java
+++ b/venue/src/main/java/covia/adapter/AssetAdapter.java
@@ -188,6 +188,7 @@ public class AssetAdapter extends AAdapter {
 	}
 
 	private static final AString K_EXISTS = Strings.intern("exists");
+	private static final AString K_HAS_CONTENT = Strings.intern("hasContent");
 	private static final AString K_CONTENT_TEXT = Strings.intern("contentText");
 	private static final AString K_MAX_SIZE = Strings.intern("maxSize");
 	private static final AString K_TRUNCATED = Strings.intern("truncated");
@@ -276,9 +277,11 @@ public class AssetAdapter extends AAdapter {
 				long sz = resolved.content().getSize();
 				if (sz > maxSz) {
 					return Maps.of(Fields.ID, idStr, K_EXISTS, CVMBool.TRUE,
+						K_HAS_CONTENT, CVMBool.TRUE,
 						K_TRUNCATED, CVMBool.TRUE, K_SIZE, CVMLong.create(sz));
 				}
 				return Maps.of(Fields.ID, idStr, K_EXISTS, CVMBool.TRUE,
+					K_HAS_CONTENT, CVMBool.TRUE,
 					Fields.VALUE, resolved.content().getBlob());
 			}
 		} catch (java.io.IOException e) {
@@ -307,13 +310,18 @@ public class AssetAdapter extends AAdapter {
 		}
 
 		if (record == null) {
-			return Maps.of(Fields.ID, idStr, K_EXISTS, CVMBool.FALSE);
+			return Maps.of(Fields.ID, idStr, K_EXISTS, CVMBool.FALSE,
+				K_HAS_CONTENT, CVMBool.FALSE);
 		}
 
 		ACell content = record.get(AssetStore.POS_CONTENT);
 		if (content == null) {
-			// Asset exists but has no content payload
-			return Maps.of(Fields.ID, idStr, K_EXISTS, CVMBool.TRUE);
+			// The CAS record exists, but callers (especially tool-using models)
+			// need an explicit distinction from a legitimately empty payload.
+			return Maps.of(Fields.ID, idStr, K_EXISTS, CVMBool.TRUE,
+				K_HAS_CONTENT, CVMBool.FALSE,
+				Fields.MESSAGE, Strings.create(
+					"Asset metadata does not specify a content payload"));
 		}
 
 		// Size guard — consistent with covia:read maxSize pattern
@@ -327,6 +335,7 @@ public class AssetAdapter extends AAdapter {
 			return Maps.of(
 				Fields.ID, idStr,
 				K_EXISTS, CVMBool.TRUE,
+				K_HAS_CONTENT, CVMBool.TRUE,
 				K_TRUNCATED, CVMBool.TRUE,
 				K_SIZE, CVMLong.create(size));
 		}
@@ -335,6 +344,7 @@ public class AssetAdapter extends AAdapter {
 		return Maps.of(
 			Fields.ID, idStr,
 			K_EXISTS, CVMBool.TRUE,
+			K_HAS_CONTENT, CVMBool.TRUE,
 			Fields.VALUE, content);
 	}
 

--- a/venue/src/main/resources/adapters/asset/content.json
+++ b/venue/src/main/resources/adapters/asset/content.json
@@ -19,7 +19,9 @@
       "properties": {
         "id": { "type": "string", "description": "Asset reference (echoed)" },
         "exists": { "type": "boolean", "description": "True if a CAS record was found for the resolved asset" },
-        "value": { "type": "string", "description": "Content as hex-encoded Blob (0x...). Present when exists is true and not truncated." },
+        "hasContent": { "type": "boolean", "description": "True if the resolved address has a content payload. An existing metadata-only asset returns exists: true and hasContent: false." },
+        "value": { "type": "string", "description": "Content as hex-encoded Blob (0x...). Present when hasContent is true and not truncated." },
+        "message": { "type": "string", "description": "Diagnostic explaining why an existing asset has no content payload." },
         "truncated": { "type": "boolean", "description": "True if content exceeds maxSize" },
         "size": { "type": "integer", "description": "Content size in bytes (present when truncated)" }
       }

--- a/venue/src/test/java/covia/adapter/AgentAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/AgentAdapterTest.java
@@ -2,6 +2,9 @@ package covia.adapter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -46,6 +49,31 @@ public class AgentAdapterTest {
 	// user namespace within the shared engine.
 	private AString ALICE_DID;
 	private AString BOB_DID;
+
+	@Test
+	public void testAwaitLoopExitIsBoundedAndAcceptsExceptionalExit() throws Exception {
+		CompletableFuture<ACell> wedged = new CompletableFuture<>();
+		assertThrows(TimeoutException.class,
+			() -> AgentAdapter.awaitLoopExit(wedged, 25));
+
+		CompletableFuture<ACell> failed = new CompletableFuture<>();
+		failed.completeExceptionally(new IllegalStateException("loop failed"));
+		assertDoesNotThrow(() -> AgentAdapter.awaitLoopExit(failed, 25),
+			"an exceptional completion is still a completed shutdown");
+	}
+
+	@Test
+	public void testTerminatedAgentCancelsLateRegisteredTransition() {
+		AgentState agent = engine.getVenueState().users().ensure(ALICE_DID)
+			.ensureAgent(Strings.create("late-transition"), Maps.empty(), null);
+		assertFalse(AgentAdapter.shouldCancelRegisteredTransition(agent));
+
+		agent.setStatus(AgentState.TERMINATED);
+		assertTrue(AgentAdapter.shouldCancelRegisteredTransition(agent),
+			"a transition registered after deletion must be cancelled");
+		assertTrue(AgentAdapter.shouldCancelRegisteredTransition(null),
+			"a transition registered after physical removal must be cancelled");
+	}
 
 	@BeforeEach
 	public void setup(TestInfo info) {

--- a/venue/src/test/java/covia/adapter/AssetAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/AssetAdapterTest.java
@@ -290,6 +290,7 @@ public class AssetAdapterTest {
 			Maps.of(Fields.ID, id), RequestContext.of(ALICE_DID));
 		ACell contentResult = contentJob.awaitResult(5000);
 		assertEquals(CVMBool.TRUE, RT.getIn(contentResult, Strings.create("exists")));
+		assertEquals(CVMBool.TRUE, RT.getIn(contentResult, "hasContent"));
 
 		ACell value = RT.getIn(contentResult, Fields.VALUE);
 		assertNotNull(value, "Content value should be present");
@@ -463,6 +464,9 @@ public class AssetAdapterTest {
 		ACell result = contentJob.awaitResult(5000);
 
 		assertEquals(CVMBool.TRUE, RT.getIn(result, Strings.create("exists")));
+		assertEquals(CVMBool.FALSE, RT.getIn(result, "hasContent"));
+		assertNotNull(RT.getIn(result, Fields.MESSAGE),
+			"metadata-only assets should explain why no value is present");
 		assertNull(RT.getIn(result, Fields.VALUE), "No content payload should mean no value");
 	}
 
@@ -473,6 +477,7 @@ public class AssetAdapterTest {
 			RequestContext.of(ALICE_DID));
 		ACell result = job.awaitResult(5000);
 		assertEquals(CVMBool.FALSE, RT.getIn(result, Strings.create("exists")));
+		assertEquals(CVMBool.FALSE, RT.getIn(result, "hasContent"));
 	}
 
 	// ========== Content vs metadata identity ==========
@@ -1085,12 +1090,13 @@ public class AssetAdapterTest {
 	public void testContentByVOpsPath() {
 		// /v/ops/json/merge is a CAS-stored asset with no content blob —
 		// resolvePath finds the metadata, derived hash hits the venue CAS
-		// record, and the content payload is null. exists: true, no value.
+		// record, and the content payload is null. exists: true, hasContent: false.
 		Job job = engine.jobs().invokeOperation("v/ops/asset/content",
 			Maps.of(Fields.ID, "v/ops/json/merge"), RequestContext.of(ALICE_DID));
 		ACell result = job.awaitResult(5000);
 
 		assertEquals(CVMBool.TRUE, RT.getIn(result, Strings.create("exists")));
+		assertEquals(CVMBool.FALSE, RT.getIn(result, "hasContent"));
 		assertNull(RT.getIn(result, Fields.VALUE));
 	}
 
@@ -1123,6 +1129,7 @@ public class AssetAdapterTest {
 			Maps.of(Fields.ID, "w/no/such/place"), RequestContext.of(ALICE_DID));
 		ACell result = job.awaitResult(5000);
 		assertEquals(CVMBool.FALSE, RT.getIn(result, Strings.create("exists")));
+		assertEquals(CVMBool.FALSE, RT.getIn(result, "hasContent"));
 	}
 
 	@Test


### PR DESCRIPTION
Closes #331. Closes #333. Adds an explicit asset content discriminator and diagnostic, bounds agent shutdown waits, closes the terminated-agent transition registration race, and adds regression coverage. Verified with the full Maven reactor test suite.