### PR TITLE
Clarify agent execution durability boundary

### DIFF
--- a/skills/test-agent/SKILL.md
+++ b/skills/test-agent/SKILL.md
@@ -57,7 +57,8 @@ covia_read  path=w/<expected-path>
 Read the agent's full state to understand behaviour:
 
 ```
-covia_read  path=g/<name>/status          → SLEEPING, RUNNING, SUSPENDED
+agent_info  agentId=<name>                → validated SLEEPING, RUNNING, or SUSPENDED
+covia_read  path=g/<name>/status          → persisted marker (RUNNING may be stale if venue is offline)
 covia_read  path=g/<name>/error           → error message if SUSPENDED
 covia_read  path=g/<name>/config          → framework config (caps, tools, model)
 covia_read  path=g/<name>/state/history   → full LLM conversation with tool calls

--- a/venue/docs/AGENT_LOOP.md
+++ b/venue/docs/AGENT_LOOP.md
@@ -58,7 +58,7 @@ The agent's value is a plain map. Every write replaces the entire map atomically
 | Field | Type | Description |
 |-------|------|-------------|
 | `ts` | long | Timestamp of the last write. **The merge discriminator.** Set on every write. |
-| `status` | string | `"SLEEPING"` \| `"RUNNING"` \| `"SUSPENDED"` \| `"TERMINATED"` |
+| `status` | string | `"SLEEPING"` \| `"RUNNING"` \| `"SUSPENDED"` \| `"TERMINATED"`. `RUNNING` is a persisted execution marker, validated against the live executor by the hosting venue. |
 | `config` | map | Framework-level configuration. Includes `operation` (default transition op). |
 | `state` | any | User-defined state. Opaque to the framework. Passed to and returned from the transition function. Transition-function-specific configuration (e.g. LLM provider, model) lives here, not in `config`. Set at creation via optional initial state. Conversation content lives on the session record (`session.frames[0].conversation`), not here. |
 | `tasks` | index | `Index<Blob, ACell>` of inbound request Job IDs. Persistent until resolved. Ordered by Job ID. |
@@ -119,10 +119,12 @@ Timeline entries are only appended on success. On error, no timeline entry is
 written — the error is recorded in the agent record's `error` field and all
 queues are preserved for retry.
 
-### 2.5 Status Lifecycle
+### 2.5 Status and execution
 
-The `status` field is the source of truth for what the agent is doing right now
-and which operations may safely act on it. There are four states:
+The lattice `status` field includes a persisted `RUNNING` marker for lattice and
+remote observability. Current execution ownership still comes from the venue's
+live executor registry. A stored `RUNNING` without a matching local executor is
+stale; startup clears it before scheduling durable work.
 
 ```
                     agent:create
@@ -139,7 +141,7 @@ and which operations may safely act on it. There are four states:
         │          └────┬─────┘         │
         │               │               │
         │      ┌────────┴────────┐      │
-        │      │ run loop done   │      │
+        │      │ attempt done    │      │
         │ ok   │                 │ error│
         └──────┘                 └─────▶┌───────────┐
                                         │ SUSPENDED │
@@ -154,16 +156,16 @@ and which operations may safely act on it. There are four states:
 
 | Status | Meaning | Run loop | Mutations allowed |
 |--------|---------|----------|-------------------|
-| `SLEEPING` | Idle, no transition active. Default after create or after a successful run with no remaining work. | Not running. `wakeAgent` triggers it. | All. Safe to update config in place. |
-| `RUNNING` | A transition is currently in flight on a virtual thread. Record mutations go through atomic cursor updates. | Running. New work is appended to `tasks`/`session.pending` and picked up on next iteration. | Task/session appends are allowed. In-place config mutation is rejected because the transition captured the old config; suspend it before updating, or delete it explicitly. |
+| `SLEEPING` | Durable runnable/idle state. | `wakeAgent` may start a live attempt. | All except config mutation while a live attempt exists. |
+| `RUNNING` | Persisted dirty marker: an attempt was launched. The hosting venue validates it against the live launcher slot. | Running when the matching slot is live; otherwise stale until startup cleanup. | Task/session appends are allowed. In-place config mutation is rejected using the live executor check. |
 | `SUSPENDED` | Last run failed with an error. Dormant — does not auto-retry. State, pending messages, sessions, and history are preserved; failed tasks are drained. | Not running. Resume via `tryResume` to keep the record, or delete it with `remove:true` before creating a replacement. | All. |
 | `TERMINATED` | Logically deleted. Slot still occupies the namespace key (so the ID is reserved) but the agent is dead. | Cannot run. `agent:request` / `agent:message` / `agent:trigger` all fail. | None. Remove the record explicitly with `agent:delete remove:true` before reusing the ID. |
 
-**State transitions** are documented in §4: `create` (→SLEEPING), `wakeAgent`
-(SLEEPING→RUNNING via CAS, §4.6), run loop completion (RUNNING→SLEEPING or
-RUNNING→SUSPENDED, §4.4), `agent:resume` (SUSPENDED→SLEEPING, §4.5),
-and `agent:delete` (any→TERMINATED or absent, §4.5). Creating another agent
-with the same ID requires physical removal of the old record first.
+**Durable state transitions** are documented in §4: `create` (→SLEEPING), a
+successful launcher install (SLEEPING→RUNNING), clean completion
+(RUNNING→SLEEPING), run-loop error (RUNNING→SUSPENDED), `agent:resume`
+(SUSPENDED→SLEEPING), and `agent:delete` (any→TERMINATED or absent). Startup
+clears a crash-stale RUNNING marker after confirming there is no live executor.
 
 ---
 
@@ -615,10 +617,9 @@ thread is started only by the winning wake. Mutations to the agent
 record (`addTask`, `appendSessionPending`, run loop writes) use atomic
 cursor updates directly — no shared lock.
 
