### PR TITLE
Fix A2A long-turn reattachment

### DIFF
--- a/venue/docs/A2A_AGENTS.md
+++ b/venue/docs/A2A_AGENTS.md
@@ -161,8 +161,11 @@ trust branch exists. The task Job records its session under `SESSION_ID` (which
 `Job.completeWith` preserves across completion), so `A2ACodec` surfaces
 `contextId = session` for the task's whole lifecycle — the same on `SendMessage`
 and on a later `GetTask`. `GetTask` / `CancelTask` reuse the front-door by-id
-handlers (a Task id is a global, caller-scoped Job id). Task continuations with
-an incoming `taskId` are not yet implemented (#306).
+handlers (a Task id is a global, caller-scoped Job id). `SubscribeToTask`
+attaches SSE updates directly to that same Job. A fresh `SendMessage` returns
+immediately with its Task and session identifiers; it never imposes a
+synchronous turn deadline. Polling and SSE therefore observe one state machine
+and converge on the same final Task.
 
 ## Relationship to the venue-as-single-agent model
 
@@ -183,6 +186,9 @@ Shipped:
 - Private-by-default cards, explicit public publication, and attenuated
   anonymous interaction scopes alongside UCAN delegation.
 - `GetTask` and `CancelTask` on the per-agent endpoint.
+- `SubscribeToTask` reattachment on the per-agent endpoint, backed by the same
+  durable Job used by polling.
+- Incoming `taskId` continuation, idempotent by A2A `messageId` (#306).
 
 The route, publication and task-mapping contract is covered by
 `A2AAgentCardTest`; common JSON-RPC and codec behavior is covered by `A2ATest`,
@@ -191,5 +197,3 @@ The route, publication and task-mapping contract is covered by
 Open protocol work:
 
 - #304 — relay authenticated caller authority for outbound A2A requests.
-- #305 — define stable reattachment when a turn outlives the synchronous wait.
-- #306 — support per-agent multi-turn continuation with incoming `taskId`.

--- a/venue/docs/CONFIG.md
+++ b/venue/docs/CONFIG.md
@@ -805,8 +805,8 @@ LAN-reachable one. The agent-card GET is public and works regardless.
 **Per-agent endpoints (COG-14):** beyond the front door, every hosted agent is
 addressable at `POST /a2a/<ownerDID>/g/<agentId>` (JSON-RPC `SendMessage` →
 `agent:request` task Job = A2A Task; `GetTask`, `CancelTask`,
-`GetExtendedAgentCard`), with its card at the A2A well-known path below that
-base. Private by default: the owner interacts as themselves; anonymous
+`SubscribeToTask`, `GetExtendedAgentCard`), with its card at the A2A well-known
+path below that base. Private by default: the owner interacts as themselves; anonymous
 non-owners get an existence-hiding 404, authenticated non-owners 403.
 Publishing is per-agent config: `a2a: {public: true}` makes the card
 discoverable; adding an explicit `a2a.caps` scope accepts stranger
@@ -848,11 +848,17 @@ The result is an A2A Task. Poll its `id` at the same `AGENT_URL` with
 The `Authorization` header may be omitted only when the agent is explicitly
 published with an `a2a.caps` scope that permits the interaction.
 
-Current boundaries: incoming per-agent `taskId` continuation is not implemented
-(#306); long-running turns still need stable synchronous-boundary reattachment
-(#305); and outbound `v/ops/a2a/*` calls do not yet relay caller authority to a
-remote venue (#304). Outbound calls do pass the HTTP adapter's SSRF checks and
-operator allow/block lists.
+`SendMessage` never waits for the agent turn to finish. It returns the current
+Task snapshot as soon as the durable Job has been submitted: Task `id` is the
+Job id and `contextId` is the session id. A turn may therefore run for minutes,
+days, or longer without crossing a protocol timeout or changing identity.
+Reconnect with `GetTask`, or open `SubscribeToTask` at the same endpoint for
+SSE updates. Both read the same Job record and converge on the same terminal
+state; closing an HTTP request or SSE connection does not fail or cancel it.
+
+Current boundary: outbound `v/ops/a2a/*` calls do not yet relay caller authority
+to a remote venue (#304). Outbound calls do pass the HTTP adapter's SSRF checks
+and operator allow/block lists.
 
 ## Secrets bootstrap
 

--- a/venue/src/main/java/covia/venue/api/A2A.java
+++ b/venue/src/main/java/covia/venue/api/A2A.java
@@ -333,6 +333,11 @@ public class A2A extends ACoviaAPI {
 					CancelTaskParams params = parseParams(paramsRaw, CancelTaskParams.class);
 					doCancelTask(ctx, id, params, dispatch);
 				}
+				case A2AMethods.SUBSCRIBE_TO_TASK_METHOD -> {
+					org.a2aproject.sdk.spec.TaskIdParams params =
+							parseParams(paramsRaw, org.a2aproject.sdk.spec.TaskIdParams.class);
+					doSubscribeToTask(ctx, id, params, dispatch, ref.agentId());
+				}
 				case A2AMethods.GET_EXTENDED_AGENT_CARD_METHOD ->
 					// The access gate already ran; the agent's extended card is
 					// its card — per-agent skills from offered ops are a later pass.
@@ -800,6 +805,18 @@ public class A2A extends ACoviaAPI {
 	}
 
 	private void doSubscribeToTask(Context ctx, Object id, org.a2aproject.sdk.spec.TaskIdParams params) {
+		doSubscribeToTask(ctx, id, params, AuthMiddleware.callerContext(ctx), null);
+	}
+
+	/**
+	 * Subscribe to the ordinary Covia Job backing an A2A Task. A non-null
+	 * {@code expectedAgentId} binds a per-agent endpoint to tasks created for
+	 * that exact agent; the endpoint must not become a general owner-wide Job
+	 * subscription surface.
+	 */
+	private void doSubscribeToTask(Context ctx, Object id,
+			org.a2aproject.sdk.spec.TaskIdParams params, RequestContext rctx,
+			String expectedAgentId) {
 		if (params == null || params.id() == null) {
 			writeError(ctx, id, A2AErrorCodes.INVALID_PARAMS, "id required");
 			return;
@@ -812,8 +829,6 @@ public class A2A extends ACoviaAPI {
 			writeError(ctx, id, A2AErrorCodes.INVALID_PARAMS, "Invalid task id");
 			return;
 		}
-		RequestContext rctx = AuthMiddleware.callerContext(ctx);
-
 		AMap<AString, ACell> jobData;
 		try {
 			jobData = engine().jobs().getJobData(taskId, rctx);
@@ -824,6 +839,14 @@ public class A2A extends ACoviaAPI {
 		if (jobData == null) {
 			writeError(ctx, id, A2AErrorCodes.TASK_NOT_FOUND, "Task not found: " + params.id());
 			return;
+		}
+		if (expectedAgentId != null) {
+			AString taskAgent = RT.ensureString(RT.getIn(jobData, Fields.INPUT, Fields.AGENT_ID));
+			if (taskAgent == null || !expectedAgentId.equals(taskAgent.toString())) {
+				writeError(ctx, id, A2AErrorCodes.TASK_NOT_FOUND,
+					"Task not found for this agent");
+				return;
+			}
 		}
 		// Per spec §9.4.6: SubscribeToTask on a terminal task returns
 		// UnsupportedOperationError — there will never be more frames.

--- a/venue/src/main/java/covia/venue/api/A2ASseSession.java
+++ b/venue/src/main/java/covia/venue/api/A2ASseSession.java
@@ -69,13 +69,18 @@ public class A2ASseSession {
 	}
 
 	/**
-	 * Emit the initial Task frame and attach the listener. Returns immediately
+	 * Attach the listener and emit the initial Task frame. Returns immediately
 	 * — subsequent frames are driven by Job updates.
 	 *
 	 * <p>If the Job is already in a terminal state, emits the initial Task
 	 * plus one {@code final:true} statusUpdate, then closes.</p>
 	 */
-	public void start() {
+	public synchronized void start() {
+		// Javalin completes an SSE response when the handler returns unless the
+		// client is explicitly kept alive. Without this, subscribers receive the
+		// initial Task snapshot but never any later Job transition (#305).
+		sseClient.keepAlive();
+
 		// Disconnect hook before anything else — Javalin closes idle SSE
 		// connections after a timeout and the peer may abort at any time.
 		sseClient.onClose(this::close);
@@ -90,6 +95,14 @@ public class A2ASseSession {
 
 		Job job = engine.jobs().getJob(taskId);
 		if (job == null) {
+			// The Job may have completed and been evicted between the authorised
+			// lookup above and this active-cache lookup. Re-read the durable record
+			// so the stream cannot finish on a stale non-terminal snapshot.
+			data = engine.jobs().getJobData(taskId, rctx);
+			if (data == null) {
+				close();
+				return;
+			}
 			// Job already evicted (terminal). Emit snapshot + final frame and close.
 			sendFrame(A2ACodec.toTask(data));
 			if (Job.isFinished(data)) {
@@ -98,6 +111,14 @@ public class A2ASseSession {
 			close();
 			return;
 		}
+
+		// Subscribe before taking the emitted snapshot. start() and
+		// onJobUpdate() share the same monitor: an update that commits in this
+		// window either appears in the snapshot below or waits and is emitted as
+		// the next status frame. Fast completion can therefore never be lost.
+		this.subscribedJob = job;
+		job.subscribe(listener);
+		data = job.getData();
 
 		// Frame 1: Task snapshot
 		sendFrame(A2ACodec.toTask(data));
@@ -108,12 +129,9 @@ public class A2ASseSession {
 			return;
 		}
 
-		// Attach directly to the Job — no taskId filtering, no global dispatch.
-		this.subscribedJob = job;
-		job.subscribe(listener);
 	}
 
-	private void onJobUpdate(Job job) {
+	private synchronized void onJobUpdate(Job job) {
 		if (closed.get()) return;
 		AMap<AString, ACell> data = job.getData();
 		try {

--- a/venue/src/test/java/covia/venue/api/A2AAgentCardTest.java
+++ b/venue/src/test/java/covia/venue/api/A2AAgentCardTest.java
@@ -11,11 +11,13 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.a2aproject.sdk.jsonrpc.common.json.JsonUtil;
 import org.a2aproject.sdk.spec.AgentCard;
@@ -24,8 +26,10 @@ import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.MessageSendParams;
 import org.a2aproject.sdk.spec.Part;
 import org.a2aproject.sdk.spec.Task;
+import org.a2aproject.sdk.spec.TaskIdParams;
 import org.a2aproject.sdk.spec.TaskQueryParams;
 import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.a2aproject.sdk.spec.TextPart;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -387,6 +391,54 @@ public class A2AAgentCardTest {
 		awaitTask(endpoint, next.id(), jwt, TaskState.TASK_STATE_COMPLETED);
 	}
 
+	/**
+	 * #305 — an A2A turn has no synchronous completion deadline. SendMessage
+	 * returns the ordinary durable task Job immediately; the same id can be
+	 * reattached through polling or SSE, and both views converge on one final
+	 * state. The deterministic transition delay keeps the task live while the
+	 * client disconnects from SendMessage and opens a fresh subscription.
+	 */
+	@Test
+	public void longTurnReattachesAndPollingConvergesWithSse() throws Exception {
+		AKeyPair kp = AKeyPair.generate();
+		AString ownerDid = didOf(kp);
+		String jwt = bearerFor(kp);
+		String agentId = "LongTurn" + Long.toUnsignedString(System.nanoTime());
+		VenueHTTP client = VenueHTTP.create(URI.create(BASE_URL), VenueAuth.bearer(jwt));
+		client.setTimeout(5000);
+
+		Job created = client.invokeAndWait(Strings.create("v/ops/agent/create"), Maps.of(
+			Fields.AGENT_ID, Strings.create(agentId),
+			Fields.CONFIG, Maps.of(
+				Fields.OPERATION, Strings.create("v/test/ops/taskcomplete"),
+				Fields.DELAY, convex.core.data.prim.CVMLong.create(3000))));
+		assertEquals(Status.COMPLETE, created.getStatus(), created.getErrorMessage());
+
+		String endpoint = "/a2a/" + ownerDid + "/g/" + agentId;
+		Task submitted = extractTask(parse(post(endpoint,
+			rpcEnvelope("long-send", "SendMessage",
+				new MessageSendParams(userMessage("long turn"), null, null)), jwt)));
+		assertNotNull(submitted);
+		assertNotNull(submitted.id(), "SendMessage must return the durable Job id");
+		assertNotNull(submitted.contextId(), "SendMessage must return the session id");
+		assertTrue(!submitted.status().state().isFinal(),
+			"SendMessage must not wait for or manufacture a terminal timeout");
+
+		TaskStatusUpdateEvent streamed = awaitFinalStatusUpdate(endpoint,
+			submitted.id(), jwt, 7000);
+		assertEquals(submitted.id(), streamed.taskId());
+		assertEquals(submitted.contextId(), streamed.contextId());
+		assertTrue(streamed.isFinal());
+		assertEquals(TaskState.TASK_STATE_COMPLETED, streamed.status().state());
+
+		Task polled = awaitTask(endpoint, submitted.id(), jwt,
+			TaskState.TASK_STATE_COMPLETED);
+		assertEquals(streamed.taskId(), polled.id());
+		assertEquals(streamed.contextId(), polled.contextId());
+		assertEquals(streamed.status().state(), polled.status().state(),
+			"GetTask and SubscribeToTask must converge on the same Job state");
+	}
+
 	// ---- helpers ----
 
 	private static AString didOf(AKeyPair kp) {
@@ -449,6 +501,69 @@ public class A2AAgentCardTest {
 			+ "; last state=" + (task == null ? null : task.status().state()));
 	}
 
+	private TaskStatusUpdateEvent awaitFinalStatusUpdate(String endpoint,
+			String taskId, String jwt, long timeoutMs) throws Exception {
+		HttpResponse<java.util.stream.Stream<String>> response = postStreaming(endpoint,
+			rpcEnvelope("long-subscribe", "SubscribeToTask", new TaskIdParams(taskId)), jwt);
+		assertEquals(200, response.statusCode());
+		assertTrue(response.headers().firstValue("Content-Type").orElse("")
+			.contains("text/event-stream"));
+
+		AtomicReference<TaskStatusUpdateEvent> terminal = new AtomicReference<>();
+		AtomicReference<Throwable> consumerFailure = new AtomicReference<>();
+		List<String> observed = Collections.synchronizedList(new java.util.ArrayList<>());
+		Object signal = new Object();
+		Thread consumer = Thread.ofVirtual().start(() -> {
+			try (java.util.stream.Stream<String> lines = response.body()) {
+				var iterator = lines.iterator();
+				while (iterator.hasNext()) {
+					String line = iterator.next();
+					if (!line.startsWith("data:")) continue;
+					observed.add(line);
+					@SuppressWarnings("unchecked")
+					Map<String, Object> envelope = JsonUtil.OBJECT_MAPPER.fromJson(
+						line.substring(line.indexOf(':') + 1).trim(), Map.class);
+					Map<String, Object> result = castMap(envelope.get("result"));
+					Map<String, Object> update = result == null
+						? null : castMap(result.get("statusUpdate"));
+					if (update == null) continue;
+					TaskStatusUpdateEvent event = JsonUtil.OBJECT_MAPPER.fromJson(
+						JsonUtil.OBJECT_MAPPER.toJson(update), TaskStatusUpdateEvent.class);
+					if (!event.isFinal()) continue;
+					terminal.set(event);
+					synchronized (signal) { signal.notifyAll(); }
+					return;
+				}
+			} catch (RuntimeException failure) {
+				consumerFailure.compareAndSet(null, failure);
+				synchronized (signal) { signal.notifyAll(); }
+			}
+		});
+
+		long deadline = System.currentTimeMillis() + timeoutMs;
+		synchronized (signal) {
+			while (terminal.get() == null && consumerFailure.get() == null
+					&& System.currentTimeMillis() < deadline) {
+				signal.wait(Math.max(1, deadline - System.currentTimeMillis()));
+			}
+		}
+		try { response.body().close(); } catch (Exception ignored) {}
+		if (!consumer.join(Duration.ofMillis(500))) consumer.interrupt();
+		if (terminal.get() == null) {
+			Task current = extractTask(parse(post(endpoint,
+				rpcEnvelope("long-diagnostic", "GetTask", new TaskQueryParams(taskId, null)), jwt)));
+			throw new AssertionError("SubscribeToTask did not emit a final update; failure="
+				+ consumerFailure.get() + "; frames=" + observed + "; current="
+				+ (current == null ? null : current.status().state()));
+		}
+		return terminal.get();
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> castMap(Object value) {
+		return value instanceof Map<?, ?> ? (Map<String, Object>) value : null;
+	}
+
 	private HttpResponse<String> postUnchecked(String path, Object body, String jwt) {
 		try {
 			return post(path, body, jwt);
@@ -471,5 +586,16 @@ public class A2AAgentCardTest {
 				.timeout(Duration.ofSeconds(10));
 		if (jwt != null) b.header("Authorization", "Bearer " + jwt);
 		return http.send(b.build(), HttpResponse.BodyHandlers.ofString());
+	}
+
+	private HttpResponse<java.util.stream.Stream<String>> postStreaming(
+			String path, Object body, String jwt) throws Exception {
+		HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(BASE_URL + path))
+			.header("Content-Type", "application/json")
+			.header("Accept", "text/event-stream")
+			.POST(HttpRequest.BodyPublishers.ofString(JsonUtil.OBJECT_MAPPER.toJson(body)))
+			.timeout(Duration.ofSeconds(10));
+		if (jwt != null) b.header("Authorization", "Bearer " + jwt);
+		return http.send(b.build(), HttpResponse.BodyHandlers.ofLines());
 	}
 }


### PR DESCRIPTION
## Summary
- expose per-agent SubscribeToTask over the existing durable Job
- keep A2A SSE sessions alive and close the snapshot/subscription race
- document immediate SendMessage return plus polling/SSE reattachment semantics
- add a deterministic delayed-agent convergence test

## Verification
- focused A2A suite: 65 tests passing
- full reactor: mvn test passing

Closes #305