-The lattice `status` field is a durable hint; `runningLoops` is the
-authoritative liveness signal. Phantom RUNNING (crash remnant or stale
-write past a clean exit) is corrected inside `wakeAgent` before
-installing a fresh slot (#64). `ConcurrentHashMap.remove(key, value)`
+The lattice `status` field supplies remote observability; `runningLoops` is the
+authoritative local liveness signal. Startup clears RUNNING markers that cannot
+have a surviving executor. `ConcurrentHashMap.remove(key, value)`
 ensures a new run's future is never accidentally completed by an old
 run's `finally` block.
 
@@ -651,7 +652,7 @@ run's `finally` block.
      into the picked session's `meta.tokens` running totals in the same
      CAS, stamped on the assistant turn, and attached to the caller's
      task/chat job record. Absent means "not measured", never zero.
-   - Status is set to `RUNNING` if work remains, else `SLEEPING`.
+   - Do not write executor status; the launcher slot remains the liveness truth.
 6. Complete any picked chat Job and drain parked task completions from
    `agent:complete-task` / `agent:fail-task` calls made during the
    transition — both strictly AFTER the merge, so external awaiters see
@@ -715,18 +716,18 @@ mutations is handled by reading the current record inside the merge
 - Once an agent is TERMINATED, it cannot transition to another status. Remove
   the record with `agent:delete remove:true` before creating a new agent with
   the same ID; there is no "un-terminate".
-- RUNNING is a transient state held only while the run loop's transition function
-  is executing or its merge step is pending. It is the only status under which
-  config mutations are rejected.
+- RUNNING is persisted while a launcher future exists, but the stored value is
+  not a concurrency lock or resume checkpoint. Config mutations consult the
+  live future and are rejected while it exists.
 - SUSPENDED preserves session/history state but failed transition tasks and
   cycle claims are settled before suspension. `agent:resume` preserves that
   record; explicit delete with `remove:true` discards it.
 
 ### 4.6 Scheduling — `wakeAgent`
 
-Scheduling is **lattice-native**: the agent's `status` field and the contents
-of `sessions`/`tasks` are the only inputs to the wake decision. There are no
-separate Java-side running/wake flags that could drift from the lattice.
+Scheduling combines durable work (`sessions`/`tasks`) with one process-local
+launcher slot. Stable lattice status gates suspended/terminated agents; the
+launcher slot provides exclusion and observable liveness.
 
 **`wakeAgent(agentId, ctx)`** is the single entry point for all agent wakes.
 It is called by `agent:request`, `agent:message`, and async job completion
@@ -737,15 +738,15 @@ callbacks. The logic (atomic CAS on `runningLoops: ConcurrentHashMap` via
    - If slot already populated → live loop exists; return existing completion
      (caller observes RUNNING; new work is in the lattice and the live loop
      will see it on its next iteration).
-   - Otherwise → read the agent's `status` from the lattice.
-   - If `status == RUNNING` with no live launcher → phantom (#64); correct to
-     SLEEPING under the same atomic update before launching.
+   - Otherwise → read the stable agent status from the lattice.
+   - A stale persisted `RUNNING` is allowed through defensively; normal startup
+     has already cleared it.
    - If no work (no session with pending messages and no tasks) → return null
      (leave slot empty).
    - Resolve `config.operation` → if null, return null.
-   - Set status → RUNNING on the lattice.
-   - Create a fresh `CompletableFuture<ACell>`, put it in the slot, and launch
-     `executeRunLoop` on a `Thread.ofVirtual()`.
+   - Create a fresh `CompletableFuture<ACell>` and atomically put it in the slot.
+   - Persist `RUNNING`, then launch `executeRunLoop` on a
+     `Thread.ofVirtual()`.
 2. The launcher wins the slot atomically; concurrent callers observing the
    populated slot simply return the same completion future.
 
@@ -758,8 +759,8 @@ An agent is eligible to run when any of:
 **No lost wakeups.** `addTask` / `appendSessionPending` write to the lattice
 atomically, then call `wakeAgent`. The loop's top-of-iteration `hasWork` check
 reads the current lattice. If work landed while a loop was running, the next
-iteration sees it. If work landed after the loop wrote SLEEPING and removed
-its slot, the `finally`-block double-check (§4.4) re-launches; failing that,
+iteration sees it. If work landed while the loop removed its slot, the
+`finally`-block double-check (§4.4) re-launches; failing that,
 the next `wakeAgent` from the writer finds the slot empty and launches.
 
 **No double runs.** `ConcurrentHashMap.compute()` serialises the
@@ -814,12 +815,13 @@ is always a state that genuinely existed on the hosting venue.
 
 ## 6. Design Decisions and Open Questions
 
-### 6.1 Recovery (on hold)
+### 6.1 Recovery
 
-An agent in `"RUNNING"` status after a venue restart was mid-transition.
-`RUNNING` may be resumable if the transition function supports it, so no
-automatic recovery to `"SUSPENDED"` for now. Revisit when transition functions
-can declare resumability.
+A venue restart has no live launcher slots, so startup clears every persisted
+RUNNING marker before scheduling remaining work.
+Durable Jobs, queued inputs, stable lifecycle state, and external interaction
+records survive independently. Recovery may start a fresh attempt from a
+durable boundary; it never treats a persisted executor bit as resumable state.
 
 ### 6.2 Effects
 

--- a/venue/docs/AGENT_SESSIONS.md
+++ b/venue/docs/AGENT_SESSIONS.md
@@ -310,7 +310,7 @@ There is no `agent:yield` op — yield is the natural state when no completion o
 |-------|--------|------|
 | `pending` | intake (`appendSessionPending`) appends; the presenting cycle drains | drain happens in the same CAS that lands the drained envelopes' user turns — at cycle start for `FramesOwning` adapters (goaltree, via `beginSessionCycle`), at merge for framework-managed conversations (llmagent) |
 | `frames` | the owning cycle | live epoch-fenced writes for `FramesOwning` adapters; the merge's turn-append for framework-managed conversations. The framework merge never touches frames for `FramesOwning` transitions |
-| `inCycle` | the owning cycle sets it at claim; the merge clears it; the suspend settle clears it | a stale value = crashed cycle (see GOAL_TREE.md §Persistence) — it counts as work for the wake gate and triggers resume |
+| `inCycle` | the owning attempt sets it at claim; merge/suspend/startup clear it | write fence only; it is never a wake signal or resume checkpoint |
 | `loads` | the merge (session-tier working set) | unchanged |
 | `meta.turns` | whoever appends root turns (shared helper) | bumped in the same CAS as the append |
 
@@ -377,7 +377,7 @@ The chat adapter is parameterised by two flags:
 | `framed` | Multi-frame mode. `subgoal` allowed; child frames summarise on return. When false, the session has a single flat frame and `subgoal` is disallowed. |
 | `persistent` | Persist the frame stack across transitions. When false, a fresh root is built each transition. |
 
-Flat + persistent is a chatbot. Framed + persistent is a resumable goal tree. Framed + non-persistent is a one-shot decomposition.
+Flat + persistent is a chatbot. Framed + persistent is a durable goal history across completed attempts. Framed + non-persistent is a one-shot decomposition.
 
 Harness tools (`more_tools`, `context_load`, `context_unload`, typed `complete`/`fail`) are available in both modes. Harness tools that depend on the frame model (`subgoal`, `compact`) are only meaningful under `framed: true`.
 
@@ -401,8 +401,8 @@ Sessions are **never deleted by the framework** (audit). Archived sessions can b
 
 ### 7.1 Session vs agent lifecycle
 
-- Agent SLEEPING ↔ no active sessions running (but sessions persist)
-- Agent RUNNING ↔ one or more sessions executing transitions
+- Agent SLEEPING ↔ runnable stable state (sessions persist)
+- Agent RUNNING ↔ persisted execution marker, validated by the hosting venue's live attempt
 - Agent SUSPENDED ↔ all sessions paused
 - Agent TERMINATED ↔ sessions still readable (audit) but no new transitions
 
@@ -466,7 +466,7 @@ A snapshot is the **full agent state at the transition boundary**, including eve
     "conv-mike":  { "meta": {...}, "state": {...}, "history": [...] },
     "support-01HXYZ": { "meta": {...}, "state": {...}, "history": [...] }
   },
-  "status": "RUNNING"
+  "status": "SLEEPING"
 }
 ```
 

--- a/venue/docs/GOAL_TREE.md
+++ b/venue/docs/GOAL_TREE.md
@@ -46,15 +46,15 @@ Everything goes here — nothing lives alongside. Live turns from chat/message i
 
 Chat sessions typically never `complete` the root frame — they run indefinitely, appending turns. One-shot invocations (a single grid operation call on a fresh session) do complete the root frame, and the session's role is the same as a single-turn task.
 
-### Persistence, interruption, and crash resume
+### Persistence and interruption
 
-**Write model.** A sessioned cycle claims the session by writing an `inCycle` epoch; every frame write is fenced on that epoch, so a superseded cycle (cancelled by suspend/delete, session removed, or reclaimed after a crash) cannot corrupt the stack — its writes bounce. The merge at cycle end clears the claim. Terminal frames carry an explicit `status` (`complete` | `failed`), written in the same CAS as their terminal turn, so a clean ending is never mistaken for a crash. Unsessioned and direct-invoke runs keep a local stack and return it in the transition output; sessioned runs emit no copy — the session record is authoritative.
+**Write model.** A sessioned execution attempt claims the session by writing an `inCycle` epoch; every frame write is fenced on that epoch, so a superseded attempt (cancelled by suspend/delete, session removed, or replaced by a later attempt) cannot corrupt the stack — its writes bounce. The merge at attempt end clears the claim. Terminal frames carry an explicit `status` (`complete` | `failed`), written in the same CAS as their terminal turn. Unsessioned and direct-invoke runs keep a local stack and return it in the transition output; sessioned runs emit no copy — the session record is authoritative.
 
-**Durability bound.** Lattice writes reach the store's mmap via the ~100ms sweep and are fsynced every `FLUSH_INTERVAL_MS` (10s default). An unclean kill can therefore lose up to ~10s of the most recent turns — bounded, versus losing the whole in-flight tree before frames were lattice-resident. Cycle semantics are **at-least-once**: a cycle that crashed after its final response but before the merge may re-run, and the model sees its own prior turns.
+**Durability bound.** Lattice writes reach the store's mmap via the ~100ms sweep and are fsynced every `FLUSH_INTERVAL_MS` (10s default). External interactions already written to the conversation therefore remain available for audit. The local execution attempt itself is not a checkpoint and is never resumed.
 
-**Crash resume.** A stale `inCycle` with no live loop means the venue died mid-cycle. The boot scan (`wakeAgentsWithWork`) wakes any agent whose durable state shows work — pending envelopes, queued tasks, or a stale claim; recovery never re-executes intake ops (#214). On the resumed cycle: dangling toolCalls get one synthetic tool-result turn ("venue restarted — effects may or may not have applied; verify before retrying") — nothing is re-executed blindly, the model decides; then the stack settles deepest-first — terminal children pop with their recorded outcome and are never re-run, live children resume their loop, and the root finally consumes any newly arrived input. The caller's side: an in-flight `agent:chat` job fails at boot with the sessionId on the record (the session is intact — re-send); an in-flight `agent:request` job survives as STARTED while its durable task remains queued.
+**Venue restart.** Startup clears persisted `RUNNING` and stale `inCycle` markers after generic Job recovery. PENDING/STARTED request Jobs fail honestly; the agent adapter removes their task/chat intake before considering remaining queued work. A stale epoch alone never wakes an agent. If a later external input starts a fresh attempt on the same session, dangling tool calls are converted to explicit unknown-outcome failures and unfinished child frames are popped un-run; their internal loops are not continued.
 
-**Operator suspend is not a crash.** Suspend settles the claim, so the session reads as quiescent: nothing auto-resumes. Leftover child frames are popped un-run ("interrupted — re-issue if needed") on the next cycle.
+**Operator suspend follows the same attempt boundary.** Suspend settles the claim. Leftover child frames are popped un-run ("interrupted — re-issue if needed") only if a later external input starts a fresh attempt.
 
 ### Per-question bracketing
 
@@ -494,7 +494,7 @@ subgoal("Analyse Delta Corp")
 
 Parent decides: retry, skip, escalate, or fail itself. The failed child frame is popped from the stack; its conversation is kept as a compacted segment in the parent's conversation with `summary` derived from the failure reason — useful for debugging and for the parent's next-inference context.
 
-**Transition atomicity.** All frame-stack changes produced by a transition (pushes, pops, appends, compactions, pending drains) land atomically on the session record. A transition that crashes mid-inference leaves the lattice at its pre-transition state; the run loop retries from there. No partial stack is ever visible to readers. Because the full stack is on the lattice, the failure point is already explorable.
+**Transition atomicity.** Each frame-stack mutation (push, pop, append, compaction, pending drain) lands atomically on the session record. A process failure can leave a valid intermediate frame stack, but never a torn lattice write. That state is retained for audit and may be settled by a later fresh attempt; the failed executor itself is not resumed.
 
 ## Zooming Into History
 
@@ -856,7 +856,7 @@ As goals get more complex, the agent can opt into more tools:
 17. **Existing tools reused.** `context_load`, `context_unload`, all `covia:*` operations, `agent:*` operations — everything from the existing tool palette. Goal tree adds 7 harness tools, not a new tool universe.
 18. **Budget is harness-managed by default.** Agent gets yes/no on loads, not arithmetic. Context map shows numbers for advanced agents.
 19. **Context layout follows attention research.** Reference at top (primacy), conversation in middle, current turn at bottom (recency).
-20. **Frame stack is lattice data on the session record.** Stored in `sessions/<sid>/frames`. Explorable, mergeable, recoverable. Survives across transitions and agent restarts.
+20. **Frame stack is lattice data on the session record.** Stored in `sessions/<sid>/frames`. Explorable and mergeable. It survives transitions and venue restarts as durable conversation state, not as an executor checkpoint.
 21. **Compacted segments accumulate.** Each `compact` appends a segment. Phase boundaries preserved. Per-question bracketing is the primary use in chat sessions.
 22. **Intake queue stays at session level.** `sessions/<sid>/pending` is the pre-transition staging area; envelopes are drained into the root frame as `user` turns atomically with the transition's other writes. Keeps concurrent intake separate from the append path.
 

--- a/venue/docs/GRID_LATTICE_DESIGN.md
+++ b/venue/docs/GRID_LATTICE_DESIGN.md
@@ -211,7 +211,7 @@ Each agent is a single atomic LWW value — the entire agent record is replaced 
 **What users see.** The user-visible agent surface is:
 
 - **`config`** — the agent's declared behaviour: transition operation, name, description, tags, A2A skills, tool palette, protocol settings. This is what an author writes when creating an agent.
-- **`status`** — high-level lifecycle (`SLEEPING` / `RUNNING` / `SUSPENDED` / `TERMINATED`), observable via `agent:info` or `covia:read`.
+- **`status`** — lifecycle plus persisted execution marker (`SLEEPING` / `RUNNING` / `SUSPENDED` / `TERMINATED`). The hosting venue validates RUNNING against its live launcher and clears stale markers at startup.
 - **Virtual namespaces `n/`, `c/`, `t/`** — user-writable scratch scoped to agent, session, and job. See §4.5.
 
 Internal framework fields (sessions, tasks, pending, timeline, caps, scheduling state) are managed by the runtime and are not a stable user-writable surface. Their structure is documented where it's authoritative:
@@ -1069,7 +1069,7 @@ The venue's Ed25519 keypair signs the venue state at the point of **persistence*
 
 ### A.5 Persistence
 
-**Startup:** Load signed state from Etch store via `store.getRootData()`, verify signature (own keypair), initialise cursors, resume operations. Job recovery walks the `:jobs` index and **stabilises — nothing is ever re-executed** (re-execution would double side effects for non-idempotent ops): PENDING and interrupted STARTED jobs fail with an honest restart message so callers can verify/retry; STARTED `agent:request` jobs whose durable task is still queued are restored live (long-running jobs survive restarts); PAUSED/INPUT_REQUIRED/AUTH_REQUIRED are restored as live in-memory Job objects. Agent work resumes separately via the boot scan (`wakeAgentsWithWork`), driven purely by durable state (pending envelopes, queued tasks, stale `inCycle` claims).
+**Startup:** Load signed state from Etch store via `store.getRootData()`, verify signature (own keypair), and initialise cursors. Job recovery stabilises PENDING/interrupted STARTED Jobs as FAILED and restores the stable waiting family (PAUSED/INPUT_REQUIRED/AUTH_REQUIRED). AgentAdapter then clears stale RUNNING/session fences, removes intake belonging to terminal Jobs, preserves jobless lattice tasks, and wakes only remaining durable queued work. No internal agent execution attempt is resumed.
 
 **Periodic sync:** Sign current venue state, write to Etch via `store.setRootData()`. Frequency is configurable:
 - **On every API request** — Maximum durability, higher IO cost (current default via `app.after("/api/*")`)

--- a/venue/docs/JOBS.md
+++ b/venue/docs/JOBS.md
@@ -146,9 +146,7 @@ Re-execution would double side effects for non-idempotent ops
 |----------------|---------|---------------|
 | `PENDING` | `FAILED` — "restarted before execution began" | retry |
 | `STARTED` (most ops) | `FAILED` — "effects may or may not have applied; verify before retrying" | verify, then retry |
-| `STARTED` `agent:chat` | `FAILED` — session intact; the record's `sessionId` names the conversation | re-send into the same session |
-| `STARTED` `agent:request`, task still queued | restored, stays `STARTED` — the durable task drives completion | keep polling by ID |
-| `STARTED` `agent:request`, task gone | `FAILED` — "task concluded; check the agent timeline" | inspect / retry |
+| `STARTED` agent request/chat | `FAILED`; AgentAdapter removes its queued intake and stale session fence | inspect external interaction records, then retry if safe |
 | `PAUSED` / `INPUT_REQUIRED` / `AUTH_REQUIRED` | restored live | continue as before |
 
 Restored non-terminal jobs **re-occupy their caller's concurrency-cap
@@ -156,9 +154,10 @@ permit** (`JobSemaphore.reserveRecovered`, which may drive permits negative):
 after a restart the cap still holds, and new work admits only as restored
 jobs finish.
 
-Agent-side work (pending session envelopes, queued tasks, interrupted
-`inCycle` cycles) is all durable and resumes independently via the boot scan
-(`AgentAdapter.wakeAgentsWithWork`).
+After generic Job recovery, AgentAdapter reconciles its own queues: intake for
+terminal Jobs is removed, stale execution markers/fences are cleared, and only
+remaining durable queued work can start a fresh attempt. `inCycle` never causes
+a wake by itself.
 
 ## Admission
 

--- a/venue/docs/SCHEDULER.md
+++ b/venue/docs/SCHEDULER.md
@@ -56,9 +56,8 @@ All three funnel into one method: `wakeAgent(agentId, ctx, force)`.
 `wakeAgent` starts a loop only when, in order:
 
 1. no live loop already exists for the agent (else attach to it);
-2. phantom-`RUNNING` is corrected to `SLEEPING` (#64 — crash remnant / stale write);
-3. status is `SLEEPING` (suspended / terminated do not start);
-4. **`force || hasWork(agent)`**, where `hasWork` = "any session has non-empty
+2. status is runnable (`SLEEPING`, or a defensively tolerated stale `RUNNING`; suspended / terminated do not start);
+3. **`force || hasWork(agent)`**, where `hasWork` = "any session has non-empty
    `pending`, or any task exists".
 
 `wakeTime` is **not** consulted by the gate. A scheduled wake works by *firing*
@@ -140,7 +139,7 @@ transient-Job fire goes through `invokeFuture` → `doKick`. Both share `wakeAge
 
 ## 6. Invariants
 
-- **One funnel.** Every wake → `wakeAgent` (atomic launcher CAS, phantom recovery,
+- **One funnel.** Every wake → `wakeAgent` (atomic launcher CAS, stale-marker tolerance,
   gate, vthread dispatch).
 - **Write-then-wake (events).** Intake writes `pending`/`tasks` before calling
   `wakeAgent`. A write landing while a loop runs is picked up by the next

--- a/venue/src/main/java/covia/adapter/AgentAdapter.java
+++ b/venue/src/main/java/covia/adapter/AgentAdapter.java
@@ -60,9 +60,9 @@ import covia.venue.Users;
  * work without races because work arrives on the lattice and is naturally
  * drained by the same loop.</p>
  *
- * <p>The lattice {@code K_STATUS} field mirrors the runtime state for
- * restart recovery and observability — it is not the concurrency
- * primitive.</p>
+ * <p>{@code RUNNING} is persisted for lattice/remote observability, but the
+ * live launcher slot remains authoritative for concurrency and mutation
+ * safety. Startup clears stale RUNNING markers before scheduling work.</p>
  */
 public class AgentAdapter extends AAdapter {
 
@@ -156,6 +156,27 @@ public class AgentAdapter extends AAdapter {
 	 * not collide on a single venue (see {@code AgentAdapterTest.testUserIsolation}).
 	 */
 	private record AgentKey(AString owner, AString id) {}
+
+	/** True only while this venue process owns a live run-loop attempt. */
+	private boolean isRunning(AgentKey key) {
+		CompletableFuture<ACell> loop = runningLoops.get(key);
+		return loop != null && !loop.isDone();
+	}
+
+	/**
+	 * Observable status: administrative terminal/stop states take precedence.
+	 * A live slot reports RUNNING; a persisted RUNNING without one is stale and
+	 * observed as SLEEPING until startup cleanup lands in the lattice.
+	 */
+	private AString observableStatus(AString ownerDID, AString agentId, AgentState agent) {
+		if (agent == null) return AgentState.TERMINATED;
+		AString stable = agent.getStatus();
+		if (AgentState.SUSPENDED.equals(stable) || AgentState.TERMINATED.equals(stable)) {
+			return stable;
+		}
+		return isRunning(new AgentKey(ownerDID, agentId))
+			? AgentState.RUNNING : AgentState.SLEEPING;
+	}
 
 	/**
 	 * Test-only: injects a chat reservation so a follow-up {@code agent:chat}
@@ -391,10 +412,9 @@ public class AgentAdapter extends AAdapter {
 		if (agentId == null) throw new IllegalArgumentException("agentId is required");
 		wakeAgent(ctx.getUserDID(), agentId, parseForce(input));
 		AgentState agent = getAgent(ctx.getUserDID(), agentId);
-		AString status = (agent != null) ? agent.getStatus() : null;
 		return Maps.of(
 			Fields.AGENT_ID, agentId,
-			Fields.STATUS,   (status != null) ? status : AgentState.SLEEPING);
+			Fields.STATUS, observableStatus(ctx.getUserDID(), agentId, agent));
 	}
 
 	/**
@@ -932,11 +952,6 @@ public class AgentAdapter extends AAdapter {
 		}
 		agent.addTask(taskId, taskData);
 
-		// The Job stays in STARTED state — the standard Job lifecycle (REST ?wait, SDK
-		// job.result()) handles sync vs async from the caller's perspective. The run
-		// loop will retrieve the Job by its ID (== taskId) and complete it.
-		job.setStatus(Status.STARTED);
-
 		// Record the session on the task Job so consumers can recover it for the
 		// task's whole lifecycle (the A2A layer maps A2A contextId = session).
 		// Job.completeWith preserves existing fields, so this survives completion.
@@ -1071,10 +1086,6 @@ public class AgentAdapter extends AAdapter {
 			Fields.JOB_ID,     jobIdHex);
 		agent.appendSessionPending(sid, envelope);
 
-		// Stay in STARTED — the run loop will completeWith the agent's
-		// response (or fail) once the next cycle for this session runs.
-		job.setStatus(Status.STARTED);
-
 		// Record the (possibly just-minted) sessionId on the job so a caller
 		// finding this job failed after a venue restart knows which session to
 		// re-engage (recovery never re-executes intake, #214). Mirrors
@@ -1139,7 +1150,8 @@ public class AgentAdapter extends AAdapter {
 			}
 			// force=false: an idle agent with no work is not an error — return a snapshot.
 			AMap<AString, ACell> snap = Maps.of(
-				Fields.AGENT_ID, agentId, Fields.STATUS, agent.getStatus());
+				Fields.AGENT_ID, agentId,
+				Fields.STATUS, observableStatus(ctx.getUserDID(), agentId, agent));
 			job.completeWith((sidHex != null) ? snap.assoc(Fields.SESSION_ID, sidHex) : snap);
 			return;
 		}
@@ -1214,7 +1226,7 @@ public class AgentAdapter extends AAdapter {
 
 		AMap<AString, ACell> summary = Maps.of(
 			Fields.AGENT_ID, agentId,
-			Fields.STATUS, record.get(AgentState.KEY_STATUS),
+			Fields.STATUS, observableStatus(ctx.getUserDID(), agentId, agent),
 			Fields.CONFIG, record.get(AgentState.KEY_CONFIG));
 
 		if (timeline != null) summary = summary.assoc(Strings.intern("timelineLength"), CVMLong.create(timeline.count()));
@@ -1342,8 +1354,8 @@ public class AgentAdapter extends AAdapter {
 					if (!(value instanceof AMap)) continue;
 					AMap<AString, ACell> record = (AMap<AString, ACell>) value;
 
-					ACell status = record.get(AgentState.KEY_STATUS);
-					if (!includeTerminated && AgentState.TERMINATED.equals(status)) continue;
+					AString stableStatus = RT.ensureString(record.get(AgentState.KEY_STATUS));
+					if (!includeTerminated && AgentState.TERMINATED.equals(stableStatus)) continue;
 
 					if (!annotated) {
 						agents = agents.conj(agentId);
@@ -1354,6 +1366,8 @@ public class AgentAdapter extends AAdapter {
 					ACell tasksCell = record.get(AgentState.KEY_TASKS);
 					if (tasksCell instanceof Index) taskCount = ((Index<?, ?>) tasksCell).count();
 
+					AString status = observableStatus(ctx.getUserDID(), agentId,
+						user.agent(agentId));
 					AMap<AString, ACell> summary = Maps.of(
 						Fields.AGENT_ID, agentId,
 						Fields.STATUS, status,
@@ -1533,7 +1547,7 @@ public class AgentAdapter extends AAdapter {
 
 		AgentState agent = lookupAgent(job, ctx.getUserDID(), agentId);
 		if (agent == null) return;
-		if (AgentState.RUNNING.equals(agent.getStatus())) {
+		if (isRunning(new AgentKey(ctx.getUserDID(), agentId))) {
 			// A running transition has already captured its config (including caps)
 			// for the duration of its tool loop, so mutating the record mid-run
 			// would not affect it and is refused by design. To revoke authority or
@@ -2113,11 +2127,11 @@ public class AgentAdapter extends AAdapter {
 	 * <p>All run-loop concurrency flows through this single entry point.
 	 * Launch is serialised by {@link ConcurrentHashMap#compute} on
 	 * {@link #runningLoops} — at most one virtual thread per agent. Wakes
-	 * that arrive during a live cycle write to the lattice (session.pending,
+	 * that arrive during a live attempt write to the lattice (session.pending,
 	 * tasks) and are picked up by the running loop's {@code hasWork()} check
 	 * at the top of the next iteration; they do not need to be signalled
-	 * across threads. The lattice {@code K_STATUS} mirrors runtime state
-	 * for observability, not concurrency control.</p>
+	 * across threads. RUNNING is persisted for observers, while this map remains
+	 * the authoritative concurrency primitive.</p>
 	 *
 	 * <p>This is a pure mechanism keyed on the agent's address
 	 * ({@code ownerDID} + {@code agentId}): it runs the agent as its owner,
@@ -2145,21 +2159,12 @@ public class AgentAdapter extends AAdapter {
 		CompletableFuture<ACell> existing = runningLoops.get(key);
 		if (existing != null && !existing.isDone()) return existing;
 
-		// Phantom RUNNING recovery (#64): if lattice shows RUNNING but no
-		// live loop in our map, it's a crash remnant or inconsistent persisted state. Correct
-		// to SLEEPING so a fresh loop can start; otherwise the agent would
-		// be locked out indefinitely.
 		AString status = agent.getStatus();
-		if (AgentState.RUNNING.equals(status)) {
-			log.warn("Agent {} in phantom RUNNING state with no live run; "
-				+ "correcting to SLEEPING", agentId);
-			agent.setStatus(AgentState.SLEEPING);
-			status = AgentState.SLEEPING;
-		}
 
-		// Only start a loop from SLEEPING. Suspended or terminated agents
-		// keep their wake flag for later resume.
-		if (!AgentState.SLEEPING.equals(status)) return null;
+		// SLEEPING is normal. RUNNING without a live slot is a stale marker
+		// (normally cleared by startup) and must not lock the agent forever.
+		if (!AgentState.SLEEPING.equals(status)
+				&& !AgentState.RUNNING.equals(status)) return null;
 
 		// Gate: only start if there's work (or forced).
 		if (!force && !hasWork(agent)) return null;
@@ -2190,10 +2195,19 @@ public class AgentAdapter extends AAdapter {
 		// identity is the agent's own sub-principal DID so what the agent did is
 		// attributable to the agent rather than to the human who owns it.
 		final RequestContext agentCtx = RequestContext.ofAgent(ownerDID, agentId);
-		agent.setStatus(AgentState.RUNNING);
-		final CompletableFuture<ACell> finalCompletion = mine;
-		Thread.ofVirtual().start(
-			() -> executeRunLoop(agentId, ownerDID, agentCtx, finalCompletion));
+		try {
+			agent.setStatus(AgentState.RUNNING);
+			final CompletableFuture<ACell> finalCompletion = mine;
+			Thread.ofVirtual().start(
+				() -> executeRunLoop(agentId, ownerDID, agentCtx, finalCompletion));
+		} catch (RuntimeException | Error t) {
+			// Do not leave an authoritative live slot behind when launch itself
+			// fails before the run loop can enter its own finally block.
+			runningLoops.remove(key, mine);
+			agent.sleep();
+			mine.completeExceptionally(t);
+			throw t;
+		}
 		return mine;
 	}
 
@@ -2385,6 +2399,24 @@ public class AgentAdapter extends AAdapter {
 				}
 				if (pickedSessionBlob != null) cycleCtx = cycleCtx.withSessionId(pickedSessionBlob);
 
+				// PENDING means accepted and queued. STARTED begins only when this
+				// live executor attempt actually picks the external request/chat.
+				if (pickedTask != null) {
+					Job taskJob = engine.jobs().getJob(pickedTask.getKey());
+					// Tasks are also a public lattice primitive and need not have a
+					// corresponding Job. Only a present terminal Job invalidates one.
+					if (taskJob != null && taskJob.isFinished()) {
+						agent.removeTask(pickedTask.getKey());
+						continue;
+					}
+					if (taskJob != null && Status.PENDING.equals(taskJob.getStatus())) {
+						taskJob.setStatus(Status.STARTED);
+					}
+				}
+				if (pickedChatJob != null && Status.PENDING.equals(pickedChatJob.getStatus())) {
+					pickedChatJob.setStatus(Status.STARTED);
+				}
+
 				AMap<AString, ACell> transitionInput = Maps.of(
 					Fields.AGENT_ID, agentId,
 					AgentState.KEY_STATE, currentState,
@@ -2491,15 +2523,13 @@ public class AgentAdapter extends AAdapter {
 					agent, agentId, ownerDID, transitionOp, framesOwned, transitionResult, pickedTask,
 					pickedTaskInput, formattedTasks, pickedSession,
 					pickedSessionBlob, pickedChatJob, filteredInbox,
-					presentedSessionPendingCount, tasks, startTs, allTaskResults);
+					presentedSessionPendingCount, startTs, allTaskResults);
 				lastResult = merged.lastResult();
 				allTaskResults = merged.allTaskResults();
 			}
 
-			// Clean exit: mark SLEEPING (atomic — preserves SUSPENDED /
-			// TERMINATED if set externally), complete the completion with
-			// the last cycle's result. Report whatever status we ended up
-			// on so callers of the completion see the true final state.
+			// Clean exit clears the persisted executor marker. The atomic sleep
+			// preserves an administrative stop/terminal state set while running.
 			AgentState agent = getAgent(ownerDID, agentId);
 			AString finalStatus = AgentState.SLEEPING;
 			if (agent != null) {
@@ -2551,8 +2581,7 @@ public class AgentAdapter extends AAdapter {
 			ACell pickedTaskInput, AVector<ACell> formattedTasks,
 			AString pickedSession, Blob pickedSessionBlob, Job pickedChatJob,
 			AVector<ACell> filteredInbox, long presentedSessionPendingCount,
-			Index<Blob, ACell> tasks, long startTs,
-			AMap<AString, ACell> allTaskResults) {
+			long startTs, AMap<AString, ACell> allTaskResults) {
 		final AgentKey key = new AgentKey(callerDID, agentId);
 		long endTs = Utils.getCurrentTimestamp();
 		ACell newState = RT.getIn(transitionResult, AgentState.KEY_STATE);
@@ -2648,8 +2677,8 @@ public class AgentAdapter extends AAdapter {
 							AgentState.K_CONTENT, msgContent,
 							AgentState.K_TURN_TS, CVMLong.create(startTs),
 							AgentState.K_SOURCE,  AgentState.SOURCE_CHAT);
-						// Chat-envelope job id travels onto the turn so a
-						// boot-recovery re-fire sees the message landed.
+						// Preserve the originating Job id as durable provenance for
+						// audit and result correlation.
 						ACell envJobId = RT.getIn(envelope, Fields.JOB_ID);
 						if (envJobId != null) turn = turn.assoc(Fields.JOB_ID, envJobId);
 						turnsToAppend = turnsToAppend.conj(
@@ -2708,10 +2737,9 @@ public class AgentAdapter extends AAdapter {
 		// mid-transition arrivals) and must not rewrite frames (the live
 		// stack is authoritative; a merge rewrite would also mask any missed
 		// live-write in testing). The merge still clears the session's
-		// inCycle claim, appends the timeline entry, removes completed tasks
-		// and settles status.
+		// inCycle claim, appends the timeline entry and removes completed tasks.
 		AMap<AString, ACell> merged = agent.mergeRunResult(
-			newState, pickedSession, tasks, taskResults,
+			newState, taskResults,
 			timelineEntry, pickedSessionBlob, turnsToAppend,
 			framesOwned ? 0 : presentedSessionPendingCount,
 			framesOwned ? null : adapterFrames,
@@ -3161,18 +3189,16 @@ public class AgentAdapter extends AAdapter {
 	}
 
 	/**
-	 * Boot scan: wakes every agent with durable work — pending session
-	 * envelopes, queued tasks, or a stale {@code inCycle} claim from a cycle
-	 * the venue crashed out of. All three are on the lattice, so this scan is
-	 * the single recovery trigger for agent work: recovery never re-executes
-	 * intake ops (#214), it just restarts the loops that durable state says
-	 * have something to do. Called once at venue launch, after
+	 * Boot scan: wakes every agent with durable queued work — pending session
+	 * envelopes or queued tasks. A stale {@code inCycle} claim is abandoned
+	 * executor state, not work and not a resume checkpoint. Called once after
 	 * {@code recoverJobs()} stabilises job records.
 	 *
 	 * @return the number of agents woken
 	 */
 	public int wakeAgentsWithWork() {
 		int woken = 0;
+		int staleRuns = 0;
 		AMap<AString, ACell> all = engine.getVenueState().users().getAll();
 		if (all == null) return 0;
 		for (var userEntry : all.entrySet()) {
@@ -3186,6 +3212,18 @@ public class AgentAdapter extends AAdapter {
 				AString agentId = agentEntry.getKey();
 				AgentState agent = getAgent(did, agentId);
 				if (agent == null) continue;   // terminated / missing
+				AgentKey key = new AgentKey(did, agentId);
+				// This method is a startup hook, but keep it safe if an embedding
+				// invokes it after launch: never reconcile beneath a live executor.
+				if (isRunning(key)) continue;
+				// No executor survives venue startup. Clear the durable dirty
+				// marker before deciding whether remaining queued work merits a
+				// fresh attempt; recoverJobs has already failed interrupted Jobs.
+				if (AgentState.RUNNING.equals(agent.getStatus())) {
+					agent.sleep();
+					staleRuns++;
+				}
+				reconcileAgentAfterRestart(user, agent);
 				if (hasWork(agent)) {
 					log.info("Waking agent {} — durable work found on boot", agentId);
 					wakeAgent(did, agentId, true);
@@ -3193,7 +3231,49 @@ public class AgentAdapter extends AAdapter {
 				}
 			}
 		}
+		if (staleRuns > 0) {
+			log.info("Agent startup recovery: cleared {} stale RUNNING marker(s)", staleRuns);
+		}
 		return woken;
+	}
+
+	/**
+	 * Removes agent-owned intake whose external Job was made terminal by the
+	 * generic Job recovery pass. Stable waiting Jobs and jobless lattice tasks
+	 * remain queued. Session epochs are executor fences, so none survives
+	 * process startup.
+	 */
+	@SuppressWarnings("unchecked")
+	private void reconcileAgentAfterRestart(User user, AgentState agent) {
+		Index<Blob, ACell> tasks = agent.getTasks();
+		if (tasks != null) {
+			for (var entry : tasks.entrySet()) {
+				ACell rawJob = user.getJob(entry.getKey());
+				if (rawJob instanceof AMap<?, ?> map
+						&& Job.isFinished((AMap<AString, ACell>) map)) {
+					agent.removeTask(entry.getKey());
+				}
+			}
+		}
+
+		Index<Blob, ACell> sessions = agent.getSessions();
+		if (sessions == null) return;
+		for (var entry : sessions.entrySet()) {
+			Blob sid = entry.getKey();
+			agent.clearSessionCycle(sid);
+			AVector<ACell> pending = agent.getSessionPending(sid);
+			if (pending == null) continue;
+			for (long i = 0; i < pending.count(); i++) {
+				AString jobIdHex = RT.ensureString(RT.getIn(pending.get(i), Fields.JOB_ID));
+				Blob jobId = (jobIdHex != null) ? Blob.fromHex(jobIdHex.toString()) : null;
+				if (jobId == null) continue; // fire-and-forget message, not a chat Job
+				ACell rawJob = user.getJob(jobId);
+				if (!(rawJob instanceof AMap<?, ?> map)
+						|| Job.isFinished((AMap<AString, ACell>) map)) {
+					agent.removeSessionPendingJob(sid, jobId);
+				}
+			}
+		}
 	}
 
 	/** Flips the agent's active-transition cancellation token (if any) and

--- a/venue/src/main/java/covia/adapter/agent/GoalTreeAdapter.java
+++ b/venue/src/main/java/covia/adapter/agent/GoalTreeAdapter.java
@@ -514,18 +514,15 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 		// local behaviour behind the same seam.
 		long cycleTs = convex.core.util.Utils.getCurrentTimestamp();
 		FrameStore store;
-		boolean resuming = false;
 		boolean tidyInterrupted = false;
 		{
 			Blob sid = ctx.getSessionId();
 			AgentState agentState = resolveAgentState(ctx, agentId);
 			if (sid != null && agentState != null && agentState.getSession(sid) != null) {
-				// Crash detection: a stale inCycle means the previous cycle's
-				// merge never ran — the venue died mid-cycle. Resume repairs
-				// and continues. (An operator suspend settles the claim, so
-				// interrupted-by-suspend sessions do NOT resume — leftover
-				// child frames are popped un-run below.)
-				resuming = agentState.getSessionCycleEpoch(sid) != null;
+				// A stale epoch is an abandoned attempt, never a checkpoint. Its
+				// externally visible tool interactions remain in conversation, but
+				// unfinished child execution is settled as failed rather than resumed.
+				boolean abandonedAttempt = agentState.getSessionCycleEpoch(sid) != null;
 
 				// Claim first (epoch only), repair under the new epoch, THEN
 				// append this cycle's input turns + drain in one CAS — repair
@@ -539,10 +536,8 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 				}
 				store = new FrameStore.LatticeFrameStore(agentState, sid, epoch, ctx.getCancellation());
 
-				// Drives frame settling below (:665) — a crash resume runs child
-				// frames, an operator stop does not. Repair is deliberately NOT
-				// gated on it; see below.
-				tidyInterrupted = !resuming && store.frames().count() > 1;
+				// Any non-quiescent stack is settled without re-running children.
+				tidyInterrupted = abandonedAttempt || store.frames().count() > 1;
 
 				// An unanswered tool call is simply a FAILED tool call (#271).
 				// Tool failures are already ordinary outcomes everywhere else —
@@ -550,7 +545,7 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 				// "Error: …" tool result the model reads and recovers from — so a
 				// call that never returned gets the same treatment, and the agent
 				// decides what to do. Repairing only when the session LOOKS
-				// crashed (resuming/tidyInterrupted) left any other abort — a
+				// interrupted left any other abort — a
 				// cancelled transition, a failed CAS, a suspend — with a
 				// tool_use carrying no tool_result. Providers reject such a
 				// history outright, so one transient failure poisoned the session
@@ -569,11 +564,11 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 					// unrepaired conversation blindly re-dispatches pre-crash
 					// tool calls. Check a fresh read (repair returns its input
 					// unchanged when nothing is dangling); retry once, then
-					// fail the resume loudly rather than proceed.
+					// fail loudly rather than proceed.
 					AVector<ACell> check = store.frames();
 					if (check.isEmpty()
 							|| GoalTreeContext.repairDanglingToolCalls(check, note) != check) {
-						log.warn("Resume repair no-oped on stale frames (agent {}, session {}, checkCount {}) — retrying (#214)",
+						log.warn("Interruption repair no-oped on stale frames (agent {}, session {}, checkCount {}) — retrying (#214)",
 							agentId, sid, check.count());
 						if (!store.update(f -> GoalTreeContext.repairDanglingToolCalls(f, note))) {
 							return abortedOutput(store);
@@ -583,16 +578,13 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 							return Maps.of(
 								AgentState.KEY_STATE, Maps.empty(),
 								Fields.ERROR, Strings.create(
-									"Crash resume could not repair dangling tool calls for session "
+									"Interruption cleanup could not repair dangling tool calls for session "
 									+ sid + " — aborting rather than re-executing them (#214)"));
 						}
 					}
 				}
 
 				AVector<ACell> cycleTurns = buildCycleInputTurns(messages, input, cycleTs);
-				if (resuming) {
-					cycleTurns = dropAlreadyAppendedRequestTurns(cycleTurns, store.frames());
-				}
 				long drainCount = (messages != null) ? messages.count() : 0;
 				if (!agentState.beginSessionCycle(sid, epoch, cycleTurns, drainCount)) {
 					return Maps.of(
@@ -621,9 +613,8 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 		AVector<ACell> frames = store.frames();
 		// The shared context is always built from the ROOT view of the stack —
 		// exactly what every pre-cutover cycle saw (clean cycles end
-		// root-only). On a crash resume the stack may still hold live child
-		// frames: the resume driver settles them, and each child's own loop
-		// assembles its own context — rendering a child's conversation into
+		// root-only). An interrupted stack may still hold child frames; the
+		// cleanup driver settles them without execution. Rendering a child's conversation into
 		// the shared history here would leak it into the root's context.
 		if (frames.count() > 1) {
 			frames = (AVector<ACell>) frames.slice(0, 1);
@@ -676,11 +667,10 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 		// Run the root frame. typedHarnessTools (if non-null) injects the
 		// typed complete/fail tools alongside the regular harness/operation
 		// tools, supporting providers that prefer tool calls over response_format.
-		// A resumed (crash) or interrupted (suspend leftovers) stack first goes
-		// through the driver, which settles child frames deepest-first —
-		// running them only on a crash resume, never after an operator stop.
-		FrameResult result = (resuming || tidyInterrupted)
-			? resumeFrames(job, store, resuming, l3Config, llmOperation, baseTools,
+		// An interrupted stack first settles child frames deepest-first without
+		// resuming their internal execution, then starts the root afresh.
+		FrameResult result = tidyInterrupted
+			? settleInterruptedFrames(job, store, l3Config, llmOperation, baseTools,
 				configToolMap, capsCtx, context.history(), typedHarnessTools, toolCallTimeoutMs,
 				outerLoads)
 			: runFrame(job, store, 0, l3Config, llmOperation, baseTools,
@@ -1053,8 +1043,8 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 
 			// Record assistant message (with tool calls) in conversation —
 			// persisted immediately so each LLM response is durable before its
-			// tools execute (a crash mid-tools leaves a detectable dangling
-			// toolCall for resume, instead of losing the response).
+			// tools execute. An interruption therefore leaves an auditable
+			// dangling call that a later fresh attempt can settle explicitly.
 			activeFrame = GoalTreeContext.appendTurn(activeFrame, l3Result);
 			if (!persist(store, frameIndex, activeFrame)) return abortedResult(store);
 
@@ -1262,7 +1252,7 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 							}
 							// Push: parent snapshot + child frame in one CAS. The
 							// child is stamped with the spawning toolCall id so a
-							// crash resume can match it back to the parent's
+							// interruption cleanup can match it back to the parent's
 							// dangling call unambiguously (identical descriptions
 							// are legal in one batch).
 							AMap<AString, ACell> childFrame = GoalTreeContext.createFrame(desc, childLoads);
@@ -1324,8 +1314,8 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 		}
 
 		log.warn("GoalTreeAdapter: max iterations reached for frame");
-		// Terminal marker in the same CAS as the give-up, so resume never
-		// re-runs a frame that already exhausted its budget.
+		// Terminal marker lands in the same CAS as the give-up, so a later
+		// fresh attempt does not mistake this frame for unfinished work.
 		store.update(f -> (frameIndex < f.count())
 			? updateFrame(f, frameIndex, GoalTreeContext.withStatus(
 				(AMap<AString, ACell>) f.get(frameIndex), GoalTreeContext.STATUS_FAILED))
@@ -1343,15 +1333,11 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 	 *       a text completion's value is recovered from its final turn, an
 	 *       unrecoverable value becomes an honest "may be lost" note. Never
 	 *       re-run (I8).</li>
-	 *   <li>live child, crash resume ({@code runChildren}) — its loop runs to
-	 *       completion (the repaired conversation ends with the synthetic
-	 *       restart results, so the model continues from where it was).</li>
-	 *   <li>live child, interrupted by operator suspend — popped un-run with
-	 *       an "interrupted — re-issue if needed" failure: suspension is a
-	 *       deliberate stop, never auto-resumed (I7).</li>
+	 *   <li>live child — popped un-run with an "interrupted — re-issue if
+	 *       needed" failure. Internal execution is never resumed.</li>
 	 * </ul>
 	 */
-	private FrameResult resumeFrames(Job job, FrameStore store, boolean runChildren,
+	private FrameResult settleInterruptedFrames(Job job, FrameStore store,
 			AMap<AString, ACell> config, AString llmOperation,
 			AVector<ACell> baseTools, Map<String, AString> configToolMap,
 			RequestContext ctx, AVector<ACell> systemMessages,
@@ -1375,17 +1361,10 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 				popValue = (recovered != null) ? recovered : Strings.create(
 					"Result may be lost — venue restarted at subgoal completion; "
 					+ "re-issue the subgoal if needed");
-			} else if (runChildren) {
-				FrameResult childResult = runFrame(job, store, deepest, config, llmOperation,
-					baseTools, configToolMap, ctx, systemMessages, null, toolCallTimeoutMs,
-					outerLoads);
-				if (store.aborted()) return abortedResult(store);
-				popStatus = childResult.status();
-				popValue = childResult.value();
 			} else {
 				popStatus = "failed";
 				popValue = Strings.create(
-					"Subgoal interrupted (operator suspend) — not resumed; re-issue if needed");
+					"Subgoal interrupted — not resumed; re-issue if needed");
 			}
 
 			AMap<AString, ACell> resultMap = Maps.of(
@@ -1414,39 +1393,6 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 		return runFrame(job, store, 0, config, llmOperation, baseTools,
 			configToolMap, ctx, systemMessages, typedRootHarnessTools, toolCallTimeoutMs,
 			outerLoads);
-	}
-
-	/**
-	 * Drops request-sourced turns whose content the root conversation already
-	 * carries as a request turn: on a crash resume the interrupted cycle's
-	 * task is re-presented (recoverJobs re-fires the caller's job), but the
-	 * crashed cycle already appended its input turn.
-	 */
-	@SuppressWarnings("unchecked")
-	private static AVector<ACell> dropAlreadyAppendedRequestTurns(
-			AVector<ACell> turns, AVector<ACell> frames) {
-		if (turns.count() == 0 || frames.count() == 0) return turns;
-		AVector<ACell> rootConv = (RT.getIn(frames.get(0), "conversation") instanceof AVector<?> cv)
-			? (AVector<ACell>) cv : Vectors.empty();
-		AVector<ACell> kept = Vectors.empty();
-		for (long i = 0; i < turns.count(); i++) {
-			ACell turn = turns.get(i);
-			boolean duplicate = false;
-			if (covia.venue.AgentState.SOURCE_REQUEST.equals(
-					RT.getIn(turn, covia.venue.AgentState.K_SOURCE))) {
-				ACell content = RT.getIn(turn, "content");
-				for (long j = 0; j < rootConv.count(); j++) {
-					ACell existing = rootConv.get(j);
-					if (covia.venue.AgentState.SOURCE_REQUEST.equals(RT.getIn(existing, "source"))
-							&& java.util.Objects.equals(content, RT.getIn(existing, "content"))) {
-						duplicate = true;
-						break;
-					}
-				}
-			}
-			if (!duplicate) kept = kept.conj(turn);
-		}
-		return kept;
 	}
 
 	/** Transition output for a cycle that lost frame ownership mid-flight. */
@@ -1571,9 +1517,8 @@ public class GoalTreeAdapter extends AbstractLLMAdapter implements FramesOwning 
 					covia.venue.AgentState.K_CONTENT, content,
 					covia.venue.AgentState.K_TURN_TS, tsCell,
 					covia.venue.AgentState.K_SOURCE,  covia.venue.AgentState.SOURCE_CHAT);
-				// Provenance for recovery idempotence: a chat envelope's job id
-				// travels onto its turn, so a boot-recovery re-fire can see the
-				// message already landed (LLM rendering strips extra fields).
+				// Preserve the originating Job id as durable provenance; LLM
+				// rendering strips this non-conversation field.
 				ACell envJobId = RT.getIn(envelope, Fields.JOB_ID);
 				if (envJobId != null) turn = turn.assoc(Fields.JOB_ID, envJobId);
 				turns = turns.conj(turn);

--- a/venue/src/main/java/covia/adapter/agent/GoalTreeContext.java
+++ b/venue/src/main/java/covia/adapter/agent/GoalTreeContext.java
@@ -55,12 +55,12 @@ public class GoalTreeContext {
 	/** Frame lifecycle status: absent while live; {@link #STATUS_COMPLETE} /
 	 *  {@link #STATUS_FAILED} written in the same CAS as the terminal turn,
 	 *  {@link #STATUS_INTERRUPTED} by an operator-suspend settle. Explicit
-	 *  markers, not structural inference — a clean complete() tail is
-	 *  otherwise indistinguishable from a crash tail (crash resume). */
+	 *  markers, not structural inference — interruption cleanup must distinguish
+	 *  a committed terminal child from abandoned execution. */
 	static final AString K_STATUS = Strings.intern("status");
 
 	/** The toolCall id of the subgoal call that spawned this (child) frame —
-	 *  stamped at push so crash resume can match a live child back to its
+	 *  stamped at push so interruption cleanup can match a child back to its
 	 *  parent's dangling toolCall unambiguously (identical descriptions are
 	 *  legal in one batch). */
 	static final AString K_CALL_ID = Strings.intern("callId");
@@ -84,10 +84,10 @@ public class GoalTreeContext {
 		return (frame.get(K_CALL_ID) instanceof AString s) ? s : null;
 	}
 
-	// ========== Crash-resume repair (pure) ==========
+	// ========== Interrupted-conversation repair (pure) ==========
 
 	/**
-	 * Repairs a crash-interrupted frame stack: every dangling toolCall — an
+	 * Repairs an interrupted frame stack: every dangling toolCall — an
 	 * entry of an assistant turn's {@code toolCalls} with no later tool-result
 	 * turn for its id — gets a synthetic tool-result turn appended, so the
 	 * conversation is provider-valid again (tool results must follow their
@@ -96,7 +96,7 @@ public class GoalTreeContext {
 	 * or may not have applied, and the agent decides (autonomy principle).
 	 *
 	 * <p>A dangling call whose id matches a deeper frame's {@code callId} is
-	 * an in-flight subgoal — skipped here; the resume driver pops it with the
+	 * an unfinished subgoal — skipped here; the interruption cleanup pops it with the
 	 * child's own outcome. Null-id calls are matched positionally within
 	 * their batch. At most one synthetic result per call, ever.</p>
 	 */
@@ -143,7 +143,7 @@ public class GoalTreeContext {
 
 	/**
 	 * True if the frame's conversation contains a tool-result turn with the
-	 * given id — the resume driver's pop-dedupe: never synthesise a second
+	 * given id — the frame-settling pop-dedupe: never synthesise a second
 	 * result for a call the parent already has one for.
 	 */
 	@SuppressWarnings("unchecked")
@@ -183,7 +183,7 @@ public class GoalTreeContext {
 
 	/**
 	 * Best-effort result value of a terminal frame, for a pop that must be
-	 * synthesised after a crash: a text-completed frame's value is its final
+	 * synthesised while settling an interrupted stack: a text-completed frame's value is its final
 	 * assistant turn's content. Returns null when unrecoverable (e.g. the
 	 * complete() tool's input was the value and is not stored) — the caller
 	 * substitutes an honest "result may be lost" note.

--- a/venue/src/main/java/covia/venue/AgentState.java
+++ b/venue/src/main/java/covia/venue/AgentState.java
@@ -63,14 +63,12 @@ public class AgentState extends ALatticeComponent<ACell> {
 	// Session record field keys (scoped within a single session map)
 	private static final AString K_C        = Strings.intern("c");
 	private static final AString K_FRAMES   = Strings.intern("frames");
-	/** Session cycle epoch: present while a transition cycle owns this session
+	/** Session attempt epoch: present while a transition owns this session
 	 *  (set by {@link #beginSessionCycle}, cleared by {@link #mergeRunResult}).
-	 *  Serves three duties: write fence for {@link #updateSessionFrames} (a
+	 *  Serves as a write fence for {@link #updateSessionFrames} (a
 	 *  cancelled cycle's zombie thread cannot write once a new epoch claims the
-	 *  session), work signal (a session mid-cycle counts as having work, so an
-	 *  interrupted cycle re-runs even though its pending was already drained),
-	 *  and crash detector (a stale epoch with no live loop means the merge
-	 *  never ran — the resume path repairs before continuing). */
+	 *  session). A stale epoch after restart is abandoned executor state; a
+	 *  later attempt may supersede it but boot never wakes solely for it. */
 	private static final AString K_IN_CYCLE = Strings.intern("inCycle");
 	private static final AString K_META     = Strings.intern("meta");
 	private static final AString K_PARTIES  = Strings.intern("parties");
@@ -107,6 +105,7 @@ public class AgentState extends ALatticeComponent<ACell> {
 
 	// Status constants
 	public static final AString SLEEPING   = Strings.intern("SLEEPING");
+	/** Persisted executor marker; live ownership is verified by AgentAdapter. */
 	public static final AString RUNNING    = Strings.intern("RUNNING");
 	public static final AString SUSPENDED  = Strings.intern("SUSPENDED");
 	public static final AString TERMINATED = Strings.intern("TERMINATED");
@@ -374,10 +373,9 @@ public class AgentState extends ALatticeComponent<ACell> {
 	 * ONE CAS, so an envelope is removed from pending only in the write that
 	 * lands its user turn (crash between the two is impossible).
 	 *
-	 * <p>A stale {@code inCycle} left by a crashed cycle is overwritten — the
-	 * run loop is the single live writer per agent, so a differing existing
-	 * epoch can only be a crash remnant, and claiming it is exactly the
-	 * resume case.</p>
+	 * <p>A stale {@code inCycle} left by an abandoned attempt is overwritten.
+	 * The epoch is a write fence, not a checkpoint: claiming it starts a fresh
+	 * attempt and does not restore the former executor.</p>
 	 *
 	 * @return true if the session existed and was claimed; false if the
 	 *         record or session is missing (nothing written)
@@ -411,7 +409,7 @@ public class AgentState extends ALatticeComponent<ACell> {
 	 * Atomically updates {@code sessions[sid].frames}, fenced by the cycle
 	 * epoch: the write applies only while {@code session.inCycle} equals
 	 * {@code expectedEpoch}. A transition whose cycle has been superseded
-	 * (cancelled and resumed, agent deleted and recreated, session claimed by
+	 * (cancelled and superseded, agent deleted and recreated, session claimed by
 	 * a fresh cycle) gets {@code false} and must stop — its view of the
 	 * frames is no longer authoritative.
 	 *
@@ -603,23 +601,42 @@ public class AgentState extends ALatticeComponent<ACell> {
 		return found.get();
 	}
 
-	/**
-	 * Whether a session record represents outstanding work: it has pending
-	 * messages, or it is mid-cycle ({@code inCycle} present — a claimed cycle
-	 * whose merge has not run, i.e. live right now or interrupted by a crash;
-	 * its input was already drained from pending, so the epoch is the only
-	 * remaining work signal). Single shared rule for the wake gate, the
-	 * session picker, and the merge's continue-vs-sleep decision.
-	 */
-	static boolean sessionHasWork(AMap<AString, ACell> session) {
-		ACell pv = session.get(K_PENDING);
-		if (pv instanceof AVector<?> v && v.count() > 0) return true;
-		return session.get(K_IN_CYCLE) != null;
+	/** Removes a queued chat envelope by its external Job id. */
+	@SuppressWarnings("unchecked")
+	public void removeSessionPendingJob(Blob sid, Blob jobId) {
+		AString jobIdHex = Strings.create(jobId.toHexString());
+		update(r -> {
+			Index<Blob, ACell> sessions = (r.get(K_SESSIONS) instanceof Index idx)
+				? (Index<Blob, ACell>) idx : Index.none();
+			ACell sv = sessions.get(sid);
+			if (!(sv instanceof AMap<?, ?>)) return r;
+			AMap<AString, ACell> session = (AMap<AString, ACell>) sv;
+			AVector<ACell> pending = (session.get(K_PENDING) instanceof AVector<?> v)
+				? (AVector<ACell>) v : Vectors.empty();
+			AVector<ACell> kept = Vectors.empty();
+			for (long i = 0; i < pending.count(); i++) {
+				ACell envelope = pending.get(i);
+				if (!jobIdHex.equals(RT.getIn(envelope, Fields.JOB_ID))) {
+					kept = kept.conj(envelope);
+				}
+			}
+			if (kept.count() == pending.count()) return r;
+			return r.assoc(K_SESSIONS,
+				sessions.assoc(sid, session.assoc(K_PENDING, kept)));
+		});
 	}
 
 	/**
-	 * Returns true if any session has outstanding work (pending messages or
-	 * an unfinished cycle — see {@link #sessionHasWork}).
+	 * Whether a session record has durable queued work. {@code inCycle} is an
+	 * executor fence, never a wake signal or a resume checkpoint.
+	 */
+	static boolean sessionHasWork(AMap<AString, ACell> session) {
+		ACell pv = session.get(K_PENDING);
+		return pv instanceof AVector<?> v && v.count() > 0;
+	}
+
+	/**
+	 * Returns true if any session has pending messages.
 	 */
 	public boolean hasSessionPending() {
 		Index<Blob, ACell> sessions = getSessions();
@@ -633,7 +650,7 @@ public class AgentState extends ALatticeComponent<ACell> {
 
 	/**
 	 * Returns the sid (Blob) of the first session with outstanding work
-	 * (pending messages or an unfinished cycle), or null if none.
+	 * (pending messages), or null if none.
 	 */
 	public Blob pickSessionWithPending() {
 		Index<Blob, ACell> sessions = getSessions();
@@ -988,15 +1005,13 @@ public class AgentState extends ALatticeComponent<ACell> {
 	}
 
 	/**
-	 * Sets SLEEPING status, unless the agent has been externally SUSPENDED
-	 * or TERMINATED — in which case the status is preserved.
+	 * Clears the persisted executor marker after a clean exit or at startup.
+	 * Administrative stop/terminal states always win.
 	 */
 	public void sleep() {
 		update(r -> {
 			AString cur = RT.ensureString(r.get(K_STATUS));
-			if (SUSPENDED.equals(cur) || TERMINATED.equals(cur)) {
-				return r;
-			}
+			if (SUSPENDED.equals(cur) || TERMINATED.equals(cur)) return r;
 			return r.assoc(K_STATUS, SLEEPING);
 		});
 	}
@@ -1047,40 +1062,10 @@ public class AgentState extends ALatticeComponent<ACell> {
 	/**
 	 * Atomically merges run loop results into the agent record.
 	 *
-	 * <p>Reconciles concurrent modifications: preserves tasks added during
-	 * the transition. Determines whether new work arrived (session pending
-	 * messages, new tasks, or wake flag) and sets status to RUNNING or
-	 * SLEEPING accordingly.</p>
-	 *
-	 * @return The new record (check status to determine if loop should continue)
+	 * <p>Reconciles concurrent modifications and preserves tasks added during
+	 * the transition. Executor status is deliberately absent from this merge:
+	 * the launcher writes {@code RUNNING} once and clears it on final exit.</p>
 	 */
-	public AMap<AString, ACell> mergeRunResult(
-			ACell newState,
-			AString consumedSession,
-			Index<Blob, ACell> presentedTasks,
-			AMap<AString, ACell> taskResults,
-			AMap<AString, ACell> timelineEntry) {
-		return mergeRunResult(newState, consumedSession,
-			presentedTasks, taskResults, timelineEntry, null, null, 0, null, null);
-	}
-
-	/**
-	 * Back-compat 8-arg overload — no adapter-owned frames. Delegates to the
-	 * full form with {@code newFrames = null}.
-	 */
-	public AMap<AString, ACell> mergeRunResult(
-			ACell newState,
-			AString consumedSession,
-			Index<Blob, ACell> presentedTasks,
-			AMap<AString, ACell> taskResults,
-			AMap<AString, ACell> timelineEntry,
-			Blob historySid,
-			AVector<ACell> turnsToAppend,
-			long presentedSessionPendingCount) {
-		return mergeRunResult(newState, consumedSession, presentedTasks,
-			taskResults, timelineEntry, historySid, turnsToAppend,
-			presentedSessionPendingCount, null, null);
-	}
 
 	/**
 	 * Atomic merge with frame-conversation append + session pending drain.
@@ -1116,8 +1101,6 @@ public class AgentState extends ALatticeComponent<ACell> {
 	@SuppressWarnings("unchecked")
 	public AMap<AString, ACell> mergeRunResult(
 			ACell newState,
-			AString consumedSession,
-			Index<Blob, ACell> presentedTasks,
 			AMap<AString, ACell> taskResults,
 			AMap<AString, ACell> timelineEntry,
 			Blob historySid,
@@ -1197,32 +1180,6 @@ public class AgentState extends ALatticeComponent<ACell> {
 				}
 			}
 
-			// Check whether any session still has work after the drain —
-			// pending messages or an unfinished cycle (same rule as the wake
-			// gate, so the loop never sleeps on a session it would wake for).
-			boolean hasSessionPendingInRecord = false;
-			ACell sessionsCell = updated.get(K_SESSIONS);
-			if (sessionsCell instanceof Index idx) {
-				for (var entry : ((Index<Blob, ACell>) idx).entrySet()) {
-					if (entry.getValue() instanceof AMap m && sessionHasWork(m)) {
-						hasSessionPendingInRecord = true;
-						break;
-					}
-				}
-			}
-
-			boolean hasNew = hasSessionPendingInRecord
-				|| hasNewTasksNotIn(remainingTasks, presentedTasks);
-
-			// Preserve externally-set SUSPENDED/TERMINATED — these are signals
-			// from outside the run loop (e.g. handleSuspend, handleTerminate)
-			// and must not be overwritten here. The CAS-retry inside
-			// updateAndGet guarantees we see the latest status.
-			AString currentStatus = RT.ensureString(r.get(K_STATUS));
-			if (!SUSPENDED.equals(currentStatus) && !TERMINATED.equals(currentStatus)) {
-				updated = updated.assoc(K_STATUS, hasNew ? RUNNING : SLEEPING);
-			}
-
 			return updated;
 		});
 	}
@@ -1258,13 +1215,4 @@ public class AgentState extends ALatticeComponent<ACell> {
 		return remaining;
 	}
 
-	private static boolean hasNewTasksNotIn(Index<Blob, ACell> current, Index<Blob, ACell> presented) {
-		if (current == null || current.count() == 0) return false;
-		if (presented == null) return current.count() > 0;
-		for (var entry : current.entrySet()) {
-			ACell before = presented.get(entry.getKey());
-			if (before == null || !Objects.equals(before, entry.getValue())) return true;
-		}
-		return false;
-	}
 }

--- a/venue/src/main/java/covia/venue/JobManager.java
+++ b/venue/src/main/java/covia/venue/JobManager.java
@@ -1002,28 +1002,20 @@ public class JobManager {
 	// ========== Job Recovery ==========
 
 	/**
-	 * Stabilises jobs from the lattice after a restart. <b>Nothing is ever
-	 * re-executed</b> (#214): recovery leaves every job in a stable, honest
-	 * state so callers can resume, cancel, or retry as they wish.
+	 * Stabilises jobs from the lattice after a restart. Execution attempts do
+	 * not survive the venue process; durable waiting Jobs do.
 	 *
 	 * <ul>
 	 *   <li>PENDING — failed: execution never began; the caller retries.</li>
-	 *   <li>STARTED {@code agent:request} whose task is still in the agent's
-	 *       tasks index — restored as a live Job, still STARTED: the durable
-	 *       task drives completion when the agent's work resumes (long-running
-	 *       jobs survive restarts; callers keep polling by ID).</li>
-	 *   <li>STARTED anything else — failed with a message saying effects may
+	 *   <li>STARTED — failed with a message saying effects may
 	 *       or may not have applied. Re-execution would double side effects
 	 *       (e.g. {@code convex:transact}, {@code http:post}); the caller
-	 *       verifies and retries. A crashed {@code agent:chat} fails too —
-	 *       the session is intact and its id is on the record, so the caller
-	 *       just re-sends.</li>
+	 *       verifies and retries.</li>
 	 *   <li>PAUSED / INPUT_REQUIRED / AUTH_REQUIRED — restored (unchanged).</li>
 	 * </ul>
 	 *
-	 * <p>Agent-side work (pending envelopes, queued tasks, interrupted
-	 * {@code inCycle} cycles) is all durable and resumed separately by the
-	 * boot scan ({@code AgentAdapter.wakeAgentsWithWork}).</p>
+	 * <p>Adapters reconcile their own durable intake after this generic Job
+	 * pass; JobManager has no knowledge of adapter-specific queue structures.</p>
 	 */
 	@SuppressWarnings("unchecked")
 	public void recoverJobs() {
@@ -1053,7 +1045,8 @@ public class JobManager {
 
 				AString status = RT.ensureString(record.get(Fields.STATUS));
 				if (Status.PENDING.equals(status) || Status.STARTED.equals(status)) {
-					if (stabiliseJob(jobID, record, status, did)) kept++; else stabilised++;
+					stabiliseJob(jobID, record, status, did);
+					stabilised++;
 				} else {
 					restoreJob(jobID, record, did);
 					kept++;
@@ -1067,54 +1060,18 @@ public class JobManager {
 	}
 
 	/**
-	 * Stabilises one PENDING/STARTED job found at boot. Returns true when the
-	 * job was restored live (STARTED {@code agent:request} with its durable
-	 * task still queued), false when it was failed with an honest
-	 * interruption message. See {@link #recoverJobs()} for the contract.
+	 * Fails one PENDING/STARTED Job found at boot.
 	 */
-	private boolean stabiliseJob(Blob jobID, AMap<AString, ACell> record, AString status, AString callerDID) {
+	private void stabiliseJob(Blob jobID, AMap<AString, ACell> record, AString status, AString callerDID) {
 		if (Status.PENDING.equals(status)) {
 			markJobFailed(jobID, record,
 				"Venue restarted before execution began — retry if desired", callerDID);
-			return false;
-		}
-
-		// Classify by the op's adapter dispatch string (e.g. "agent:request").
-		AString opRef = RT.ensureString(record.get(Fields.OP));
-		Asset asset = (opRef != null) ? engine.resolveAsset(opRef) : null;
-		String adapterOp = (asset != null) ? AAdapter.getAdapterOperation(asset.meta()) : null;
-
-		if ("agent:request".equals(adapterOp)) {
-			// The task index is the durable work marker (taskId == jobID). If
-			// the task is still queued, the job legitimately outlives the
-			// restart: restore it and let the resumed agent complete it.
-			AString agentId = RT.ensureString(RT.getIn(record, Fields.INPUT, Fields.AGENT_ID));
-			User user = engine.getVenueState().users().get(callerDID);
-			AgentState agent = (user != null && agentId != null) ? user.agent(agentId.toString()) : null;
-			Index<Blob, ACell> tasks = (agent != null) ? agent.getTasks() : null;
-			if (tasks != null && tasks.get(jobID) != null) {
-				restoreJob(jobID, record, callerDID);
-				log.info("Restored in-flight task job {} (task still queued)", jobID);
-				return true;
-			}
-			markJobFailed(jobID, record,
-				"Venue restarted as the task concluded — check the agent timeline/session for the result",
-				callerDID);
-			return false;
-		}
-
-		if ("agent:chat".equals(adapterOp)) {
-			AString sid = RT.ensureString(record.get(Fields.SESSION_ID));
-			markJobFailed(jobID, record,
-				"Venue restarted mid-conversation — the session is intact; re-send your message"
-				+ ((sid != null) ? " (sessionId " + sid + ")" : ""), callerDID);
-			return false;
+			return;
 		}
 
 		markJobFailed(jobID, record,
 			"Venue restarted during execution — effects may or may not have applied;"
 			+ " verify state before retrying", callerDID);
-		return false;
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/server/VenueServer.java
+++ b/venue/src/main/java/covia/venue/server/VenueServer.java
@@ -530,10 +530,9 @@ public class VenueServer {
 		engine.provisionConfiguredSecrets();
 		engine.jobs().recoverJobs();
 
-		// Wake agents with durable work (pending envelopes, queued tasks, or a
-		// stale inCycle claim from an interrupted cycle). recoverJobs only
-		// stabilises job records — it never re-executes anything (#214) — so
-		// this scan is the single trigger that restarts agent loops after restart.
+		// Reconcile agent-owned intake after generic Job recovery: clear stale
+		// executor markers/fences, remove intake for terminal Jobs, then wake only
+		// remaining durable queued work. Internal execution is never resumed.
 		if (engine.getAdapter("agent") instanceof covia.adapter.AgentAdapter agentAdapter) {
 			agentAdapter.wakeAgentsWithWork();
 		}

--- a/venue/src/test/java/covia/adapter/AgentAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/AgentAdapterTest.java
@@ -96,6 +96,13 @@ public class AgentAdapterTest {
 		}
 	}
 
+	/** Current API-visible status, including the live executor overlay. */
+	private AString observableStatus(AgentState agent) {
+		AMap<AString, ACell> info = ((AgentAdapter) engine.getAdapter("agent"))
+			.agentInfo(RequestContext.of(ALICE_DID), agent.getAgentId());
+		return RT.ensureString(info.get(Fields.STATUS));
+	}
+
 	// ========== agent:create ==========
 
 	/**
@@ -1999,8 +2006,7 @@ public class AgentAdapterTest {
 	@Test
 	public void testTriggerWaitFalseReturnsImmediately() {
 		// wait=false → return immediately with status RUNNING. Run loop still
-		// executes in the background; caller polls via agent:info or
-		// covia:read path=g/<agent>/status.
+		// executes in the background; caller observes it via agent:info.
 		engine.jobs().invokeOperation(
 			"v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, "async-agent",
@@ -2102,17 +2108,12 @@ public class AgentAdapterTest {
 	}
 
 	/**
-	 * Regression for #64 — phantom RUNNING state. If the agent's lattice status
-	 * shows RUNNING but no live run exists (crash-recovery remnant, stale
-	 * write, or race that slips past clean-exit), a subsequent trigger must
-	 * still be able to start a fresh loop. The runningLoops slot is the source
-	 * of truth for liveness — wakeAgent corrects the lattice inside the atomic
-	 * ConcurrentHashMap.compute() update.
+	 * Legacy persisted RUNNING is not liveness. The API reports SLEEPING when
+	 * no executor exists, and the next wake performs the one-way data migration
+	 * before starting normally.
 	 *
-	 * <p>Deterministic: we force the phantom by writing status=RUNNING
-	 * directly while no run is live (fresh agent, no triggers yet), then
-	 * issue a normal trigger. Without the fix this fails with "Cannot start
-	 * agent"; with the fix the trigger recovers and completes.</p>
+	 * <p>Deterministic: force the old record shape while no run is live, observe
+	 * it through agent:info, then issue a normal trigger.</p>
 	 */
 	@Test
 	public void testPhantomRunningRecovery() {
@@ -2127,7 +2128,9 @@ public class AgentAdapterTest {
 
 		// Force the phantom: status=RUNNING with no runningLoops entry
 		agent.setStatus(AgentState.RUNNING);
-		assertEquals(AgentState.RUNNING, agent.getStatus());
+		assertEquals(AgentState.RUNNING, agent.getStatus()); // raw legacy record
+		assertEquals(AgentState.SLEEPING, observableStatus(agent),
+			"persisted RUNNING without a live executor must not report liveness");
 
 		// Trigger must recover — not fail with "Cannot start agent"
 		Job job = engine.jobs().invokeOperation(
@@ -2136,7 +2139,7 @@ public class AgentAdapterTest {
 			RequestContext.of(ALICE_DID));
 		ACell result = job.awaitResult(5000);
 
-		assertNotNull(result, "Trigger should recover from phantom RUNNING");
+		assertNotNull(result, "Trigger should tolerate stale persisted RUNNING");
 		assertEquals(Status.COMPLETE, job.getStatus(),
 			"Job should complete, not fail with 'Cannot start agent'");
 		assertEquals(AgentState.SLEEPING, RT.getIn(result, Fields.STATUS));
@@ -2540,13 +2543,15 @@ public class AgentAdapterTest {
 			Maps.of(Fields.AGENT_ID, "del-wedge", Fields.INPUT, Maps.of("data", "slow")),
 			RequestContext.of(ALICE_DID));
 
-		// Wait until the run loop is live in the never-completing transition
+		// Wait until the live executor reports the never-completing transition.
 		AgentState agent = engine.getVenueState().users().get(ALICE_DID).agent("del-wedge");
 		long deadline = System.currentTimeMillis() + 5000;
-		while (!AgentState.RUNNING.equals(agent.getStatus())
+		while (!AgentState.RUNNING.equals(observableStatus(agent))
 				&& System.currentTimeMillis() < deadline) Thread.sleep(10);
-		assertEquals(AgentState.RUNNING, agent.getStatus(),
+		assertEquals(AgentState.RUNNING, observableStatus(agent),
 			"agent should be blocked in the never-completing transition");
+		assertEquals(AgentState.RUNNING, agent.getStatus(),
+			"RUNNING is persisted for lattice observers while the executor is live");
 
 		engine.jobs().invokeOperation(
 			"v/ops/agent/delete",
@@ -3066,7 +3071,9 @@ public class AgentAdapterTest {
 				Fields.TIMEOUT, 0),
 			RequestContext.of(ALICE_DID)).get(5000, java.util.concurrent.TimeUnit.MILLISECONDS);
 
-		assertEquals(Status.STARTED, RT.getIn(snapshot, Fields.STATUS));
+		AString snapshotStatus = RT.ensureString(RT.getIn(snapshot, Fields.STATUS));
+		assertTrue(Status.PENDING.equals(snapshotStatus) || Status.STARTED.equals(snapshotStatus),
+			"accepted request is queued or already picked: " + snapshot);
 		Blob taskId = Job.parseID(RT.getIn(snapshot, Fields.ID));
 		assertNotNull(taskId);
 		Job task = engine.jobs().getJob(taskId);
@@ -3269,12 +3276,13 @@ public class AgentAdapterTest {
 
 		// The async pattern: the request returns immediately with a pollable task
 		// Job. The agent runs asynchronously, so the job is legitimately either
-		// STARTED (not yet picked up) or already COMPLETE — a caller must handle
-		// both rather than assume one. Assert only that we got a real, pollable
+		// PENDING (queued), STARTED (picked), or already COMPLETE — a caller must
+		// handle all three rather than assume one. Assert only that we got a pollable
 		// job in a valid state.
 		AString status = job.getStatus();
-		assertTrue(Status.STARTED.equals(status) || Status.COMPLETE.equals(status),
-			"Async request should return a STARTED or COMPLETE job, was: " + status);
+		assertTrue(Status.PENDING.equals(status) || Status.STARTED.equals(status)
+				|| Status.COMPLETE.equals(status),
+			"Async request should return a queued, started or complete job, was: " + status);
 
 		// Poll to completion, then read the output — the normal async retrieval path.
 		job.awaitResult(5000);
@@ -3360,7 +3368,9 @@ public class AgentAdapterTest {
 		long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
 
 		assertTrue(elapsedMs < 500, "timeout=0 should return immediately, took " + elapsedMs + "ms");
-		assertEquals(Status.STARTED, RT.getIn(result, Fields.STATUS));
+		AString status = RT.ensureString(RT.getIn(result, Fields.STATUS));
+		assertTrue(Status.PENDING.equals(status) || Status.STARTED.equals(status),
+			"accepted request is queued or already picked: " + result);
 		assertNotNull(RT.getIn(result, Fields.ID), "Async response must carry Job id");
 	}
 
@@ -4084,8 +4094,9 @@ public class AgentAdapterTest {
 		User user = engine.getVenueState().users().get(ALICE_DID);
 		AgentState old = user.agent("run-ow");
 		long deadline = System.currentTimeMillis() + 5000;
-		while (!AgentState.RUNNING.equals(old.getStatus())
+		while (!AgentState.RUNNING.equals(observableStatus(old))
 				&& System.currentTimeMillis() < deadline) Thread.sleep(10);
+		assertEquals(AgentState.RUNNING, observableStatus(old));
 		assertEquals(AgentState.RUNNING, old.getStatus());
 
 		// History-preserving mutation cannot safely swap config under an active
@@ -4425,9 +4436,6 @@ public class AgentAdapterTest {
 		assertTrue(agent.getTs() > 0, "Agent should have a ts after creation");
 		assertEquals(0, agent.getTasks().count(), "New agent should have empty tasks");
 		assertEquals(0, agent.getPending().count(), "New agent should have empty pending");
-
-		agent.setStatus(AgentState.RUNNING);
-		assertEquals(AgentState.RUNNING, agent.getStatus());
 
 		agent.setStatus(AgentState.SUSPENDED);
 		assertEquals(AgentState.SUSPENDED, agent.getStatus());

--- a/venue/src/test/java/covia/adapter/AgentConcurrencyTest.java
+++ b/venue/src/test/java/covia/adapter/AgentConcurrencyTest.java
@@ -128,74 +128,29 @@ public class AgentConcurrencyTest {
 	// ========== Unit: mergeRunResult ==========
 
 	@Test
-	public void testMergeRunResultDetectsNewSessionPending() {
-		// mergeRunResult should detect session pending messages delivered
-		// DURING the transition and stay RUNNING.
+	public void testMergeRunResultDoesNotPersistExecutorStatus() {
+		// Work that arrives during a transition is durable, but executor
+		// liveness is not part of the merge result.
 		Users users = engine.getVenueState().users();
 		User user = users.ensure(ALICE_DID);
 		AgentState agent = user.ensureAgent("merge-msg", Maps.empty(), null);
-		agent.setStatus(AgentState.RUNNING);
 
-		// Set up a session with a pending message
 		Blob sid = Blob.fromHex("66660001666600016666000166660001");
 		agent.ensureSession(sid, ALICE_DID);
 		agent.appendSessionPending(sid, Maps.of("content", "hello"));
+		Blob taskId = Blob.fromHex("0001");
+		agent.addTask(taskId, Strings.create("new work"));
 
-		// mergeRunResult with 0 drain: session.pending still has the message
-		// → hasSessionPendingInRecord = true → status RUNNING
 		AMap<AString, ACell> merged = agent.mergeRunResult(
-			null, null, Index.none(), null,
-			Maps.of("ts", CVMLong.create(1)),
-			sid, null, 0);
+			null, null, Maps.of("ts", CVMLong.create(1)),
+			sid, null, 0, null, null);
 
-		assertEquals(AgentState.RUNNING, RT.ensureString(merged.get(AgentState.KEY_STATUS)),
-			"Should detect session pending and stay RUNNING");
-
-		// Now drain that message: presentedSessionPendingCount=1
-		AMap<AString, ACell> merged2 = agent.mergeRunResult(
-			null, null, Index.none(), null,
-			Maps.of("ts", CVMLong.create(2)),
-			sid, null, 1);
-
-		assertEquals(AgentState.SLEEPING, RT.ensureString(merged2.get(AgentState.KEY_STATUS)),
-			"No pending messages — should go to SLEEPING");
-	}
-
-	@Test
-	public void testMergeRunResultDetectsNewTask() {
-		// mergeRunResult should detect tasks added DURING the transition
-		// via hasNewTasksNotIn(remainingTasks, presentedTasks).
-		Users users = engine.getVenueState().users();
-		User user = users.ensure(ALICE_DID);
-		AgentState agent = user.ensureAgent("merge-task", Maps.empty(), null);
-		agent.setStatus(AgentState.RUNNING);
-
-		// Add task T1
-		Blob t1 = Blob.fromHex("0001");
-		agent.addTask(t1, Strings.create("task-1"));
-
-		// mergeRunResult presenting T1 as already processed
-		AMap<AString, ACell> merged = agent.mergeRunResult(
-			null, null, agent.getTasks(), null,
-			Maps.of("ts", CVMLong.create(1)));
-
-		assertEquals(AgentState.SLEEPING, RT.ensureString(merged.get(AgentState.KEY_STATUS)),
-			"No new tasks beyond what was presented — SLEEPING");
-
-		// Now add T2 while "transition is running"
-		agent.setStatus(AgentState.RUNNING);
-		Blob t2 = Blob.fromHex("0002");
-		agent.addTask(t2, Strings.create("task-2"));
-
-		// mergeRunResult presenting only T1
-		@SuppressWarnings("unchecked")
-		Index<Blob, ACell> presentedTasks = (Index<Blob, ACell>) (Index<?,?>) Index.none().assoc(t1, Strings.create("task-1"));
-		AMap<AString, ACell> merged2 = agent.mergeRunResult(
-			null, null, presentedTasks, null,
-			Maps.of("ts", CVMLong.create(2)));
-
-		assertEquals(AgentState.RUNNING, RT.ensureString(merged2.get(AgentState.KEY_STATUS)),
-			"New task T2 not in presented set — should stay RUNNING");
+		assertEquals(AgentState.SLEEPING,
+			RT.ensureString(merged.get(AgentState.KEY_STATUS)));
+		assertEquals(1, agent.getSessionPending(sid).count(),
+			"pending work remains available to the live loop");
+		assertNotNull(agent.getTasks().get(taskId),
+			"new task remains available to the live loop");
 	}
 
 	// ========== Integration: concurrent triggers ==========
@@ -559,13 +514,9 @@ public class AgentConcurrencyTest {
 			Maps.of(Fields.AGENT_ID, "resume-wake"),
 			RequestContext.of(ALICE_DID)).awaitResult(5000);
 
-		// Wait for the auto-wake run loop to complete
-		for (int i = 0; i < 50; i++) {
-			if (AgentState.SLEEPING.equals(agent.getStatus())) break;
-			try { Thread.sleep(10); } catch (InterruptedException e) { break; }
-		}
-
-		assertEquals(AgentState.SLEEPING, agent.getStatus(),
+		// Wait on the live executor, not the stable lattice status (which stays
+		// SLEEPING throughout the attempt).
+		assertEquals(AgentState.SLEEPING, awaitFinished(agent),
 			"Agent should complete run loop after resume auto-wake");
 		assertFalse(agent.hasSessionPending(),
 			"Messages should be processed by auto-wake");

--- a/venue/src/test/java/covia/venue/AgentStateSessionCycleTest.java
+++ b/venue/src/test/java/covia/venue/AgentStateSessionCycleTest.java
@@ -29,8 +29,8 @@ import convex.core.lang.RT;
  * Stage A): {@link AgentState#beginSessionCycle},
  * {@link AgentState#updateSessionFrames} (epoch-fenced), the shared
  * root-turn-append/pending-drain helpers, the {@code inCycle} clear inside
- * {@link AgentState#mergeRunResult}, and {@code inCycle}-as-work in the
- * session work predicates.
+ * {@link AgentState#mergeRunResult}, and the rule that {@code inCycle} is a
+ * write fence rather than durable queued work.
  */
 public class AgentStateSessionCycleTest {
 
@@ -167,19 +167,18 @@ public class AgentStateSessionCycleTest {
 			"merge must release the cycle claim in the same CAS");
 	}
 
-	// ========== inCycle counts as work ==========
+	// ========== inCycle is not work ==========
 
 	@Test
-	public void testInCycleCountsAsWork() {
-		// Drain everything: pending empty, but the cycle is unfinished — the
-		// session must still register as work (crash-interrupted cycles would
-		// otherwise never re-run, their input already consumed).
+	public void testInCycleDoesNotCountAsWork() {
+		// Drain everything: the epoch remains only as a live write fence. It is
+		// not a durable instruction to resume the interrupted execution.
 		agent.appendSessionPending(sid, envelope("m1"));
 		assertTrue(agent.beginSessionCycle(sid, EPOCH_A, Vectors.of(turn("m1")), 1));
 		assertEquals(0, agent.getSessionPending(sid).count());
 
-		assertTrue(agent.hasSessionPending(), "inCycle session must count as work");
-		assertEquals(sid, agent.pickSessionWithPending(), "inCycle session must be pickable");
+		assertFalse(agent.hasSessionPending(), "inCycle must not count as queued work");
+		assertNull(agent.pickSessionWithPending(), "inCycle session must not be pickable");
 
 		mergeMinimalCycle();
 		assertFalse(agent.hasSessionPending(), "merged cycle with empty pending is quiescent");
@@ -226,7 +225,7 @@ public class AgentStateSessionCycleTest {
 	private void mergeMinimalCycle() {
 		AMap<AString, ACell> timelineEntry = Maps.of(
 			Strings.create("op"), Strings.create("test-cycle"));
-		agent.mergeRunResult(Maps.empty(), null, Index.none(), null,
+		agent.mergeRunResult(Maps.empty(), null,
 			timelineEntry, sid, null, 0, null, null);
 	}
 }

--- a/venue/src/test/java/covia/venue/GoalTreeCrashResumeTest.java
+++ b/venue/src/test/java/covia/venue/GoalTreeCrashResumeTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import convex.core.crypto.AKeyPair;
+import convex.core.crypto.util.Multikey;
 import convex.core.data.ACell;
 import convex.core.data.AMap;
 import convex.core.data.AString;
@@ -18,7 +19,6 @@ import convex.core.data.Keyword;
 import convex.core.data.Maps;
 import convex.core.data.Strings;
 import convex.core.data.prim.CVMLong;
-import convex.core.crypto.util.Multikey;
 import convex.core.lang.RT;
 import convex.etch.EtchStore;
 import convex.node.NodeConfig;
@@ -30,44 +30,52 @@ import covia.grid.Status;
 import covia.lattice.Covia;
 
 /**
- * Crash resume for lattice-resident goal-tree frames (Stage C): a venue that
- * dies mid-cycle restarts, detects the stale {@code inCycle} claim, repairs
- * dangling toolCalls with synthetic results, settles child frames
- * deepest-first, and completes the interrupted work. Two-engine pattern over
- * one Etch store (see {@link VenueRestartTest}); the pre-crash transition is
- * parked deterministically in a {@code v/test/ops/never} tool call with a
- * long timeout, so the "crash" (engine close) always lands mid-cycle.
+ * Restart boundary for agent execution. Jobs and external interaction records
+ * are durable; a live GoalTree execution attempt is not resumed after its venue
+ * process disappears.
  */
-// Durability guarantee: forks real JVMs / relaunches venues to prove crash
-// and restart survival. Slow and unavoidably so — excluded from the default
-// `mvn test` inner loop, run on every push via CI (-DexcludedGroups=integration).
 @Tag("durability")
 public class GoalTreeCrashResumeTest {
 
-	private static final AString ALICE = Strings.create("did:key:z6MkCrashResumeAlice");
+	private static final AString ALICE = Strings.create("did:key:z6MkCrashBoundaryAlice");
 
-	private static void await(BooleanSupplier cond, long ms, String desc) {
-		long deadline = System.currentTimeMillis() + ms;
-		while (!cond.getAsBoolean()) {
-			if (System.currentTimeMillis() > deadline) fail("timeout waiting for: " + desc);
-			try { Thread.sleep(20); } catch (InterruptedException e) {
+	private static void await(BooleanSupplier condition, long timeoutMs, String description) {
+		long deadline = System.currentTimeMillis() + timeoutMs;
+		while (!condition.getAsBoolean()) {
+			if (System.currentTimeMillis() > deadline) fail("timeout waiting for: " + description);
+			try {
+				Thread.sleep(20);
+			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 				fail("interrupted");
 			}
 		}
 	}
 
-	private static void createGoalAgent(Engine engine, String agentId, String llmOp) {
-		engine.jobs().invokeOperation(
-			"v/ops/agent/create",
+	private static AMap<AString, ACell> config(AKeyPair keyPair) {
+		String did = "did:key:" + Multikey.encodePublicKey(keyPair.getAccountKey());
+		return Maps.of(Config.DID, did, Config.USERS, Maps.of(Config.AUTO_CREATE, true));
+	}
+
+	private static Engine start(EtchStore store, AKeyPair keyPair,
+			AMap<AString, ACell> config, NodeServer<Index<Keyword, ACell>>[] holder)
+			throws Exception {
+		NodeServer<Index<Keyword, ACell>> node =
+			new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
+		node.launch();
+		holder[0] = node;
+		Engine engine = new Engine(config, node.getCursor(), keyPair).start();
+		Engine.addDemoAssets(engine);
+		return engine;
+	}
+
+	private static void createGoalAgent(Engine engine, String agentId) {
+		engine.jobs().invokeOperation("v/ops/agent/create",
 			Maps.of(Fields.AGENT_ID, agentId,
 				Fields.CONFIG, Maps.of(
 					Fields.OPERATION, Strings.create("v/ops/goaltree/chat"),
-					Strings.create("llmOperation"), Strings.create(llmOp),
+					Strings.create("llmOperation"), Strings.create("v/test/ops/nevertoolllm"),
 					Strings.create("systemPrompt"), Strings.create("Test agent."),
-					// Long tool timeout: the pre-crash cycle stays parked in the
-					// never-tool for the whole test — the crash always lands
-					// mid-cycle, deterministically.
 					Strings.create("toolCallTimeoutMs"), CVMLong.create(60_000))),
 			RequestContext.of(ALICE)).awaitResult(5000);
 	}
@@ -78,544 +86,139 @@ public class GoalTreeCrashResumeTest {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static AVector<ACell> frames(Engine engine, String agentId, Blob sid) {
-		AMap<AString, ACell> session = agent(engine, agentId).getSession(sid);
-		if (session == null) return null;
-		ACell fv = session.get(AgentState.KEY_FRAMES);
-		return (fv instanceof AVector) ? (AVector<ACell>) fv : null;
-	}
-
 	private static AVector<ACell> rootConversation(Engine engine, String agentId, Blob sid) {
-		AVector<ACell> fs = frames(engine, agentId, sid);
-		return RT.ensureVector(RT.getIn(fs.get(0), "conversation"));
+		AMap<AString, ACell> session = agent(engine, agentId).getSession(sid);
+		AVector<ACell> frames = (AVector<ACell>) session.get(AgentState.KEY_FRAMES);
+		return RT.ensureVector(RT.getIn(frames.get(0), "conversation"));
 	}
 
-	private static long countTurnsContaining(AVector<ACell> conv, String needle) {
-		long n = 0;
-		for (long i = 0; i < conv.count(); i++) {
-			if (String.valueOf(conv.get(i)).contains(needle)) n++;
-		}
-		return n;
+	private static boolean parkedInTool(Engine engine, String agentId, Blob sid) {
+		AVector<ACell> conversation = rootConversation(engine, agentId, sid);
+		return conversation != null && String.valueOf(conversation).contains("toolCalls");
 	}
 
-	/**
-	 * True when the child frame is parked in the never-tool with its dangling
-	 * assistant toolCall turn DURABLE. Awaiting only {@code frames.count()==2}
-	 * races the child's assistant turn: the crash then lands on a child with
-	 * just the goal turn, there is nothing to repair, and the resumed child
-	 * legitimately re-runs the tool from scratch (at-least-once) — parking for
-	 * the full tool timeout, which is not the scenario these tests pin.
-	 */
-	private static boolean childParkedDurably(Engine engine, String agentId, Blob sid) {
-		AVector<ACell> fs = frames(engine, agentId, sid);
-		if (fs == null || fs.count() != 2) return false;
-		ACell conv = RT.getIn(fs.get(1), "conversation");
-		return conv instanceof AVector<?> v && v.count() >= 2
-			&& String.valueOf(conv).contains("toolCalls");
-	}
-
-	/**
-	 * Message-driven interruption, recovered by the boot scan: the intake job
-	 * completed at delivery, so recoverJobs has nothing to re-fire —
-	 * {@code wakeInterruptedCycles} is the only wake path. The resumed cycle
-	 * repairs the dangling toolCall and finishes.
-	 */
 	@Test
-	public void testCrashResumeViaBootScan() throws Exception {
+	public void testInterruptedRequestFailsAndDoesNotResume() throws Exception {
 		EtchStore store = EtchStore.createTemp();
-		AKeyPair kp = AKeyPair.generate();
-		String did = "did:key:" + Multikey.encodePublicKey(kp.getAccountKey());
-		AMap<AString, ACell> config = Maps.of(Config.DID, did,
-			Config.USERS, Maps.of(Config.AUTO_CREATE, true));
-		Blob sid = Blob.fromHex("cc112233445566778899aabbccddee01");
+		AKeyPair keyPair = AKeyPair.generate();
+		AMap<AString, ACell> config = config(keyPair);
+		Blob sid = Blob.fromHex("cc112233445566778899aabbccddee31");
+		Blob requestId;
 
-		// ===== Stage 1: run until parked mid-cycle, then "crash" =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
+		@SuppressWarnings("unchecked")
+		NodeServer<Index<Keyword, ACell>>[] node = new NodeServer[1];
+		Engine first = start(store, keyPair, config, node);
+		createGoalAgent(first, "request-agent");
+		agent(first, "request-agent").ensureSession(sid, ALICE);
+		Job request = first.jobs().invokeOperation("v/ops/agent/request",
+			Maps.of(Fields.AGENT_ID, "request-agent",
+				Fields.SESSION_ID, Strings.create(sid.toHexString()),
+				Fields.INPUT, Strings.create("use the slow tool")),
+			RequestContext.of(ALICE));
+		requestId = request.getID();
+		await(() -> parkedInTool(first, "request-agent", sid), 10_000, "request parked in tool");
+		assertEquals(Status.STARTED, request.getStatus());
+		assertEquals(AgentState.RUNNING, agent(first, "request-agent").getStatus());
+		assertNotNull(agent(first, "request-agent").getSessionCycleEpoch(sid));
+		first.flush();
+		first.close();
+		node[0].close();
 
-			createGoalAgent(engine, "boot-agent", "v/test/ops/nevertoolllm");
-			agent(engine, "boot-agent").ensureSession(sid, ALICE);
+		Engine second = start(store, keyPair, config, node);
+		second.jobs().recoverJobs();
+		AMap<AString, ACell> failed = second.jobs().getJobData(requestId, RequestContext.of(ALICE));
+		assertEquals(Status.FAILED, failed.get(Fields.STATUS));
 
-			engine.jobs().invokeOperation(
-				"v/ops/agent/message",
-				Maps.of(Fields.AGENT_ID, "boot-agent",
-					Fields.SESSION_ID, Strings.create(sid.toHexString()),
-					Fields.MESSAGE, Strings.create("please use the slow tool")),
-				RequestContext.of(ALICE)).awaitResult(5000);
-
-			// Parked in the never-tool: the assistant turn with its dangling
-			// toolCall is live on the lattice and the cycle claim is set.
-			await(() -> {
-				AVector<ACell> conv = rootConversation(engine, "boot-agent", sid);
-				return conv != null && countTurnsContaining(conv, "toolCalls") > 0;
-			}, 10_000, "cycle parked in the never-tool");
-			assertNotNull(agent(engine, "boot-agent").getSessionCycleEpoch(sid));
-
-			engine.flush();      // make the mid-cycle state durable
-			engine.close();      // "crash": sweep stops, zombie writes never persist
-			ns.close();
-		}
-
-		// ===== Stage 2: restart, boot scan wakes, cycle resumes =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
-
-			// Mid-cycle state survived the crash
-			assertNotNull(agent(engine, "boot-agent").getSessionCycleEpoch(sid),
-				"stale inCycle claim must survive the restart");
-
-			engine.jobs().recoverJobs();   // nothing in flight (message completed at delivery)
-			AgentAdapter aa = (AgentAdapter) engine.getAdapter("agent");
-			assertEquals(1, aa.wakeAgentsWithWork(),
-				"the boot scan must find and wake the interrupted agent");
-
-			AgentState ag = agent(engine, "boot-agent");
-			await(() -> AgentState.SLEEPING.equals(ag.getStatus())
-					&& ag.getSessionCycleEpoch(sid) == null,
-				15_000, "resumed cycle completes and releases the claim");
-
-			AVector<ACell> conv = rootConversation(engine, "boot-agent", sid);
-			assertEquals(1, countTurnsContaining(conv, "did not return"),
-				"exactly one synthetic error result for the dangling call: " + conv);
-			assertTrue(countTurnsContaining(conv, "gave up") > 0,
-				"the model continued from the synthetic result: " + conv);
-			assertEquals(1, countTurnsContaining(conv, "please use the slow tool"),
-				"no duplicated user turn on resume");
-
-			engine.close();
-			ns.close();
-		}
+		AgentAdapter adapter = (AgentAdapter) second.getAdapter("agent");
+		assertEquals(0, adapter.wakeAgentsWithWork(),
+			"the abandoned request must not become fresh boot work");
+		AgentState recovered = agent(second, "request-agent");
+		assertEquals(AgentState.SLEEPING, recovered.getStatus());
+		assertNull(recovered.getSessionCycleEpoch(sid));
+		assertNull(recovered.getTasks().get(requestId));
+		assertFalse(String.valueOf(rootConversation(second, "request-agent", sid)).contains("gave up"),
+			"startup must not continue the interrupted model loop");
+		second.close();
+		node[0].close();
 	}
 
-	/**
-	 * An unanswered tool call is repaired WITHOUT a restart (#271).
-	 *
-	 * <p>Every other tool failure — timeout, denial, malformed arguments — already
-	 * comes back as an {@code "Error: …"} tool result the model reads and recovers
-	 * from. A call that never returned must be no different. Repair used to be
-	 * gated on the session looking crashed, so any other abort left a
-	 * {@code tool_use} with no {@code tool_result}; providers reject such a
-	 * history outright, so one transient failure poisoned the session
-	 * permanently — every later message on it failed while fresh sessions worked.</p>
-	 *
-	 * <p>{@code agent:suspend} reproduces it deterministically with no process
-	 * death: it cancels the in-flight transition AND clears the cycle claim, so
-	 * the session presents as perfectly clean while its conversation still holds
-	 * the dangling call. Nothing here restarts the venue.</p>
-	 */
 	@Test
-	public void testAbortedTurnRepairsWithoutRestart() throws Exception {
+	public void testCompletedMessageDoesNotMakeStaleCycleBootWork() throws Exception {
 		EtchStore store = EtchStore.createTemp();
-		AKeyPair kp = AKeyPair.generate();
-		String did = "did:key:" + Multikey.encodePublicKey(kp.getAccountKey());
-		AMap<AString, ACell> config = Maps.of(Config.DID, did,
-			Config.USERS, Maps.of(Config.AUTO_CREATE, true));
-		Blob sid = Blob.fromHex("cc112233445566778899aabbccddee09");
+		AKeyPair keyPair = AKeyPair.generate();
+		AMap<AString, ACell> config = config(keyPair);
+		Blob sid = Blob.fromHex("cc112233445566778899aabbccddee32");
 
-		NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-		ns.launch();
-		Engine engine = new Engine(config, ns.getCursor(), kp).start();
-		Engine.addDemoAssets(engine);
+		@SuppressWarnings("unchecked")
+		NodeServer<Index<Keyword, ACell>>[] node = new NodeServer[1];
+		Engine first = start(store, keyPair, config, node);
+		createGoalAgent(first, "message-agent");
+		agent(first, "message-agent").ensureSession(sid, ALICE);
+		Job delivery = first.jobs().invokeOperation("v/ops/agent/message",
+			Maps.of(Fields.AGENT_ID, "message-agent",
+				Fields.SESSION_ID, Strings.create(sid.toHexString()),
+				Fields.MESSAGE, Strings.create("use the slow tool")),
+			RequestContext.of(ALICE));
+		delivery.awaitResult(5000);
+		await(() -> parkedInTool(first, "message-agent", sid), 10_000, "message parked in tool");
+		first.flush();
+		first.close();
+		node[0].close();
+
+		Engine second = start(store, keyPair, config, node);
+		second.jobs().recoverJobs();
+		AgentAdapter adapter = (AgentAdapter) second.getAdapter("agent");
+		assertEquals(0, adapter.wakeAgentsWithWork(),
+			"inCycle alone must not wake an agent after restart");
+		AgentState recovered = agent(second, "message-agent");
+		assertEquals(AgentState.SLEEPING, recovered.getStatus());
+		assertNull(recovered.getSessionCycleEpoch(sid));
+		assertFalse(String.valueOf(rootConversation(second, "message-agent", sid)).contains("gave up"));
+		second.close();
+		node[0].close();
+	}
+
+	@Test
+	public void testFreshAttemptRepairsAnAbortedToolCall() throws Exception {
+		EtchStore store = EtchStore.createTemp();
+		AKeyPair keyPair = AKeyPair.generate();
+		AMap<AString, ACell> config = config(keyPair);
+		Blob sid = Blob.fromHex("cc112233445566778899aabbccddee33");
+
+		@SuppressWarnings("unchecked")
+		NodeServer<Index<Keyword, ACell>>[] node = new NodeServer[1];
+		Engine engine = start(store, keyPair, config, node);
 		try {
-			createGoalAgent(engine, "nokill-agent", "v/test/ops/nevertoolllm");
-			agent(engine, "nokill-agent").ensureSession(sid, ALICE);
-
-			engine.jobs().invokeOperation(
-				"v/ops/agent/message",
-				Maps.of(Fields.AGENT_ID, "nokill-agent",
+			createGoalAgent(engine, "repair-agent");
+			agent(engine, "repair-agent").ensureSession(sid, ALICE);
+			engine.jobs().invokeOperation("v/ops/agent/message",
+				Maps.of(Fields.AGENT_ID, "repair-agent",
 					Fields.SESSION_ID, Strings.create(sid.toHexString()),
-					Fields.MESSAGE, Strings.create("please use the slow tool")),
+					Fields.MESSAGE, Strings.create("use the slow tool")),
+				RequestContext.of(ALICE)).awaitResult(5000);
+			await(() -> parkedInTool(engine, "repair-agent", sid),
+				10_000, "message parked in tool");
+
+			engine.jobs().invokeOperation("v/ops/agent/suspend",
+				Maps.of(Fields.AGENT_ID, "repair-agent"),
+				RequestContext.of(ALICE)).awaitResult(5000);
+			await(() -> agent(engine, "repair-agent").getSessionCycleEpoch(sid) == null,
+				10_000, "cycle fence cleared after suspension");
+			engine.jobs().invokeOperation("v/ops/agent/resume",
+				Maps.of(Fields.AGENT_ID, "repair-agent"),
 				RequestContext.of(ALICE)).awaitResult(5000);
 
-			await(() -> {
-				AVector<ACell> conv = rootConversation(engine, "nokill-agent", sid);
-				return conv != null && countTurnsContaining(conv, "toolCalls") > 0;
-			}, 10_000, "cycle parked in the never-tool");
-
-			// Abort the turn in place — no crash, no restart.
-			engine.jobs().invokeOperation(
-				"v/ops/agent/suspend",
-				Maps.of(Fields.AGENT_ID, "nokill-agent"),
-				RequestContext.of(ALICE)).awaitResult(5000);
-
-			// The poisoned shape: the session looks clean (no cycle claim), yet
-			// the conversation still carries a tool call with no result.
-			await(() -> agent(engine, "nokill-agent").getSessionCycleEpoch(sid) == null,
-				10_000, "cycle claim cleared by suspend");
-			assertTrue(countTurnsContaining(
-					rootConversation(engine, "nokill-agent", sid), "toolCalls") > 0,
-				"precondition: the dangling toolCall is still on the lattice");
-
-			engine.jobs().invokeOperation(
-				"v/ops/agent/resume",
-				Maps.of(Fields.AGENT_ID, "nokill-agent"),
-				RequestContext.of(ALICE)).awaitResult(5000);
-
-			// Next turn on the SAME session: loading the conversation must heal
-			// the dangling call rather than hand the provider an invalid history.
-			engine.jobs().invokeOperation(
-				"v/ops/agent/message",
-				Maps.of(Fields.AGENT_ID, "nokill-agent",
+			engine.jobs().invokeOperation("v/ops/agent/message",
+				Maps.of(Fields.AGENT_ID, "repair-agent",
 					Fields.SESSION_ID, Strings.create(sid.toHexString()),
-					Fields.MESSAGE, Strings.create("are you still there")),
+					Fields.MESSAGE, Strings.create("start a fresh attempt")),
 				RequestContext.of(ALICE)).awaitResult(5000);
-
-			await(() -> countTurnsContaining(
-					rootConversation(engine, "nokill-agent", sid), "did not return") == 1,
-				10_000, "dangling call answered with a synthetic error result, no restart involved");
+			await(() -> String.valueOf(rootConversation(engine, "repair-agent", sid))
+				.contains("did not return"), 10_000,
+				"fresh attempt settled the dangling call explicitly");
 		} finally {
 			engine.close();
-			ns.close();
-		}
-	}
-
-	/**
-	 * Crash inside a running subgoal child. Recovery never re-executes intake
-	 * (#214): at boot the caller's chat job FAILS honestly (session intact,
-	 * sessionId on the record so the caller can re-engage), and the boot scan
-	 * resumes the agent's interrupted cycle from durable state — the repaired
-	 * child completes, pops atomically into the parent, and the root's answer
-	 * lands in the conversation.
-	 */
-	@Test
-	public void testCrashResumeInsideSubgoalChild() throws Exception {
-		EtchStore store = EtchStore.createTemp();
-		AKeyPair kp = AKeyPair.generate();
-		String did = "did:key:" + Multikey.encodePublicKey(kp.getAccountKey());
-		AMap<AString, ACell> config = Maps.of(Config.DID, did,
-			Config.USERS, Maps.of(Config.AUTO_CREATE, true));
-		Blob sid = Blob.fromHex("cc112233445566778899aabbccddee02");
-		String chatJobId;
-
-		// ===== Stage 1: crash while the child frame is mid-flight =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
-
-			createGoalAgent(engine, "sub-agent", "v/test/ops/subgoalllm");
-			agent(engine, "sub-agent").ensureSession(sid, ALICE);
-
-			Job chatJob = engine.jobs().invokeOperation(
-				"v/ops/agent/chat",
-				Maps.of(Fields.AGENT_ID, "sub-agent",
-					Fields.SESSION_ID, Strings.create(sid.toHexString()),
-					Fields.MESSAGE, Strings.create("decompose the work")),
-				RequestContext.of(ALICE));
-			chatJobId = chatJob.getID().toHexString();
-
-			// Child frame live on the lattice, parked in its never-tool — with
-			// the dangling toolCall turn durable (the state the resume repairs).
-			await(() -> childParkedDurably(engine, "sub-agent", sid),
-				10_000, "child parked with its dangling toolCall durable");
-
-			engine.flush();
-			engine.close();
-			ns.close();
-		}
-
-		// ===== Stage 2: restart; refired chat + resume completes the tree =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
-
-			AVector<ACell> preResume = frames(engine, "sub-agent", sid);
-			assertEquals(2, preResume.count(), "child frame survived the crash");
-			assertEquals(Strings.create("call_subgoal"), RT.getIn(preResume.get(1), "callId"));
-
-			engine.jobs().recoverJobs();   // stabilises: fails the in-flight chat job
-
-			// The caller's chat job fails honestly — never re-executed — with the
-			// sessionId on the record so the caller knows which session to re-engage.
-			RequestContext aliceCtx = RequestContext.of(ALICE);
-			Blob chatId = Blob.fromHex(chatJobId);
-			AMap<AString, ACell> chatData = engine.jobs().getJobData(chatId, aliceCtx);
-			assertEquals(Status.FAILED, RT.getIn(chatData, Fields.STATUS),
-				"in-flight chat fails at boot: " + chatData);
-			String err = String.valueOf(RT.getIn(chatData, Fields.ERROR));
-			assertTrue(err.contains("re-send"), "error tells the caller to re-send: " + err);
-			assertTrue(err.contains(sid.toHexString()), "error names the session: " + err);
-
-			// The agent's own interrupted work resumes from durable state alone.
-			AgentAdapter aa = (AgentAdapter) engine.getAdapter("agent");
-			assertEquals(1, aa.wakeAgentsWithWork(), "boot scan wakes the interrupted agent");
-
-			AgentState ag = agent(engine, "sub-agent");
-			try {
-				await(() -> ag.getSessionCycleEpoch(sid) == null
-						&& countTurnsContaining(rootConversation(engine, "sub-agent", sid), "root done") > 0,
-					30_000, "resumed cycle completes the tree and releases the claim");
-			} catch (AssertionError e) {
-				// Self-diagnosing: dump the durable state AND all thread stacks
-				// (incl. virtual threads) so a stall names its cause.
-				String dumpPath = System.getProperty("java.io.tmpdir")
-					+ "/goaltree-stall-" + System.currentTimeMillis() + ".txt";
-				try {
-					long pid = ProcessHandle.current().pid();
-					new ProcessBuilder("jcmd", Long.toString(pid),
-						"Thread.dump_to_file", "-format=plain", dumpPath)
-						.inheritIO().start().waitFor();
-				} catch (Exception ignored) {}
-				fail("resume stalled — epoch=" + ag.getSessionCycleEpoch(sid)
-					+ " status=" + ag.getStatus()
-					+ " threadDump=" + dumpPath
-					+ " frames=" + frames(engine, "sub-agent", sid), e);
-			}
-
-			AVector<ACell> fs = frames(engine, "sub-agent", sid);
-			assertEquals(1, fs.count(), "child popped — end state is root-only");
-			AVector<ACell> conv = rootConversation(engine, "sub-agent", sid);
-			assertEquals(1, countTurnsContaining(conv, "sub done"),
-				"exactly one popped subgoal result (deduped by callId): " + conv);
-			assertEquals(1, countTurnsContaining(conv, "decompose the work"),
-				"chat-refire dedupe: no duplicate user turn: " + conv);
-
-			engine.close();
-			ns.close();
-		}
-	}
-
-	/**
-	 * A chat sent WITHOUT a sessionId (the first-contact case: the venue mints
-	 * one), crashed mid-cycle. Recovery must leave exactly one session — the
-	 * minted one — and fail the caller's job with that sessionId on the record
-	 * (the stamp is how a caller re-engages the conversation their failed chat
-	 * started). The boot scan alone resumes the interrupted cycle; nothing
-	 * re-executes intake, so no duplicate session can ever be minted (#214).
-	 */
-	@Test
-	public void testCrashResumeMintedSessionNotDuplicated() throws Exception {
-		EtchStore store = EtchStore.createTemp();
-		AKeyPair kp = AKeyPair.generate();
-		String did = "did:key:" + Multikey.encodePublicKey(kp.getAccountKey());
-		AMap<AString, ACell> config = Maps.of(Config.DID, did,
-			Config.USERS, Maps.of(Config.AUTO_CREATE, true));
-		String chatJobId;
-		String sidHex;
-
-		// ===== Stage 1: chat with NO sessionId, crash mid-tool =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
-
-			createGoalAgent(engine, "mint-agent", "v/test/ops/nevertoolllm");
-
-			Job chatJob = engine.jobs().invokeOperation(
-				"v/ops/agent/chat",
-				Maps.of(Fields.AGENT_ID, "mint-agent",
-					Fields.MESSAGE, Strings.create("start the slow job")),   // no sessionId
-				RequestContext.of(ALICE));
-			chatJobId = chatJob.getID().toHexString();
-
-			// The venue minted a session — discover it and wait until parked.
-			await(() -> agent(engine, "mint-agent").getSessions().count() == 1, 5000, "session minted");
-			sidHex = agent(engine, "mint-agent").getSessions().entrySet().iterator().next().getKey().toHexString();
-			Blob sid = Blob.fromHex(sidHex);
-			await(() -> {
-				AVector<ACell> conv = rootConversation(engine, "mint-agent", sid);
-				ACell turn = (conv != null && conv.count() > 0) ? conv.get(conv.count() - 1) : null;
-				return turn != null && RT.getIn(turn, "toolCalls") != null;
-			}, 5000, "parked in the tool");
-
-			engine.flush();
-			engine.close();
-			ns.close();
-		}
-
-		// ===== Stage 2: recover; exactly one session, caller gets ITS answer =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
-
-			engine.jobs().recoverJobs();
-
-			// The caller's job fails honestly, carrying the MINTED sessionId —
-			// the caller's route back into the conversation their chat started.
-			Blob sid = Blob.fromHex(sidHex);
-			Blob chatId = Blob.fromHex(chatJobId);
-			RequestContext aliceCtx = RequestContext.of(ALICE);
-			AMap<AString, ACell> chatData = engine.jobs().getJobData(chatId, aliceCtx);
-			assertEquals(Status.FAILED, RT.getIn(chatData, Fields.STATUS),
-				"in-flight chat fails at boot: " + chatData);
-			assertTrue(String.valueOf(RT.getIn(chatData, Fields.ERROR)).contains(sidHex),
-				"the failed job names the minted session: " + chatData);
-
-			// Boot scan resumes the interrupted cycle from durable state.
-			AgentAdapter aa = (AgentAdapter) engine.getAdapter("agent");
-			assertEquals(1, aa.wakeAgentsWithWork(), "boot scan wakes the interrupted agent");
-			await(() -> agent(engine, "mint-agent").getSessionCycleEpoch(sid) == null,
-				30_000, "resumed cycle completed");
-
-			// The one session the chat minted is the only one — no spurious dup.
-			assertEquals(1, agent(engine, "mint-agent").getSessions().count(),
-				"recovery must not mint a second session");
-
-			// The resumed cycle finished the conversation in that session.
-			AVector<ACell> conv = rootConversation(engine, "mint-agent", sid);
-			assertEquals(1, countTurnsContaining(conv, "did not return"),
-				"exactly one synthetic error turn");
-
-			engine.close();
-			ns.close();
-		}
-	}
-
-	/**
-	 * An in-flight {@code agent:request} whose task is still queued at the
-	 * crash is RESTORED at boot, not failed and not re-executed (#214): the
-	 * task index is the durable work marker (taskId == jobID), so the job
-	 * legitimately outlives the restart — callers keep polling by ID — and the
-	 * boot scan wakes the agent to run it.
-	 */
-	@Test
-	public void testCrashRequestJobRestoredWhileTaskQueued() throws Exception {
-		EtchStore store = EtchStore.createTemp();
-		AKeyPair kp = AKeyPair.generate();
-		String did = "did:key:" + Multikey.encodePublicKey(kp.getAccountKey());
-		AMap<AString, ACell> config = Maps.of(Config.DID, did,
-			Config.USERS, Maps.of(Config.AUTO_CREATE, true));
-		Blob sid = Blob.fromHex("cc112233445566778899aabbccddee03");
-		String requestJobId;
-
-		// ===== Stage 1: request parked mid-cycle (task not yet merged out) =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
-
-			createGoalAgent(engine, "task-agent", "v/test/ops/nevertoolllm");
-			agent(engine, "task-agent").ensureSession(sid, ALICE);
-
-			Job requestJob = engine.jobs().invokeOperation(
-				"v/ops/agent/request",
-				Maps.of(Fields.AGENT_ID, "task-agent",
-					Fields.SESSION_ID, Strings.create(sid.toHexString()),
-					Fields.INPUT, Strings.create("please use the slow tool")),
-				RequestContext.of(ALICE));
-			requestJobId = requestJob.getID().toHexString();
-
-			// nevertoolllm parks at the ROOT (no subgoal child): await the
-			// dangling assistant toolCall turn itself, not just any frame state.
-			await(() -> {
-				AVector<ACell> conv = rootConversation(engine, "task-agent", sid);
-				return conv != null && conv.count() >= 2
-					&& countTurnsContaining(conv, "toolCalls") > 0;
-			}, 10_000, "root parked with its dangling toolCall durable");
-			assertNotNull(agent(engine, "task-agent").getTasks().get(requestJob.getID()),
-				"task still queued while the cycle runs");
-
-			engine.flush();
-			engine.close();
-			ns.close();
-		}
-
-		// ===== Stage 2: restored live, still STARTED, task queued, agent woken =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
-
-			engine.jobs().recoverJobs();
-
-			Blob reqId = Blob.fromHex(requestJobId);
-			Job restored = engine.jobs().getJob(reqId);
-			assertNotNull(restored, "in-flight task job is restored live, never failed");
-			assertEquals(Status.STARTED, restored.getStatus(),
-				"restored task job stays STARTED — caller keeps awaiting by ID");
-			assertNotNull(agent(engine, "task-agent").getTasks().get(reqId),
-				"the durable task marker survived");
-
-			AgentAdapter aa = (AgentAdapter) engine.getAdapter("agent");
-			assertEquals(1, aa.wakeAgentsWithWork(),
-				"boot scan wakes the agent to run its queued task");
-
-			engine.close();
-			ns.close();
-		}
-	}
-
-	/**
-	 * The converse: an in-flight {@code agent:request} whose task is GONE at
-	 * boot (venue crashed in the window between the merge removing the task
-	 * and the job completion write) fails honestly, pointing the caller at the
-	 * agent's timeline — there is no durable work left to drive completion,
-	 * and recovery never re-executes.
-	 */
-	@Test
-	public void testCrashRequestJobTaskGoneFailsAtBoot() throws Exception {
-		EtchStore store = EtchStore.createTemp();
-		AKeyPair kp = AKeyPair.generate();
-		String did = "did:key:" + Multikey.encodePublicKey(kp.getAccountKey());
-		AMap<AString, ACell> config = Maps.of(Config.DID, did,
-			Config.USERS, Maps.of(Config.AUTO_CREATE, true));
-		Blob sid = Blob.fromHex("cc112233445566778899aabbccddee04");
-		String requestJobId;
-
-		// ===== Stage 1: as above — parked mid-cycle, then crash =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
-
-			createGoalAgent(engine, "gone-agent", "v/test/ops/nevertoolllm");
-			agent(engine, "gone-agent").ensureSession(sid, ALICE);
-
-			Job requestJob = engine.jobs().invokeOperation(
-				"v/ops/agent/request",
-				Maps.of(Fields.AGENT_ID, "gone-agent",
-					Fields.SESSION_ID, Strings.create(sid.toHexString()),
-					Fields.INPUT, Strings.create("please use the slow tool")),
-				RequestContext.of(ALICE));
-			requestJobId = requestJob.getID().toHexString();
-
-			await(() -> {
-				AVector<ACell> conv = rootConversation(engine, "gone-agent", sid);
-				return conv != null && conv.count() >= 2
-					&& countTurnsContaining(conv, "toolCalls") > 0;
-			}, 10_000, "root parked with its dangling toolCall durable");
-
-			engine.flush();
-			engine.close();
-			ns.close();
-		}
-
-		// ===== Stage 2: simulate the merge→completion crash window, recover =====
-		{
-			NodeServer<Index<Keyword, ACell>> ns = new NodeServer<>(Covia.ROOT, store, NodeConfig.port(-1));
-			ns.launch();
-			Engine engine = new Engine(config, ns.getCursor(), kp).start();
-			Engine.addDemoAssets(engine);
-
-			// The merge removed the task but the job completion never landed.
-			Blob reqId = Blob.fromHex(requestJobId);
-			agent(engine, "gone-agent").removeTask(reqId);
-
-			engine.jobs().recoverJobs();
-
-			AMap<AString, ACell> data = engine.jobs().getJobData(reqId, RequestContext.of(ALICE));
-			assertEquals(Status.FAILED, RT.getIn(data, Fields.STATUS),
-				"task-gone request job fails at boot: " + data);
-			assertTrue(String.valueOf(RT.getIn(data, Fields.ERROR)).contains("task concluded"),
-				"error points the caller at the agent's result: " + data);
-
-			engine.close();
-			ns.close();
+			node[0].close();
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- persist RUNNING for remote observability while treating the live launcher slot as authoritative for liveness and exclusion
- keep JobManager recovery generic; reconcile agent-owned intake and stale cycle fences inside AgentAdapter
- stop resuming interrupted GoalTree execution and settle dangling external interactions only on a later fresh attempt
- preserve jobless lattice tasks while failing/removing intake tied to interrupted Jobs
- remove crash-resume special cases and update lifecycle documentation

## Verification
- focused agent lifecycle/durability suite: 290 tests passing
- full default reactor suite: 78 core + 2,052 venue tests passing
- git diff --check

Fixes #332