### PR TITLE
Convex 0.8.11, native non-expiring UCANs, venue identity Phase A

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ covia/                          # ai.covia:covia (parent POM)
 
 - **Java 21+** (JDK; the published Docker image runs on Java 25)
 - **Maven 3.7+** (enforced by maven-enforcer-plugin)
-- **Convex 0.8.10** — pinned to the Maven Central release. A clean clone builds in one command (`mvn clean install`); no local Convex build is needed. To track an unreleased Convex, build it locally (`mvn install -DskipTests` from `../convex`) and point `convex.version` at its `-SNAPSHOT`; CI compiles Convex from source automatically whenever `convex.version` ends in `-SNAPSHOT`.
+- **Convex 0.8.11** — pinned to the Maven Central release. A clean clone builds in one command (`mvn clean install`); no local Convex build is needed. To track an unreleased Convex, build it locally (`mvn install -DskipTests` from `../convex`) and point `convex.version` at its `-SNAPSHOT`; CI compiles Convex from source automatically whenever `convex.version` ends in `-SNAPSHOT`.
 
 ## Build & Run
 
@@ -90,7 +90,7 @@ mvn test -pl covia-core
 
 | Dependency | Version | Purpose |
 |------------|---------|---------|
-| Convex | 0.8.10 | Lattice platform, immutable data, cryptography |
+| Convex | 0.8.11 | Lattice platform, immutable data, cryptography |
 | Javalin | 7.2.2 | HTTP server with OpenAPI/Swagger/ReDoc |
 | LangChain4j | 1.18.1 | LLM orchestration (OpenAI, Ollama, Gemini, DeepSeek) |
 | MCP SDK | 2.0.0 | Model Context Protocol |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ Defined in code at `venue/src/main/java/covia/lattice/Covia.java`. Full design i
 - **SSE** — Server-sent events for real-time job updates (`/api/v1/jobs/{id}/sse`)
 - **MCP** — Model Context Protocol JSON-RPC endpoint
 - **A2A** — Agent-to-Agent federated protocol
-- **DID** — Decentralized identifiers for venue discovery (`/.well-known/did.json`). Identity is always the venue's `did:key`; a venue with a public `hostname` also publishes a spec-compliant `did:web:<hostname>` alias (`id` = did:web, canonical did:key in `alsoKnownAs`) so strict resolvers work — did:web is discovery, the did:key is identity (#167)
+- **DID** — Decentralized identifiers for venue discovery (`/.well-known/did.json`). A venue with a public `hostname` presents `did:web:<hostname>` as its identity (`id` = did:web, the did:key in `alsoKnownAs` as an informational cross-reference — never a canonical identity to re-bind to); without one, the did:key is the identity. Consumers respect the presented identity as-is (#167, #343). Internally, durable state still roots in the did:key pending the operator-declared identity flip (#343 Phase B)
 
 ## Development Conventions
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,7 @@ This document describes how to build the Covia project using Maven.
 - **Maven 3.7+**: Minimum Maven version required (enforced by maven-enforcer-plugin)
 - **Git**: For cloning the repository
 
-All dependencies resolve from Maven Central, including [Convex](https://github.com/Convex-Dev/convex) (`0.8.10`) — the lattice layers the venue state model is built on. A clean clone builds with no extra steps (`mvn clean install`). To track an unreleased Convex, build it from source (`mvn install -DskipTests` in a `develop` checkout of the Convex repo) and point `convex.version` at its `-SNAPSHOT`; CI compiles Convex from source automatically whenever `convex.version` ends in `-SNAPSHOT`, and the step skips itself for a released pin.
+All dependencies resolve from Maven Central, including [Convex](https://github.com/Convex-Dev/convex) (`0.8.11`) — the lattice layers the venue state model is built on. A clean clone builds with no extra steps (`mvn clean install`). To track an unreleased Convex, build it from source (`mvn install -DskipTests` in a `develop` checkout of the Convex repo) and point `convex.version` at its `-SNAPSHOT`; CI compiles Convex from source automatically whenever `convex.version` ends in `-SNAPSHOT`, and the step skips itself for a released pin.
 
 ## Project Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - Venue admission documented and exposed (#318)
 - Venue authentication design agreed (`venue/docs/AUTH.md`, #297)
 - Etch store policy pass-through (`etch` config block): venues can run on
-  encrypted Etch v3 stores, with fail-closed key sourcing (env/file/hex)
+  encrypted Etch v3 stores, with fail-closed key sourcing (env/file/hex),
+  auto-stamped and verified key-identity hints, and an embedder-supplied
+  key function for caller-opened vault stores
 
 ### Changed
 - Updated Convex to 0.8.11: `ucan:issue` mints genuinely non-expiring tokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - DLFS roots scoped to subpaths (#326)
 - Venue admission documented and exposed (#318)
 - Venue authentication design agreed (`venue/docs/AUTH.md`, #297)
+- Etch store policy pass-through (`etch` config block): venues can run on
+  encrypted Etch v3 stores, with fail-closed key sourcing (env/file/hex)
 
 ### Changed
 - Updated Convex to 0.8.11: `ucan:issue` mints genuinely non-expiring tokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,37 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - Operator-declared venue identity: the `did` config key is validated
   fail-closed (did:web must match the public hostname; did:key pins the venue
   key pair), and did:web principals verify at every ingress seam (#343)
-- Native DLFS move/copy on the `file:` surface via Convex 0.8.11 (#321)
+- `file:move` / `file:copy` with provider-native dispatch — fully native on
+  DLFS-backed roots with Convex 0.8.11 (#321)
+- Outbound A2A agents modelled as assets (#340)
+- Result-oriented run execution (#316)
+- Agent session titles
+- DLFS roots scoped to subpaths (#326)
+- Venue admission documented and exposed (#318)
+- Venue authentication design agreed (`venue/docs/AUTH.md`, #297)
 
 ### Changed
 - Updated Convex to 0.8.11: `ucan:issue` mints genuinely non-expiring tokens
   (explicit `exp: null`) in the Convex UCAN JWT profile, replacing the 99-year
   workaround (#322)
+- HITL grant expiry policy configurable (#314)
+- Agent creation exclusive (#329)
+- Structured admission errors (#327)
 - Updated JUnit to 6.1.3 and the A2A Java SDK to 1.2.0.Final; A2A streaming
   responses use the SDK's declared union serializer and omitted cancel metadata
   is normalised to the SDK's empty-map default
+
+### Fixed
+- Standard bearer auth for outbound A2A (#339)
+- A2A long-turn reattachment (#338)
+- Typed and nested collection tool results preserved in agent loops (#334)
+- Unavailable configured agent tools surfaced (#317)
+- Forbidden returned for denied CORS origins (#320)
+- MCP connection failures made actionable
+- Orchestrator strict schemas resolved at the target venue
+- Agent session title updates hardened
+- Asset content semantics and bound agent shutdown (#331, #333)
+- Agent execution durability boundary clarified (#332)
 
 ## [0.8.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+- Operator-declared venue identity: the `did` config key is validated
+  fail-closed (did:web must match the public hostname; did:key pins the venue
+  key pair), and did:web principals verify at every ingress seam (#343)
+- Native DLFS move/copy on the `file:` surface via Convex 0.8.11 (#321)
+
 ### Changed
+- Updated Convex to 0.8.11: `ucan:issue` mints genuinely non-expiring tokens
+  (explicit `exp: null`) in the Convex UCAN JWT profile, replacing the 99-year
+  workaround (#322)
 - Updated JUnit to 6.1.3 and the A2A Java SDK to 1.2.0.Final; A2A streaming
   responses use the SDK's declared union serializer and omitted cancel metadata
   is normalised to the SDK's empty-map default

--- a/DX_PLAN.md
+++ b/DX_PLAN.md
@@ -38,7 +38,7 @@ An honest snapshot, so newcomers know what to expect and contributors know where
 | README / first impression | ✅ Done | Rewritten for developers: quickstart, badges, architecture, SDK examples |
 | Onboarding / quickstart (docs) | ✅ Done | README quickstart and the docs "Getting Started" page both go zero-to-first-operation |
 | Published artifacts up to date | ✅ Done | Platform `0.6.0` on GitHub, GHCR, and Maven Central; TS SDK 1.7.3 on npm; Python SDK 0.6.0 on PyPI |
-| Build reproducibility | ✅ Done | Depends on released Convex 0.8.10 from Maven Central; a clean clone builds in one command |
+| Build reproducibility | ✅ Done | Depends on released Convex 0.8.11 from Maven Central; a clean clone builds in one command |
 | CI quality gate | ✅ Done | `test.yml` runs the full reactor (with tests) on every PR and push to `develop`/`master`; its first run caught three latent flaky tests |
 | Client/auth test coverage | 🔨 In progress | `VenueHTTP` has contract tests against a real venue; dedicated auth-strategy tests remain |
 | Community scaffolding | 🔨 In progress | `CONTRIBUTING`, `SECURITY`, `CHANGELOG`, and issue/PR templates in place; a governance note remains |
@@ -68,7 +68,7 @@ _Goal: every clone builds reproducibly, every PR is validated automatically, and
 
 - [x] **Add a CI quality gate.** `.github/workflows/test.yml` runs `mvn clean install` (full reactor, with tests) on every pull request and on pushes to `develop`/`master`. Running and green; its first run surfaced three latent flaky tests (now fixed) — exactly the job it's there to do.
 - [x] **Make the gate a required check and fix the build badge.** Branch protection on `develop` and `master` now requires the `build-and-test` check for merges (admin direct pushes exempt), and the README "build" badge points at the `Test` workflow.
-- [x] **Make the build reproducible.** Covia now depends on released **Convex 0.8.10** from Maven Central — a clean clone builds with `mvn clean install`, no Convex source build. CI conditionally builds Convex from source only when `convex.version` deliberately names a snapshot. Restore a released pin before shipping. See [Convex ↔ Covia dependency](#a-note-on-the-convex-dependency).
+- [x] **Make the build reproducible.** Covia now depends on released **Convex 0.8.11** from Maven Central — a clean clone builds with `mvn clean install`, no Convex source build. CI conditionally builds Convex from source only when `convex.version` deliberately names a snapshot. Restore a released pin before shipping. See [Convex ↔ Covia dependency](#a-note-on-the-convex-dependency).
 - [x] **Add a `CHANGELOG.md`** — in Keep a Changelog format. Keep it current per release, and make the release-notes link point at it for real.
 - [x] **Coherent versioning across the product — and ship a current artifact.** The versioning story is agreed (see _Resolved_ under _Open questions_) and shipped: **platform `0.6.0`** on GitHub, GHCR, and Maven Central, TypeScript SDK **1.7.3** on npm, and Python SDK **0.6.0** on PyPI. Remaining follow-ons live under _Consolidate the SDK story_.
 - [x] **Decouple the public Docker image from deployment.** `publish-docker.yml` is the single source of `ghcr.io/covia-ai/covia` tags. It publishes the exact commit that passed the full `Test` workflow; Azure/EC2/GCP deploy only after that publish succeeds.
@@ -110,7 +110,7 @@ Related: the platform is licensed under the **Eclipse Public License 2.0** (inhe
 
 ## A note on the Convex dependency
 
-Covia is built on the [Convex](https://github.com/Convex-Dev/convex) lattice platform and tends to track its latest capabilities. Covia depends on **released Convex artifacts from Maven Central** (currently 0.8.10), so a clean clone always builds. When development genuinely needs an unreleased Convex capability, the coupling is deliberate and temporary: build Convex from source, point `convex.version` at its snapshot locally, and restore the release pin (bumping to the next Convex release) before the work merges.
+Covia is built on the [Convex](https://github.com/Convex-Dev/convex) lattice platform and tends to track its latest capabilities. Covia depends on **released Convex artifacts from Maven Central** (currently 0.8.11), so a clean clone always builds. When development genuinely needs an unreleased Convex capability, the coupling is deliberate and temporary: build Convex from source, point `convex.version` at its snapshot locally, and restore the release pin (bumping to the next Convex release) before the work merges.
 
 ---
 

--- a/covia-core/src/main/java/covia/grid/auth/VenueDID.java
+++ b/covia-core/src/main/java/covia/grid/auth/VenueDID.java
@@ -19,9 +19,11 @@ import convex.core.util.JSON;
  * self-issued tokens ({@link VenueAuth#keyPair(convex.core.crypto.AKeyPair, String)})
  * without hand-rolling discovery.
  *
- * <p>The returned DID is the document's {@code id} — the did:web alias when the
- * venue has a public hostname, else its canonical did:key. Venues accept tokens
- * audienced to either form.</p>
+ * <p>The returned DID is the document's {@code id} — the identity the venue
+ * presents: did:web when it has a public hostname, else its did:key. Consumers
+ * use it as-is (store, pin, audience-bind) — {@code alsoKnownAs} entries are
+ * informational cross-references, never a canonical identity to re-bind to
+ * (covia#343). Venues accept tokens audienced to either published form.</p>
  *
  * <p>Results are cached <b>on success only</b> (a venue's DID is stable for its
  * lifetime); failures are never cached, so a venue that was briefly unreachable

--- a/covia-core/src/main/java/covia/grid/hitl/Hitl.java
+++ b/covia-core/src/main/java/covia/grid/hitl/Hitl.java
@@ -79,7 +79,7 @@ public class Hitl {
 	public static final AString CAN  = Strings.intern("can");
 	public static final AString EXP  = Strings.intern("exp");
 
-	// ===== Token-ask (COG-18) — self-sovereign cross-venue token transport =====
+	// ===== Token-ask (COG-19) — self-sovereign cross-venue token transport =====
 	/** Token-ask request spec: requested capabilities, {@code [{with, can}]}. */
 	public static final AString CAPS     = Strings.intern("caps");
 	/** Token-ask request spec: intended audience DID of the signed token
@@ -105,7 +105,7 @@ public class Hitl {
 	public static final AString APPROVAL   = Strings.intern("approval");
 	public static final AString CHOICE     = Strings.intern("choice");
 	public static final AString CHECKBOXES = Strings.intern("checkboxes");
-	/** COG-18: a request for a self-sovereign access token. The human signs a
+	/** COG-19: a request for a self-sovereign access token. The human signs a
 	 *  UCAN with their own key client-side; the answer is that signed JWT, which
 	 *  the venue verifies and TRANSPORTS (never mints). Its request spec lives
 	 *  under the ask's {@code token} field ({@link #TOKEN}). */

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<maven.compiler.release>21</maven.compiler.release>
 		<maven.compiler.source>21</maven.compiler.source>
 		<junit.version>6.1.3</junit.version>
-		<convex.version>0.8.10</convex.version>
+		<convex.version>0.8.11</convex.version>
 		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		

--- a/venue/CLAUDE.md
+++ b/venue/CLAUDE.md
@@ -255,6 +255,7 @@ java -jar target/covia.jar [config.json]
 
 ## Related Documentation
 
+- `docs/AUTH.md` — authentication design (#297): method contract, central sessions, assurance policy
 - `docs/CONFIG.md` — operator configuration reference
 - `docs/JOBS.md` — job implementation semantics (COG-8 companion)
 - `docs/UCAN.md` — capabilities, granting surface, proof channels

--- a/venue/docs/AUTH.md
+++ b/venue/docs/AUTH.md
@@ -180,25 +180,31 @@ not the method.
 
 ### 5.1 Finishing #296 (self-sovereign named users)
 
-The core is implemented (§2). The remaining delta:
+The core is implemented and the acceptance-test sweep is in place
+(`NamedUserAuthTest`, `UserAPITest`, `AudienceBoundAuthTest`): multiple
+keys, rotation with immediate revocation, tombstone audit, last-key
+guard, wrong key/subject/issuer/audience and foreign-`did:web`
+rejections, temporal negatives, DID-document publication. #296 is
+closed.
 
-1. **covia#323** — the `did:key` branch of `tryVerifySelfIssued` never
-   reads `iss`, so a present-but-mismatched `iss` verifies (RFC 8725
-   §3.8 non-conformant). Reject `iss` present-and-≠-`sub` in both
-   branches; keep `iss` optional for `did:key` subjects.
-2. **Acceptance-test sweep** per the #296 criteria: multiple keys,
-   rotation, revoked-key rejection (stale key after removal), foreign
-   `did:web` rejection, `kid` belonging to another user, audience and
-   temporal negatives.
-3. **Enrolment authorisation** (decided): add/revoke ops require the
+Two notes:
+
+1. **Mismatched `iss` on `did:key` tokens is accepted by design**
+   (covia#323, closed): identity binds to the *signing key* — a signed
+   `sub` claim conveys no authority by itself, and a distinct named
+   subject requires an explicitly registered authentication key.
+   Enforcing `iss == sub` would conflate JWT claim semantics with
+   Covia's separate subject-admission policy. (COG-3 §5's
+   "MUST equal `sub` when present" wording is stricter than enforced
+   behaviour — a docs follow-up may reconcile them.)
+2. **Enrolment authorisation** (decided): add/revoke ops require the
    venue operator, or the user themselves meeting `policy.enrolment`
    via step-up (§9) — a live session alone is never enough to change
    the key set, since an enrolled authenticator outlives any stolen
-   credential. `user:create` continues to install keys at creation
-   under the creating authority.
-
-With those, #296 closes. Nothing in this design blocks it; the method
-registry (§6) treats it as the already-working `key` method.
+   credential. Lands with Phase 1 policy machinery; until then the
+   existing gate (the named user themselves, or a venue-rooted
+   delegation) applies. `user:create` continues to install keys at
+   creation under the creating authority.
 
 ## 6. Configuration
 
@@ -359,7 +365,7 @@ venue-auth state.
    existing verifiers and the OAuth callback through the contract and
    the central session issuer (sessions become opaque `covia_…` tokens
    backed by per-user records; outstanding venue-signed JWTs honoured
-   until expiry). Fix #323. Land the #296 test sweep and close #296.
+   until expiry), plus the enrolment step-up gate (§5.1).
 2. **Phase 2 — #298 OIDC hardening** on the new plumbing: PKCE,
    server-bound single-use `state`, OIDC `nonce`, exact redirect
    allowlist, back-channel token delivery, `(iss, sub)` binding (§7),

--- a/venue/docs/AUTH.md
+++ b/venue/docs/AUTH.md
@@ -1,0 +1,395 @@
+# Venue Authentication — Design (covia#297)
+
+Configurable authentication methods and assurance policy for named venue
+users. This is the design companion to covia#297 and its child issues
+(#296 self-sovereign keys, #298 OIDC hardening, #299 email, #300
+WebAuthn, #301 passwords). Registration/admission is separate (#269);
+authorisation (capabilities, roles) is downstream and out of scope —
+see `UCAN.md`.
+
+Status: design agreed (2026-08-10) — all open decisions resolved inline
+(marked "decided"). Phase 1 (§10) is unblocked.
+
+## 1. Principles
+
+1. **Identity invariant.** Every successful method authenticates the
+   same stable venue user DID (e.g. `did:web:venue.example:u:sabine`).
+   A login method is an *authenticator bound to that subject*, never the
+   subject itself. Email, password, passkey and provider changes must
+   not change the user DID.
+2. **Authentication proves an authenticator; it grants nothing.**
+   Roles, capabilities and admission remain separate decisions.
+3. **Secure defaults.** No method is implicitly enabled by the presence
+   of unrelated credentials; configuration validation fails closed.
+4. **One verification seam.** All credential classes verify through
+   `VenueAuthenticator` — embedders and transports never reproduce
+   signature/audience/temporal rules. Policy checks are single
+   Engine-owned methods at the seam, not scattered call-sites.
+5. **Self-sovereign parity.** A named venue user with a registered key
+   is as self-sovereign as a `did:key` user: the venue holds only
+   public keys and can neither sign for the user nor lose their key.
+
+## 2. Baseline (what exists on develop)
+
+The implementation is further along than #297/#296 suggest:
+
+| Piece | Where | State |
+|-------|-------|-------|
+| Single verification seam | `VenueAuthenticator.verify` | Four credential classes: UCAN bearer, self-issued EdDSA, venue-signed session JWT, external provider RS256 |
+| Named-user key registry (#296) | `Auth.addAuthenticationKey(s)` / `revokeAuthenticationKey` | Active/revoked tombstones, one-subject-per-key, no silent reactivation, last-active-key guard (`allowLast` for venue recovery) |
+| Named-user self-issued login (#296) | `VenueAuthenticator.tryVerifySelfIssued` | `sub` = local `did:web:…:u:<id>`, requires `iss == sub`, record DID match, **active** registered key, audience + temporal bounds |
+| DID document publication (#296) | `UserAPI.getUserDIDDocument` | Active user-held keys published under `verificationMethod` + `authentication`, controller = user DID |
+| Key enrolment surface (#296) | `UserAdapter` (`user:create` keys, add/revoke ops), `Engine` creation path | Venue-authorised, audited (`addedBy`/`revokedBy`) |
+| Session minting | `LoginProviders` OAuth callback | Inline `JWT.signPublic` — no session id, no revocation, no amr/auth_time |
+| Audience policy | `Auth` config + `requireAudience` | `verify`/`require`, `acceptedAudiences`, did:web alias |
+| Public ceiling | `auth.public.*` (COG-10) | Unchanged by this design |
+
+**Gaps this design closes:** per-method enable/disable and policy
+config; a common method result (method reference, `amr`, assurance,
+`auth_time`); a central session issuer with revocation; provider
+identity keyed by `(issuer, subject)` instead of email; account-linking
+rules; route-class assurance enforcement.
+
+## 3. The method contract
+
+Every authentication method produces one `AuthResult`:
+
+| Field | Meaning |
+|-------|---------|
+| `userDID` | Stable venue user DID — the identity that acts |
+| `authenticatedIdentity` | Identity directly proven by the credential (key `did:key`, provider `(iss,sub)`, session subject) |
+| `method` | Stable method id (see §5) |
+| `amr` | RFC 8176 authentication-method references (`pop`, `pwd`, `otp`, `hwk`, `mfa`, …) |
+| `assurance` | Venue assurance level derived from `amr` + method (§6) |
+| `authTime` | When the human/key actually authenticated (Unix s) |
+| `provider` | Optional issuer/subject metadata — audit only, never authority |
+
+Two event shapes share the contract:
+
+- **Interactive login** (OIDC, email, WebAuthn, password) — produces an
+  `AuthResult` once, then a **session** carries it (§4).
+- **Per-request credential** (self-issued key JWT, UCAN bearer) —
+  stateless; every request re-proves possession. `authTime` = token
+  `iat`; no session exists or is needed.
+
+`VenueAuthenticator.VerifiedPrincipal` grows into this record; the
+existing two-identity model (`authenticatedIdentity` vs `venueUserDID`)
+is already the right split and is retained.
+
+**Embedders plug in at the same contract.** The method set is a
+registry, not a closed enum: an embedder may register additional
+methods implementing the same interface — each produces an
+`AuthResult`, appears under its own id in `auth.methods` (registered
+before config validation, so fail-closed checks accept it), and is
+subject to the same policy machinery, session issuance, and step-up
+rules as the built-ins. The existing `bindIdentity` attribution seam
+remains for fully embedder-owned authentication that maps to a venue
+user outside the registry.
+
+## 4. Central session service
+
+One issuer mints every venue session; methods never mint credentials
+themselves (`LoginProviders` currently signs JWTs inline — it re-routes
+here).
+
+**Sessions are opaque venue-issued credentials, not JWTs** (decided).
+The venue's own state is the source of truth, so a signed,
+claims-bearing token would add parsing surface and a readable payload
+for no benefit — signature verification is redundant once verification
+requires a record. Opaque server-side session ids are the standard
+pattern (RFC 6750 does not require JWT bearers; this is the
+reference-token model of RFC 7662).
+
+- **Token**: `covia_<base64url(128-bit random)>`. The prefix makes
+  leaked tokens secret-scannable; the body is the raw session key. The
+  token carries no information at all — no user, no claims, no
+  structure beyond the prefix.
+- **Lookup**: a venue-owned lattice `Index` keyed by the 128-bit Blob →
+  `{userId, sid}`. Convex `Index` handles Blob keys natively — no
+  hashing layer. (If leaked-backup hardening is ever wanted, keying the
+  index by a hash of the token is a server-side-only change; the token
+  format does not move.)
+- **Session records are per-user** (decided): a `sessions` map on the
+  venue-owned auth user record, `sid → {status, iat, exp, auth_time,
+  method, amr, acr, revokedAt?, revokedBy?}`, tombstone-style like the
+  key registry. `sid` is a short random display/audit identifier —
+  never the token — so session listings and logs never contain
+  credentials. Managed under the venue's update policy; never writable
+  through the user's own namespace.
+- **Verification**: decode token → Index lookup → the user's
+  `sessions[sid]` must be `active` and unexpired. A dangling index
+  entry (record gone or revoked) fails closed.
+- **Assurance data lives in the record** — `amr`, `acr`, `auth_time`,
+  `method` are read by the policy seam (§9). Clients get their login
+  metadata from the login response, not by decoding the token.
+- **Revocation**: flip the record — one session, or all of a user's by
+  iterating their own map. Account-level kill remains the admission
+  layer (a disabled user fails admission on every request, whatever
+  they hold). Sessions no longer depend on the venue key, so key
+  rotation does not collaterally log everyone out; clearing session
+  state is the global lever, and a targeted one.
+- **Audience**: not applicable — an opaque token is meaningless outside
+  this venue's index, so sessions are venue-bound by construction. The
+  JWT `aud` policy applies only to the signed credential classes.
+- **Restart / GC / migration**: index and records are venue lattice
+  state — sessions survive restarts and revocations are never
+  forgotten; expired entries drop lazily on the next write; legacy
+  venue-signed JWTs are honoured until expiry (bounded by
+  `tokenExpiry`, default unchanged at 24 h), then that class retires
+  from the session role.
+
+**Delivery** (decided): one token endpoint, response-body delivery
+everywhere; session tokens never travel in URLs (#298).
+
+- `POST /api/v1/auth/login` — the single token endpoint. Accepts a
+  method credential (password, OTP, WebAuthn assertion) *or* a
+  single-use code (OIDC callback, email magic link) and returns
+  `{token, did, exp}` in the response body.
+- Redirect-based methods adapt to the endpoint via **single-use
+  codes**: the venue's OIDC callback redirects to the frontend's
+  registered `redirect_uri` with `?code=<single-use, seconds-lived>`,
+  and the frontend exchanges it at the login endpoint. A code in a URL
+  is safe the same way an OAuth authorization code is — single-use,
+  near-instant expiry, useless without the exchange. Email magic links
+  carry the same kind of code, never a session.
+- `POST /api/v1/auth/logout` — revokes the presented session's record.
+- Stateless credentials (`key`, `ucan`) never touch the login surface:
+  per-request `Authorization` headers, no session minted.
+- Cookies are embedder/BFF territory: an embedder owning the frontend
+  origin may exchange the code server-side and set its own `HttpOnly`
+  cookie. The venue primitive stays origin-agnostic.
+
+## 5. Methods
+
+| `method` id | Credential | User mapping | amr | Session? | Issue |
+|-------------|-----------|--------------|-----|----------|-------|
+| `key` | Self-issued EdDSA JWT | `did:key` direct; named user via active registered key | `pop` | No — stateless | #296 |
+| `ucan` | UCAN bearer (aud = venue) | Issuer DID | `pop` | No — stateless | — |
+| `session` | Opaque venue token (`covia_…`) | Index → per-user record | inherited | Is the session | — |
+| `oidc` | Authorization Code + PKCE | `(issuer, subject)` binding (§7) | provider-dependent (`mfa` iff proven) | Yes | #298 |
+| `email` | Magic link / OTP | Verified address on the user record | `otp` | Yes | #299 |
+| `webauthn` | Passkey assertion | Registered credential id | `hwk`,`user` (UV) | Yes | #300 |
+| `password` | Password (+ recovery) | Stored verifier | `pwd` | Yes | #301 |
+
+Named-user and `did:key` self-issued login share the `key` method
+deliberately: same credential class, same proof (`pop`), same
+verification path — a named user with a registered key is exactly as
+self-sovereign as a bare `did:key` (§1.5). Policy that must distinguish
+"venue-managed subject" from "raw did:key" keys off the *subject form*,
+not the method.
+
+### 5.1 Finishing #296 (self-sovereign named users)
+
+The core is implemented (§2). The remaining delta:
+
+1. **covia#323** — the `did:key` branch of `tryVerifySelfIssued` never
+   reads `iss`, so a present-but-mismatched `iss` verifies (RFC 8725
+   §3.8 non-conformant). Reject `iss` present-and-≠-`sub` in both
+   branches; keep `iss` optional for `did:key` subjects.
+2. **Acceptance-test sweep** per the #296 criteria: multiple keys,
+   rotation, revoked-key rejection (stale key after removal), foreign
+   `did:web` rejection, `kid` belonging to another user, audience and
+   temporal negatives.
+3. **Enrolment authorisation** (decided): add/revoke ops require the
+   venue operator, or the user themselves meeting `policy.enrolment`
+   via step-up (§9) — a live session alone is never enough to change
+   the key set, since an enrolled authenticator outlives any stolen
+   credential. `user:create` continues to install keys at creation
+   under the creating authority.
+
+With those, #296 closes. Nothing in this design blocks it; the method
+registry (§6) treats it as the already-working `key` method.
+
+## 6. Configuration
+
+Extends the existing `auth` block (`public`, `tokenExpiry`, `audience`,
+`acceptedAudiences` unchanged). New `methods` and `policy` sections:
+
+```json
+"auth": {
+  "methods": {
+    "key":      { "enabled": true },
+    "ucan":     { "enabled": true },
+    "oidc":     { "enabled": false,
+                  "providers": { "google": { "clientId": "…", "clientSecret": "s/google-oauth" } } },
+    "email":    { "enabled": false, "modes": ["magic-link", "otp"] },
+    "webauthn": { "enabled": false, "rpId": "venue.example" },
+    "password": { "enabled": false }
+  },
+  "policy": {
+    "default":   { "allowed": ["key", "ucan", "session", "oidc"] },
+    "enrolment": { "minimumAssurance": "strong", "maxAuthenticationAgeSeconds": 900 },
+    "admin":     { "allowed": ["key", "webauthn"], "minimumAssurance": "strong",
+                   "maxAuthenticationAgeSeconds": 900 }
+  }
+}
+```
+
+Rules:
+
+- **Defaults** (no `methods` block): current behaviour — `key`, `ucan`
+  and `session` enabled; `oidc` enabled iff providers are configured
+  (`auth.oauth` remains a deprecated alias for `methods.oidc.providers`
+  for one release). `email`/`webauthn`/`password` default off.
+- **Disabled = absent**: routes not registered, credentials of that
+  class rejected at the seam, regardless of stored state (a disabled
+  `password` verifier or OIDC binding stays on record for re-enable,
+  but authenticates nothing).
+- **Fail closed at startup**: unknown method names, malformed provider
+  blocks, non-HTTPS/unsafe redirect origins, and impossible policy
+  (a policy whose `allowed` methods cannot reach its
+  `minimumAssurance`) are configuration errors, not warnings.
+- **Secrets stay external**: provider secrets by `s/<name>` reference
+  (SecretStore), never inline in tracked config.
+- The **last viable strong authenticator** of a venue administrator
+  cannot be removed without the explicit venue recovery path
+  (`allowLast` — already enforced for keys; generalise per method).
+- **Policy names label surface classes, not user roles** (§9): `admin`
+  above means "surfaces the operator designates admin-grade", never a
+  role held by users.
+
+**Assurance ladder** (decided): three named levels, used directly as
+profile-defined `acr` values, mapping approximately to NIST 800-63B:
+
+| Level | ≈ NIST | Meaning | Methods |
+|-------|--------|---------|---------|
+| `standard` | AAL1 | Any single accepted factor | `password`, `email`, plain `oidc` |
+| `strong` | AAL2 | MFA, or phishing-resistant possession proof | `oidc` with IdP-asserted `mfa`, `key`, software passkeys |
+| `hard` | AAL3 | Hardware-backed, phishing-resistant, user-verified | `webauthn` with attestation requiring hardware + UV |
+
+- **Documented deviation from strict NIST**: a self-sovereign `key` is
+  formally single-factor, but the venue cannot observe how the key is
+  held (HSM or plaintext file — inherent to self-sovereignty), while
+  the property that distinguishes the upper tiers — phishing /
+  verifier-impersonation resistance — is exactly what a signature
+  credential has. `key` therefore rates `strong`; a strict-NIST venue
+  can gate its sensitive surfaces on `hard` instead.
+- **`hard` is initially unreachable** — no method attains it until
+  WebAuthn (#300) lands with attestation-required configuration;
+  policy naming it before then fails closed at startup (the
+  impossible-policy rule).
+- **Interop note**: the OpenID `phr`/`phrh` acr values
+  (phishing-resistant / phishing-resistant hardware) correspond to
+  `strong`/`hard` — the ladder stratifies on phishing resistance, not
+  factor count, matching ecosystem practice. Raw `amr` is stored in
+  the session record regardless, so finer-grained policy remains
+  possible later without migration.
+
+## 7. Provider identity binding (#298 prerequisite)
+
+Provider logins bind by immutable `(issuer, subject)`, held in a
+venue-owned index: `(iss, sub) → userId`, one user per pair. Email and
+display name are mutable attributes on the user record, refreshed at
+login (given `email_verified`), **never lookup keys**. Records already
+holding `provider`/`providerSub` fields bind directly.
+
+**Legacy email-only records** (decided): conditional auto-bind by
+default — a login binds a legacy record only when it comes from the
+**same provider** the record names **and** the IdP asserts
+`email_verified`; the `(issuer, subject)` pair is then stamped
+permanently. A different issuer or an unverified email requires
+operator confirmation. A cross-provider email match **never** binds —
+that is account linking (§8), requiring proof of both sides. The
+residual risk is a recycled address at the same IdP during the
+pre-stamp window; `legacyEmailBinding: "confirm"` routes everything
+through confirmation for venues on recycling-prone domains (both modes
+share the confirmation path). Note this is a strict tightening: today
+email match binds every login, cross-provider included.
+
+**Embedder policy seam**: the binding decision is pluggable. The two
+built-in modes (`auto`, `confirm`) implement a `BindingPolicy`
+interface — `(issuer, subject, email, emailVerified, candidate
+record) → BIND | CONFIRM | REJECT` — and an embedder may register its
+own (e.g. consult an HR directory before binding). Configuration
+selects the policy by name; unknown names fail closed at startup.
+
+## 8. Account linking
+
+Linking a second method to a user is its own operation, never a side
+effect:
+
+- Requires an **active session (or stateless proof) meeting
+  `policy.enrolment`** — fresh, strong — *plus* an immediate proof of
+  the method being linked (complete the OIDC flow / verify the key /
+  assert the passkey within the linking transaction).
+- Matching email alone never links (#297/#298 invariant).
+- Every linked authenticator is auditable (`addedBy`, `addedAt`,
+  method metadata) and individually revocable, mirroring the key
+  registry's tombstone model.
+
+## 9. Assurance policy enforcement
+
+One Engine-owned seam: `engine.requireAssurance(ctx, policyName)` —
+resolves the request's method/`acr`/`auth_time` (from the session
+record, or inherently for stateless credential classes) against the
+named policy. Protected venue surfaces (key enrolment, user admin,
+config-affecting operations) name their policy at the point of action,
+exactly like `requireCapability`. Embedders reuse the same call for
+application routes.
+
+**Step-up** (decided) — the standard sudo-mode pattern:
+
+- A failed check rejects with the RFC 9470 challenge —
+  `WWW-Authenticate: Bearer error="insufficient_user_authentication"`,
+  naming the required `acr_values` / `max_age` — so clients know
+  exactly what quality of re-authentication to perform.
+- Re-authentication is a re-run of login with stricter parameters
+  (OIDC: `max_age=0` / `prompt=login`, optionally `acr_values`;
+  password/WebAuthn: re-present at the login endpoint). A successful
+  re-auth **updates the existing session record's**
+  `auth_time`/`amr`/`acr`; the client then retries the original call.
+- Stateless `key`/`ucan` credentials satisfy freshness inherently —
+  every request carries a signature minted at call time, so
+  `auth_time` is effectively *now*; a key user never sees a step-up
+  prompt.
+
+**Roles are out of scope** (decided): policies name *surface classes*,
+never user roles — authentication proves an authenticator and grants
+nothing (§1). Anything role-shaped is downstream authorisation, owned
+by the application or embedder, which performs its own role check and
+then calls this same seam with its own policy name. #297's per-role
+acceptance criterion is met exactly that way: the venue enforces the
+assurance a surface demands; who counts as an admin is never
+venue-auth state.
+
+## 10. Phasing
+
+1. **Phase 1 — contract, config, no behaviour change.** `AuthResult` +
+   method registry + fail-closed config validation; re-plumb the four
+   existing verifiers and the OAuth callback through the contract and
+   the central session issuer (sessions become opaque `covia_…` tokens
+   backed by per-user records; outstanding venue-signed JWTs honoured
+   until expiry). Fix #323. Land the #296 test sweep and close #296.
+2. **Phase 2 — #298 OIDC hardening** on the new plumbing: PKCE,
+   server-bound single-use `state`, OIDC `nonce`, exact redirect
+   allowlist, back-channel token delivery, `(iss, sub)` binding (§7),
+   negative-path tests.
+3. **Phase 3 — sessions and policy**: revocation records + central
+   revocation surface; `requireAssurance` enforcement on the enrolment
+   and admin surfaces.
+4. **Phase 4 — new methods** as independent reviews: #299 email, #300
+   WebAuthn, #301 passwords (in that order of value; passwords last and
+   default-off).
+
+## 11. Security considerations
+
+- **Existence privacy**: authentication errors never disclose whether a
+  named account exists (uniform failure at the seam — already the
+  pattern in `verify`).
+- **Method downgrade**: policy `allowed` lists are enforced at the
+  seam, so an attacker cannot authenticate a high-value user via a
+  weaker enabled method than policy permits for the surface.
+- **Stateless credentials and revocation**: `key`/`ucan` proofs cannot
+  be centrally revoked mid-lifetime — they are short-lived by
+  construction (minutes), and named-user keys are revocable at the
+  registry. Session revocation covers the long-lived class.
+- **Audit**: authentication records (key registry, provider bindings,
+  session records) are venue-owned state; users cannot edit them via
+  their own namespaces.
+
+## Related
+
+- `UCAN.md` — capabilities and the proof channel (authorisation layer)
+- `CONFIG.md` — operator configuration reference (gains §6 on landing)
+- COG-3 / COG-10 — token classes, self-issued rules, public ceiling
+- covia#297 (this design), #296, #298, #299, #300, #301, #323, #269

--- a/venue/docs/CONFIG.md
+++ b/venue/docs/CONFIG.md
@@ -76,6 +76,37 @@ Venue state (lattice, agents, secrets, DLFS) is persisted via Etch store:
 - `store`: `"temp"` (default, deleted on exit), `"memory"`, or file path
 - `seed`: Ed25519 hex seed for stable venue identity. If omitted with a persistent store, auto-generated and saved to `venue.key` alongside the store file. On POSIX filesystems this raw seed is created with owner-only permissions (`0600`), and existing key-file permissions are repaired on each launch. On non-POSIX filesystems it inherits the platform ACL policy.
 
+### Etch store policy (`etch`)
+
+An optional `etch` block (Convex 0.8.11+) sets the Etch creation policy for
+the venue's store — including **encrypted Etch v3**:
+
+```json
+{
+  "store": "/data/venue.etch",
+  "etch": {
+    "version": 3,
+    "cipher": "aes-256-ctr",
+    "encryptIndex": true,
+    "key": { "env": "COVIA_ETCH_KEY" }
+  }
+}
+```
+
+- `version` / `mapping` / `buildChains` / `publicKeyHint` / `cipher`
+  (`none`, `aes-256-ctr`, `chacha20`) / `encryptIndex` pass through to
+  Convex's `EtchConfig` unchanged.
+- `key` is Covia-side: the 32-byte store encryption key as hex, sourced from
+  `{"env": "VAR"}`, `{"file": "path"}` (operator-secured file), or an inline
+  hex string (dev/test only — never commit key material).
+- The policy applies to file stores and `"temp"` stores; `"memory"` is not an
+  Etch store and rejects an `etch` block.
+- Fail-closed: an invalid field, unresolvable key, wrong-sized key, an
+  encrypted cipher without a key source, or the wrong key for an existing
+  encrypted file are all startup errors — never a silently-unencrypted or
+  empty store. The store encryption key is independent of the venue identity
+  `seed`; rotate and guard them separately.
+
 ## Venue identity
 
 Identity resolution order: `seed` → `keystore` → `venue.key` next to a

--- a/venue/docs/CONFIG.md
+++ b/venue/docs/CONFIG.md
@@ -111,6 +111,26 @@ the venue's store — including **encrypted Etch v3**:
   `seed`/`keystore` rather than relying on the auto-generated plaintext
   `venue.key` beside the store (the venue warns about that combination:
   encrypted data with the identity readable off the same disk).
+- For an encrypted **vault**, keep content in the store: with
+  `storage.content: file`, asset content bytes are written outside the
+  encrypted store as plaintext files (the venue warns). The lattice default
+  keeps everything — workspace, DLFS drives, secrets, content — inside the
+  encrypted Etch file.
+
+**Embedders** hold vault key material in their own code (KMS, passphrase
+derivation, HSM) rather than config: compile the policy with a key
+*function* and adopt a caller-opened store —
+
+```java
+EtchConfig policy = config.getEtchConfig(hint -> myKms.vaultKey());
+VenueServer server = VenueServer.launch(venueConfig,
+    EtchStore.create(vaultFile, policy));
+```
+
+No key material touches config, environment, or disk on this path; hint
+management is the embedder's concern. The key function and the config `key`
+field are mutually exclusive. A keyless encrypted policy constructs (so
+embedder configs validate) but fails closed on an operator launch.
 - The policy applies to file stores and `"temp"` stores; `"memory"` is not an
   Etch store and rejects an `etch` block.
 - Fail-closed: an invalid field, unresolvable key, wrong-sized key, an

--- a/venue/docs/CONFIG.md
+++ b/venue/docs/CONFIG.md
@@ -99,6 +99,18 @@ the venue's store — including **encrypted Etch v3**:
 - `key` is Covia-side: the 32-byte store encryption key as hex, sourced from
   `{"env": "VAR"}`, `{"file": "path"}` (operator-secured file), or an inline
   hex string (dev/test only — never commit key material).
+- **Key identity** (consistent with venue key management): the master key is
+  treated as an Ed25519 seed and identified by its derived public key — the
+  same identifier scheme as venue identity keys and keystore aliases. New
+  files stamp that identity as the Etch v3 `publicKeyHint` automatically
+  (set `publicKeyHint` explicitly to pin your own label), and opening
+  verifies the file's hint against the configured key, so a wrong key fails
+  with a precise identification error, never a decrypt failure.
+- The store key is **independent of the venue identity `seed`** — rotate and
+  guard them separately. For an encrypted store, configure the identity via
+  `seed`/`keystore` rather than relying on the auto-generated plaintext
+  `venue.key` beside the store (the venue warns about that combination:
+  encrypted data with the identity readable off the same disk).
 - The policy applies to file stores and `"temp"` stores; `"memory"` is not an
   Etch store and rejects an `etch` block.
 - Fail-closed: an invalid field, unresolvable key, wrong-sized key, an

--- a/venue/docs/UCAN.md
+++ b/venue/docs/UCAN.md
@@ -47,7 +47,7 @@ A UCAN is a CVM map with the following fields:
 | `iss` | AString (DID) | Yes | Issuer. The DID of the principal signing this UCAN. Resolves to an Ed25519 public key for signature verification. |
 | `aud` | AString (DID/DID URL) | Yes | Audience. The DID (or DID URL for agent-scoped grants) of the intended recipient. |
 | `att` | AVector of maps | Yes | Attenuations. Each entry is a `{with, can}` capability pair, optionally with `nb` constraints. |
-| `exp` | CVMLong or null | Yes | Expiry. Unix timestamp in seconds, or explicit null for no expiry. While Convex #678 is pending, Covia issuance represents null as a 99-year finite expiry; `0` is expired, not permanent. |
+| `exp` | CVMLong or null | Yes | Expiry. Unix timestamp in seconds, or explicit null for no expiry (Convex #678). The key must be present — an absent `exp` is malformed; `0` is expired, not permanent. |
 | `nbf` | CVMLong | No | Not Before. Token is invalid before this time. Omit for immediate validity. |
 | `nnc` | AString | No | Nonce. Unique value for replay prevention. |
 | `fct` | AVector of maps | No | Facts. Additional signed metadata (grid version, venue context, etc.). |
@@ -237,9 +237,12 @@ ucan:issue {
 ```
 
 `exp` may be explicitly `null` to request a non-expiring UCAN. For tolerant API
-input, `ucan:issue` also treats an omitted `exp` as null. Until Convex #678 adds
-nullable expiry to the core UCAN model and validator, issuance encodes either
-form as a 99-year finite expiry, so the emitted UCAN always has a valid `exp`.
+input, `ucan:issue` also treats an omitted `exp` as null. Either form mints a
+genuinely non-expiring token: the emitted UCAN carries an explicit `exp: null`
+per UCAN v0.10.0 (Convex #678), in the Convex UCAN JWT profile (`ucv` claim +
+`typ` header — required for the token to parse from 0.8.11 on). A non-expiring
+mint under a granting right requires the enabling right to be non-expiring too
+(the §4.1 horizon check evaluates at an unbounded horizon).
 
 The venue signs the token with the **venue key pair** (the venue is the
 issuer — custodial attestation on the authenticated caller's instruction)

--- a/venue/docs/UCAN.md
+++ b/venue/docs/UCAN.md
@@ -144,6 +144,8 @@ Abilities follow UCAN's slash-delimited convention with no leading slash. `*` is
 
 **Attenuation rule:** An ability is a valid attenuation of a parent if it is equal to or has the parent as a prefix. `crud/read` attenuates `crud`. `*` proves any ability.
 
+**Time bounds are not attenuation.** Resource and ability scope narrow structurally through a chain; time bounds deliberately do not. Each link carries its own `exp`/`nbf` on its own timescale, and validation requires every link to be valid at evaluation time — UCAN 1.0 execution-time semantics ("proofs MAY have different validity periods, but MUST all be valid at execution-time"), adopted in preference to the v0.10.0 §6.1 containment rule that required a delegation's window to fit inside its proofs' (do not "fix" validation back to that). A chain is therefore usable in the window [latest `nbf`, earliest finite `exp`] across its links; a link with `exp: null` never expires, but the chain still stops when any other link does. The one place temporal containment *does* apply is at granting surfaces: authority minted under an enabling right must not outlive that right (§4.1), because the right is consumed at issuance and is not part of the minted token's chain — use-time validation can never see it.
+
 ### 3.3 Constraints (`nb`)
 
 Optional per-capability constraints as a map:
@@ -260,7 +262,8 @@ Resource rules at issuance (`UCANAdapter.handleIssue`):
   proofs must cover `grant/<can>` on the resource (proofs travel in the
   proof channel, never in operation input), and the minted `exp` must not
   outlive the enabling right (coverage is re-evaluated at the minted
-  expiry), and the resource must still be controlled by this venue (the
+  expiry — so a non-expiring mint requires a non-expiring enabling
+  right), and the resource must still be controlled by this venue (the
   venue's own DID or a local custodial user). A granting right cannot turn
   the venue into root authority for an external DID. This makes `ucan:issue`
   a *granting surface* — the `grant/…` rule binds token production; chain

--- a/venue/src/main/java/covia/adapter/GridAdapter.java
+++ b/venue/src/main/java/covia/adapter/GridAdapter.java
@@ -232,7 +232,7 @@ public class GridAdapter extends AAdapter {
 
     private Venue connectRemote(RequestContext ctx, AString venueSpec) {
         AString venueDID = engine.getDIDString();
-        java.util.List<UCAN> tokens = parsedRawUcans(ctx);
+        java.util.List<UCAN> tokens = parsedRawUcans(ctx, engine.didVerifier());
 
         boolean relayAsSelf = hasRelayInstruction(tokens, ctx.getCallerDID(), venueDID);
         VenueAuth auth = relayAsSelf
@@ -335,7 +335,8 @@ public class GridAdapter extends AAdapter {
     /** Parses the caller's raw transport tokens (already signature-verified at
      *  ingress) for audience/issuer inspection; null-padded on parse failure so
      *  indices align with {@link RequestContext#getRawUcans()}. */
-    static java.util.List<UCAN> parsedRawUcans(RequestContext ctx) {
+    static java.util.List<UCAN> parsedRawUcans(RequestContext ctx,
+            convex.auth.did.DIDVerifier verifier) {
         AVector<ACell> raw = ctx.getRawUcans();
         if (raw == null || raw.isEmpty()) return null;
         java.util.List<UCAN> out = new java.util.ArrayList<>();
@@ -345,7 +346,7 @@ public class GridAdapter extends AAdapter {
             AString jwt = RT.ensureString(raw.get(i));
             if (jwt != null) {
                 try {
-                    token = UCANValidator.validateJWT(jwt, now, convex.auth.did.DIDVerifier.CONVEX);
+                    token = UCANValidator.validateJWT(jwt, now, verifier);
                 } catch (Exception e) {
                     // defective token: null slot, grants nothing
                 }

--- a/venue/src/main/java/covia/adapter/HITLAdapter.java
+++ b/venue/src/main/java/covia/adapter/HITLAdapter.java
@@ -400,8 +400,8 @@ public class HITLAdapter extends AAdapter {
 	/** Issues the approved grants as a single token via the granting surface
 	 *  (ucan:issue under the RESPONDER's authority — bare paths canonicalise to
 	 *  the responder's namespace). Token exp = earliest grant exp, defaulted;
-	 *  explicit null is unbounded and is temporarily encoded by ucan:issue as a
-	 *  99-year finite expiry until Convex #678 ships. */
+	 *  explicit null is unbounded and mints a genuinely non-expiring token
+	 *  (exp: null, Convex #678) — permitted only when no venue ceiling is set. */
 	private AString issueGrants(AString responder, AString requester, AVector<ACell> approved) {
 		if (requester == null) throw new IllegalStateException("record has no requester identity");
 		long now = System.currentTimeMillis() / 1000;

--- a/venue/src/main/java/covia/adapter/UCANAdapter.java
+++ b/venue/src/main/java/covia/adapter/UCANAdapter.java
@@ -34,14 +34,6 @@ public class UCANAdapter extends AAdapter {
 	private static final AString K_AUTHORISES = Strings.intern("authorises");
 	private static final AString K_AUDIENCE = Strings.intern("audience");
 
-	/**
-	 * Temporary representation of the UCAN {@code exp: null} (never expires)
-	 * form while convex-core cannot represent nullable expiry (Convex #678).
-	 * Keep this inside issuance so callers can use the spec-shaped API now and
-	 * the workaround can be removed without changing that API later.
-	 */
-	static final long NON_EXPIRING_COMPAT_LIFETIME_SECS = 99L * 365 * 24 * 60 * 60;
-
 	@Override
 	public String getName() {
 		return "ucan";
@@ -118,19 +110,19 @@ public class UCANAdapter extends AAdapter {
 		ACell expValue = inputMap.get(UCAN.EXP);
 		CVMLong expCell = RT.ensureLong(expValue);
 		long now = System.currentTimeMillis() / 1000;
-		long exp;
+		// UCAN v0.10.0 (Convex #678, covia#322): a non-expiring token carries an
+		// explicit exp: null. Tolerant API input treats an omitted exp as null;
+		// the minted claim is always explicit.
+		Long exp;
 		if (expValue == null) {
-			// UCAN v0.10.0 requires explicit null for a non-expiring token. Convex
-			// #678 will make that directly representable; accept omitted input as
-			// null, then mint a deliberately conspicuous far-future finite expiry.
-			exp = now + NON_EXPIRING_COMPAT_LIFETIME_SECS;
+			exp = null;
 		} else if (expCell != null) {
 			exp = expCell.longValue();
+			if (exp <= now) {
+				throw new RuntimeException("exp must be in the future, or null for no expiry");
+			}
 		} else {
 			throw new RuntimeException("exp must be unix seconds or null for no expiry");
-		}
-		if (exp <= now) {
-			throw new RuntimeException("exp must be in the future");
 		}
 
 		// Canonicalise + validate 'with' fields. A bare path names the ISSUER's
@@ -175,10 +167,13 @@ public class UCANAdapter extends AAdapter {
 							+ "resource owner (transport ucans / bearer), or use your own namespace");
 					}
 					// This second check asks only whether the granting chain still
-					// exists at the minted token's expiry horizon. Dynamic gates rule
-					// on the issuance happening now (the check above); they must not
-					// execute a second time against an imaginary future invocation.
-					if (!engine.proofsStructurallyCover(ctx, resource, grantAbility, exp - 1)) {
+					// exists at the minted token's expiry horizon — unbounded for a
+					// non-expiring mint, so exp: null requires the enabling right to
+					// be non-expiring too. Dynamic gates rule on the issuance
+					// happening now (the check above); they must not execute a
+					// second time against an imaginary future invocation.
+					long horizon = (exp == null) ? Long.MAX_VALUE : exp - 1;
+					if (!engine.proofsStructurallyCover(ctx, resource, grantAbility, horizon)) {
 						throw new RuntimeException("att[" + i + "]: exp exceeds the validity of the "
 							+ "granting right enabling this issuance — minted authority must not "
 							+ "outlive the right it was minted under; request a shorter exp");
@@ -224,12 +219,19 @@ public class UCANAdapter extends AAdapter {
 			throw new IllegalArgumentException("aud must be a valid audience DID: " + audDID);
 		}
 		AKeyPair venueKP = engine.getKeyPair();
+		// Mint the Convex UCAN JWT profile (0.8.11): the ucv claim and an
+		// explicit exp key (null = non-expiring) are required for the token to
+		// parse; JWT.signPublic supplies the typ header and kid. Claims are
+		// built directly (not via UCAN.signJWT) because the venue's iss is its
+		// declared identity, which may be did:web (covia#343) — the profile
+		// accepts any DID-shaped issuer.
 		AMap<AString, ACell> claims = Maps.of(
 			UCAN.ISS, venueDID,
 			UCAN.AUD, audDID,
-			UCAN.EXP, CVMLong.create(exp),
+			UCAN.UCV, UCAN.VERSION,
 			UCAN.ATT, att,
 			UCAN.PRF, Vectors.empty());
+		claims = claims.assoc(UCAN.EXP, (exp == null) ? null : CVMLong.create(exp));
 		AString token = JWT.signPublic(claims, venueKP);
 
 		return Maps.of("token", token);
@@ -328,11 +330,12 @@ public class UCANAdapter extends AAdapter {
 			}
 		}
 
+		Long tokenExp = token.getExpiry();
 		AMap<AString, ACell> result = Maps.of(
 			"valid", true,
 			"iss", token.getIssuer(),
 			"aud", token.getAudience(),
-			"exp", CVMLong.create(token.getExpiry()),
+			"exp", (tokenExp == null) ? null : CVMLong.create(tokenExp),
 			"chainDepth", CVMLong.create(depth),
 			"rootIssuer", rootIssuer,
 			"att", verdicts);

--- a/venue/src/main/java/covia/adapter/UCANAdapter.java
+++ b/venue/src/main/java/covia/adapter/UCANAdapter.java
@@ -262,8 +262,8 @@ public class UCANAdapter extends AAdapter {
 		String failure = null;
 		try {
 			token = (tokenStr != null)
-				? convex.auth.ucan.UCANValidator.validateJWT(tokenStr, now, convex.auth.did.DIDVerifier.CONVEX)
-				: convex.auth.ucan.UCANValidator.validate(UCAN.parse(tokenMap), now, convex.auth.did.DIDVerifier.CONVEX);
+				? convex.auth.ucan.UCANValidator.validateJWT(tokenStr, now, engine.didVerifier())
+				: convex.auth.ucan.UCANValidator.validate(UCAN.parse(tokenMap), now, engine.didVerifier());
 		} catch (Exception e) {
 			failure = e.getMessage();
 		}

--- a/venue/src/main/java/covia/venue/Config.java
+++ b/venue/src/main/java/covia/venue/Config.java
@@ -1182,7 +1182,30 @@ public class Config {
 		java.util.function.Function<convex.core.data.AccountKey, byte[]> keyFn = null;
 		if (keySource != null) {
 			byte[] key = resolveEtchKey(keySource);
-			keyFn = ignoredHint -> key;
+			// Key identity convention, consistent with venue key management: the
+			// 32-byte master key is treated as an Ed25519 seed and identified by
+			// its derived public key — the same identifier scheme as venue
+			// identity keys and keystore aliases. New files stamp that identity
+			// as the Etch v3 public-key hint (unless the operator pins one
+			// explicitly), and the key function verifies the file's hint before
+			// releasing key material — a wrong key fails at identification with
+			// a precise diagnostic, never as a downstream decrypt failure.
+			convex.core.data.AccountKey keyId = convex.core.crypto.AKeyPair
+				.create(convex.core.data.Blob.wrap(key)).getAccountKey();
+			convex.core.data.AccountKey explicit =
+				convex.core.data.AccountKey.parse(convexMap.get(Strings.intern("publicKeyHint")));
+			convex.core.data.AccountKey expectedHint = (explicit != null) ? explicit : keyId;
+			if (explicit == null) {
+				convexMap = convexMap.assoc(Strings.intern("publicKeyHint"), keyId);
+			}
+			keyFn = hint -> {
+				if (hint != null && !hint.equals(expectedHint)) {
+					throw new IllegalStateException("Etch store is encrypted under key "
+						+ hint + " but the configured etch key has identity " + expectedHint
+						+ " — wrong key material for this store");
+				}
+				return key;
+			};
 		}
 		try {
 			return convex.etch.EtchConfig.fromMap(convexMap, keyFn);

--- a/venue/src/main/java/covia/venue/Config.java
+++ b/venue/src/main/java/covia/venue/Config.java
@@ -358,7 +358,7 @@ public class Config {
 		"defaultLlmOperation", "defaultTransitionOp", "maxToolIterations",
 		"port", "bindAddress", "baseUrl", "rateLimit", "acceptQueueSize",
 		"httpSelectors", "httpAcceptors", "mcp", "a2a", "adapters",
-		"modules", "users", "store", "seed", "keystore", "storage",
+		"modules", "users", "store", "seed", "keystore", "storage", "etch",
 		"maxContentSize", "auth", "webdav", "file", "corsOrigins",
 		"allowPrivateNetwork", "enablePrivateJobs", "recordReadOnlyOperations", "fixMcpStrings",
 		"outputValidation", "secrets", "strictAssets", "strictConfig");
@@ -432,6 +432,7 @@ public class Config {
 		optionalString(config, DEFAULT_TRANSITION_OP, "defaultTransitionOp");
 		optionalString(config, BIND_ADDRESS, "bindAddress");
 		optionalString(config, STORE, "store");
+		getEtchConfig(); // compile the etch block now — fail closed at construction
 		optionalString(config, SEED, "seed");
 
 		optionalLong(config, MAX_TOOL_ITERATIONS, "maxToolIterations", 1, Integer.MAX_VALUE);
@@ -1145,6 +1146,83 @@ public class Config {
 	 */
 	public boolean isStoreConfigured() {
 		return config.get(STORE) != null;
+	}
+
+	/**
+	 * Config key for the optional Etch store creation policy (Convex 0.8.11+):
+	 * a map passed through to {@link convex.etch.EtchConfig#fromMap} —
+	 * {@code version}, {@code mapping}, {@code buildChains},
+	 * {@code publicKeyHint}, {@code cipher} ({@code none}, {@code aes-256-ctr},
+	 * {@code chacha20}), {@code encryptIndex} — plus the Covia-side {@code key}
+	 * field naming the 32-byte encryption key source for encrypted stores: a
+	 * hex string (dev/test only), {@code {"env": "VAR"}} (hex in an environment
+	 * variable), or {@code {"file": "path"}} (hex in an operator-secured file).
+	 * Applies wherever the venue creates an Etch store ({@code store} = file
+	 * path or {@code "temp"}).
+	 */
+	public static final AString ETCH = Strings.intern("etch");
+	private static final AString ETCH_KEY = Strings.intern("key");
+
+	/**
+	 * Compiles the optional Etch creation policy, resolving the {@code key}
+	 * source into the key function Convex requires for encrypted stores.
+	 * Fail-closed: an invalid field, unresolvable key source, or wrong-sized
+	 * key is a configuration error, never a silently-unencrypted store.
+	 *
+	 * @return compiled Etch configuration, or null when no {@code etch} block
+	 *         is configured
+	 */
+	public convex.etch.EtchConfig getEtchConfig() {
+		ACell raw = config.get(ETCH);
+		if (raw == null) return null;
+		AMap<AString, ACell> etch = RT.castMap(raw);
+		if (etch == null) throw malformed("etch", "must be an object");
+		ACell keySource = etch.get(ETCH_KEY);
+		AMap<AString, ACell> convexMap = etch.dissoc(ETCH_KEY);
+		java.util.function.Function<convex.core.data.AccountKey, byte[]> keyFn = null;
+		if (keySource != null) {
+			byte[] key = resolveEtchKey(keySource);
+			keyFn = ignoredHint -> key;
+		}
+		try {
+			return convex.etch.EtchConfig.fromMap(convexMap, keyFn);
+		} catch (IllegalArgumentException e) {
+			throw malformed("etch", e.getMessage());
+		}
+	}
+
+	/** Resolves the {@code etch.key} source to the raw 32-byte encryption key. */
+	private byte[] resolveEtchKey(ACell keySource) {
+		String hex;
+		if (keySource instanceof AString s) {
+			hex = s.toString();
+		} else {
+			AMap<AString, ACell> m = RT.castMap(keySource);
+			AString env = (m != null) ? RT.ensureString(m.get(Strings.intern("env"))) : null;
+			AString file = (m != null) ? RT.ensureString(m.get(Strings.intern("file"))) : null;
+			if (env != null) {
+				hex = System.getenv(env.toString());
+				if (hex == null) {
+					throw malformed("etch.key", "environment variable " + env + " is not set");
+				}
+			} else if (file != null) {
+				try {
+					hex = java.nio.file.Files.readString(
+						java.nio.file.Path.of(file.toString())).trim();
+				} catch (java.io.IOException e) {
+					throw malformed("etch.key",
+						"cannot read key file " + file + ": " + e.getMessage());
+				}
+			} else {
+				throw malformed("etch.key",
+					"must be a 32-byte hex string, {\"env\": name} or {\"file\": path}");
+			}
+		}
+		convex.core.data.Blob key = convex.core.data.Blob.fromHex(hex.trim());
+		if (key == null || key.count() != 32) {
+			throw malformed("etch.key", "must resolve to exactly 32 bytes of hex");
+		}
+		return key.getBytes();
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/Config.java
+++ b/venue/src/main/java/covia/venue/Config.java
@@ -426,6 +426,7 @@ public class Config {
 		optionalString(config, NAME, "name");
 		optionalString(config, Strings.intern("description"), "description");
 		optionalString(config, DID, "did");
+		validateDeclaredDID();
 		optionalString(config, HOSTNAME, "hostname");
 		optionalString(config, DEFAULT_LLM_OPERATION, "defaultLlmOperation");
 		optionalString(config, DEFAULT_TRANSITION_OP, "defaultTransitionOp");
@@ -900,10 +901,47 @@ public class Config {
 	}
 
 	/**
+	 * Validates an operator-declared venue identity (covia#343): the {@code did}
+	 * key takes the DID this venue presents as its identity. A {@code did:web}
+	 * declaration must be the bare venue form naming the configured public
+	 * hostname (so the identity resolves to this venue's DID document); a
+	 * {@code did:key} declaration must carry a valid multikey — its match
+	 * against the venue key pair is enforced at Engine construction, where the
+	 * key is known (an explicit identity pin). Absent means the venue's
+	 * key-derived did:key, unchanged.
+	 */
+	private void validateDeclaredDID() {
+		AString did = RT.ensureString(config.get(DID));
+		if (did == null) return;
+		String d = did.toString();
+		if (d.startsWith("did:web:")) {
+			String host = d.substring("did:web:".length());
+			if (host.contains(":")) {
+				throw malformed("did", "a declared did:web identity must be the bare venue "
+					+ "form (did:web:<hostname>, no path segments)");
+			}
+			if (!isPublicHostname(host)) {
+				throw malformed("did", "did:web requires a public DNS hostname, got: " + host);
+			}
+			if (!host.equals(getHostname())) {
+				throw malformed("did", "did:web host must equal the configured hostname ("
+					+ getHostname() + "), got: " + host);
+			}
+		} else if (d.startsWith("did:key:")) {
+			if (convex.core.crypto.util.Multikey.decodePublicKey(
+					d.substring("did:key:".length())) == null) {
+				throw malformed("did", "did:key must carry a valid Ed25519 multikey");
+			}
+		} else {
+			throw malformed("did", "supported identity methods are did:key and did:web");
+		}
+	}
+
+	/**
 	 * True iff {@code host} is a plausible public DNS name: contains a dot,
 	 * no port/IPv6 colon, not "localhost", and not an IPv4 literal.
 	 */
-	static boolean isPublicHostname(String host) {
+	public static boolean isPublicHostname(String host) {
 		if (host == null || host.isEmpty()) return false;
 		if (host.indexOf(':') >= 0) return false;        // port or IPv6 literal
 		if (host.indexOf('.') < 0) return false;          // bare names (localhost, myhost)

--- a/venue/src/main/java/covia/venue/Config.java
+++ b/venue/src/main/java/covia/venue/Config.java
@@ -432,7 +432,7 @@ public class Config {
 		optionalString(config, DEFAULT_TRANSITION_OP, "defaultTransitionOp");
 		optionalString(config, BIND_ADDRESS, "bindAddress");
 		optionalString(config, STORE, "store");
-		getEtchConfig(); // compile the etch block now — fail closed at construction
+		validateEtch();
 		optionalString(config, SEED, "seed");
 
 		optionalLong(config, MAX_TOOL_ITERATIONS, "maxToolIterations", 1, Integer.MAX_VALUE);
@@ -1173,14 +1173,41 @@ public class Config {
 	 *         is configured
 	 */
 	public convex.etch.EtchConfig getEtchConfig() {
+		return getEtchConfig(null);
+	}
+
+	/**
+	 * Compiles the optional Etch creation policy with an embedder-supplied key
+	 * resolver, mirroring Convex's {@code PeerConfig.getEtchConfig(fn)}: the
+	 * function receives the store's public-key hint and returns the 32-byte
+	 * master key — sourced however the embedder holds keys (KMS, passphrase
+	 * derivation, HSM). No key material touches config, environment, or disk
+	 * on this path, and hint stamping/verification is the caller's concern.
+	 * Mutually exclusive with the config {@code key} field. With a null
+	 * function, the config {@code key} field is resolved under Covia's
+	 * conventions (derived key identity auto-stamped as the hint, verified on
+	 * open); an encrypted cipher with neither source is then an error at store
+	 * creation.
+	 *
+	 * @param keyFunction embedder key resolver, or null to resolve the config
+	 *                    {@code key} field
+	 * @return compiled Etch configuration, or null when no {@code etch} block
+	 *         is configured
+	 */
+	public convex.etch.EtchConfig getEtchConfig(
+			java.util.function.Function<convex.core.data.AccountKey, byte[]> keyFunction) {
 		ACell raw = config.get(ETCH);
 		if (raw == null) return null;
 		AMap<AString, ACell> etch = RT.castMap(raw);
 		if (etch == null) throw malformed("etch", "must be an object");
 		ACell keySource = etch.get(ETCH_KEY);
+		if (keyFunction != null && keySource != null) {
+			throw malformed("etch.key", "both a config key source and an embedder "
+				+ "key function were supplied — use exactly one");
+		}
 		AMap<AString, ACell> convexMap = etch.dissoc(ETCH_KEY);
-		java.util.function.Function<convex.core.data.AccountKey, byte[]> keyFn = null;
-		if (keySource != null) {
+		java.util.function.Function<convex.core.data.AccountKey, byte[]> keyFn = keyFunction;
+		if (keyFunction == null && keySource != null) {
 			byte[] key = resolveEtchKey(keySource);
 			// Key identity convention, consistent with venue key management: the
 			// 32-byte master key is treated as an Ed25519 seed and identified by
@@ -1195,7 +1222,11 @@ public class Config {
 			convex.core.data.AccountKey explicit =
 				convex.core.data.AccountKey.parse(convexMap.get(Strings.intern("publicKeyHint")));
 			convex.core.data.AccountKey expectedHint = (explicit != null) ? explicit : keyId;
-			if (explicit == null) {
+			CVMLong version = RT.ensureLong(convexMap.get(Strings.intern("version")));
+			if (explicit == null && version != null && version.longValue() == 3) {
+				// Hints exist only in the v3 header; stamping is gated on an
+				// explicit v3 policy so other version errors keep their own
+				// accurate diagnostics.
 				convexMap = convexMap.assoc(Strings.intern("publicKeyHint"), keyId);
 			}
 			keyFn = hint -> {
@@ -1209,6 +1240,32 @@ public class Config {
 		}
 		try {
 			return convex.etch.EtchConfig.fromMap(convexMap, keyFn);
+		} catch (IllegalArgumentException e) {
+			throw malformed("etch", e.getMessage()
+				+ ((keyFn == null) ? " (configure etch.key, or supply a key function "
+					+ "via getEtchConfig(fn) when embedding)" : ""));
+		}
+	}
+
+	/**
+	 * Shape-validates the etch block at construction with a placeholder
+	 * resolver, so embedder configs that supply the key function at runtime
+	 * ({@link #getEtchConfig(java.util.function.Function)}) still construct.
+	 * When the config carries its own {@code key} source, the full compile —
+	 * including key resolution — runs now, fail-closed. An encrypted policy
+	 * with neither source fails at store creation instead.
+	 */
+	private void validateEtch() {
+		ACell raw = config.get(ETCH);
+		if (raw == null) return;
+		AMap<AString, ACell> etch = RT.castMap(raw);
+		if (etch == null) throw malformed("etch", "must be an object");
+		if (etch.get(ETCH_KEY) != null) {
+			getEtchConfig();
+			return;
+		}
+		try {
+			convex.etch.EtchConfig.fromMap(etch.dissoc(ETCH_KEY), ignored -> null);
 		} catch (IllegalArgumentException e) {
 			throw malformed("etch", e.getMessage());
 		}

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -2132,13 +2132,14 @@ public class Engine {
 	 *
 	 * <p>The document {@code id} must equal the DID a resolver asked for (DID
 	 * Core), so when the venue has a public hostname configured the document is
-	 * presented under its <b>did:web alias</b> ({@code did:web:<hostname>}) with
-	 * the canonical did:key in {@code alsoKnownAs} — making strict did:web
-	 * resolution work (covia#167). The alias is a derived, per-request view and
-	 * is discovery only: the venue's identity remains its did:key (the same
-	 * ed25519 key material verifies in both presentations), and nothing durable
-	 * references the did:web form. Without a public hostname the document is
-	 * served under the did:key directly, unchanged.</p>
+	 * presented under {@code did:web:<hostname>}, with the did:key in
+	 * {@code alsoKnownAs} — making strict did:web resolution work (covia#167).
+	 * Consumers respect the presented identity as-is: {@code alsoKnownAs} is
+	 * the DID spec's informational same-subject cross-reference, never a
+	 * canonical identity to re-bind to (covia#343 — the did:key is key
+	 * material, published as a verification method; the identity a persistent
+	 * venue presents is its did:web). Without a public hostname the document
+	 * is served under the did:key directly, unchanged.</p>
 	 *
 	 * @param endpoint Service endpoint URL for the CoviaGrid service entry
 	 * @return DID document map
@@ -2176,8 +2177,8 @@ public class Engine {
 					))
 		);
 
-		// Bind the alias to the canonical identity: consumers resolving
-		// did:web re-bind to the did:key for anything they store or pin.
+		// Informational same-subject cross-reference (non-authoritative, DID
+		// Core): consumers keep the identity they resolved — no rebinding.
 		if (aliased) {
 			ddo=ddo.assoc(Strings.intern("alsoKnownAs"), Vectors.create(canonicalDID));
 		}

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -222,6 +222,7 @@ public class Engine {
 			AKeyPair keyPair, PersistenceHandler persistHandler) throws IOException {
 		this.config=java.util.Objects.requireNonNull(config, "config");
 		this.keyPair=keyPair;
+		validateDeclaredIdentity();
 		this.lattice=cursor;
 		this.persistHandler = (persistHandler != null) ? persistHandler : PersistenceHandler.NOOP;
 		this.lastFlushMillis = System.currentTimeMillis();
@@ -1992,6 +1993,58 @@ public class Engine {
 			s=Strings.create("did:key:"+key);
 		}
 		return s;
+	}
+
+	/**
+	 * Fail-closed check that an operator-declared identity (config {@code did},
+	 * covia#343) is one this venue can actually prove: a declared did:key must
+	 * match the venue key pair — an explicit identity pin, so a venue started
+	 * with the wrong seed or keystore refuses to run rather than silently
+	 * assuming a new identity — and a declared did:web must match the public
+	 * hostname's derived form. Shape validation lives in {@link Config}.
+	 */
+	private void validateDeclaredIdentity() {
+		AString declared = config.getDID();
+		if (declared == null) return;
+		String d = declared.toString();
+		if (d.startsWith("did:key:")) {
+			AString derived = Strings.create("did:key:"
+				+ Multikey.encodePublicKey(keyPair.getAccountKey()));
+			if (!derived.equals(declared)) {
+				throw new IllegalStateException("Declared venue identity " + declared
+					+ " does not match the venue key pair (" + derived
+					+ ") — wrong seed or keystore?");
+			}
+		} else if (d.startsWith("did:web:")) {
+			AString web = config.getWebDID();
+			if (!declared.equals(web)) {
+				throw new IllegalStateException("Declared venue identity " + declared
+					+ " does not match the venue's did:web form ("
+					+ (web == null ? "no public hostname" : web) + ")");
+			}
+		}
+	}
+
+	private volatile covia.venue.auth.VenueDIDVerifier didVerifier;
+
+	/**
+	 * The venue's DID signature verifier (covia#343): did:key statelessly, the
+	 * venue's own identity and locally managed users from venue state, remote
+	 * did:web via cached DID-document resolution. Ingress seams use this in
+	 * place of {@link convex.auth.did.DIDVerifier#CONVEX} so did:web-identified
+	 * principals verify exactly like did:key ones.
+	 */
+	public covia.venue.auth.VenueDIDVerifier didVerifier() {
+		covia.venue.auth.VenueDIDVerifier v = didVerifier;
+		if (v == null) {
+			synchronized (this) {
+				if (didVerifier == null) {
+					didVerifier = new covia.venue.auth.VenueDIDVerifier(this);
+				}
+				v = didVerifier;
+			}
+		}
+		return v;
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -328,7 +328,7 @@ public class CoviaAPI extends ACoviaAPI {
 		// proof for cross-DID reads, per the IETF UCAN-HTTP convention).
 		RequestContext rctx = AuthMiddleware.callerContext(ctx);
 		AString bearer = ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR);
-		rctx = AuthMiddleware.withTransportAuth(rctx, bearer, null);
+		rctx = AuthMiddleware.withTransportAuth(rctx, bearer, null, null, engine().didVerifier());
 
 		try {
 			Asset asset=resolveAssetReference(ref, rctx);
@@ -557,7 +557,7 @@ public class CoviaAPI extends ACoviaAPI {
 		RequestContext rctx = AuthMiddleware.callerContext(ctx);
 		AVector<ACell> ucans = RT.getIn(req, Fields.UCANS);
 		AString bearer = ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR);
-		rctx = AuthMiddleware.withTransportAuth(rctx, bearer, ucans, engine().getDIDString());
+		rctx = AuthMiddleware.withTransportAuth(rctx, bearer, ucans, engine().getDIDString(), engine().didVerifier());
 
 		try {
 			ACell result = engine().jobs().runOperation(op, input, rctx).join();
@@ -663,7 +663,7 @@ public class CoviaAPI extends ACoviaAPI {
 		// venueDID enables identity-from-ucans: an anonymous transport carrying a
 		// verified identity token audienced to this venue authenticates as its
 		// issuer (relayed cross-venue callers, covia#100 C3a).
-		rctx = AuthMiddleware.withTransportAuth(rctx, bearer, ucans, engine().getDIDString());
+		rctx = AuthMiddleware.withTransportAuth(rctx, bearer, ucans, engine().getDIDString(), engine().didVerifier());
 
 		try {
 			// Wait window: `wait` (query param or body field) is boolean or an
@@ -792,7 +792,7 @@ public class CoviaAPI extends ACoviaAPI {
 		// this is how a grid hop observes the remote job it created.
 		AString bearer = ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR);
 		rctx = AuthMiddleware.withTransportAuth(rctx, bearer,
-			AuthMiddleware.headerUcans(ctx), engine().getDIDString());
+			AuthMiddleware.headerUcans(ctx), engine().getDIDString(), engine().didVerifier());
 
 		try {
 			AMap<AString,ACell> status=engine().jobs().getJobData(id, rctx);
@@ -1319,7 +1319,7 @@ public class CoviaAPI extends ACoviaAPI {
 
 		RequestContext rctx = AuthMiddleware.callerContext(ctx);
 		AString bearer = ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR);
-		rctx = AuthMiddleware.withTransportAuth(rctx, bearer, null);
+		rctx = AuthMiddleware.withTransportAuth(rctx, bearer, null, null, engine().didVerifier());
 
 		AMap<AString, ACell> input;
 		try {

--- a/venue/src/main/java/covia/venue/api/MCP.java
+++ b/venue/src/main/java/covia/venue/api/MCP.java
@@ -475,7 +475,7 @@ public class MCP extends McpServer {
 				// bearer UCAN.
 				AVector<ACell> ucans = RT.getIn(arguments, Fields.UCANS);
 				AString bearer = (ctx != null) ? ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR) : null;
-				rctx = AuthMiddleware.withTransportAuth(rctx, bearer, ucans, engine().getDIDString());
+				rctx = AuthMiddleware.withTransportAuth(rctx, bearer, ucans, engine().getDIDString(), engine().didVerifier());
 				// `ucans` is transport authority, not operation input. Never let
 				// raw proof JWTs enter durable Job records, adapter logs, or agent
 				// timelines merely because MCP carries them inside tool arguments.

--- a/venue/src/main/java/covia/venue/auth/VenueAuthenticator.java
+++ b/venue/src/main/java/covia/venue/auth/VenueAuthenticator.java
@@ -99,6 +99,12 @@ public final class VenueAuthenticator {
 		audienceStrings.addAll(venueAuth.getConfiguredAudiences());
 		AString webDID = venueAuth.getWebDID();
 		if (webDID != null) audienceStrings.add(webDID.toString());
+		// The key-derived did:key is always an accepted audience: a declared
+		// did:web identity (covia#343) must not orphan clients that
+		// audience-bind to the venue's key form.
+		if (venueKey != null) {
+			audienceStrings.add("did:key:" + Multikey.encodePublicKey(venueKey));
+		}
 		this.acceptedAudienceStrings = Set.copyOf(audienceStrings);
 
 		Set<AString> audiences = new HashSet<>();
@@ -237,10 +243,11 @@ public final class VenueAuthenticator {
 		if (claims == null || claims.get(UCAN.ATT) == null) return null;
 
 		AString issuer = token.getIssuer();
-		AccountKey issuerKey = UCAN.fromDIDKey(issuer);
-		if (issuerKey == null || JWT.verifyPublic(jwt, issuerKey) == null) return null;
+		if (issuer == null) return null;
 		long now = System.currentTimeMillis() / 1000;
-		if (!UCANValidator.checkTemporalBounds(token, now)) return null;
+		// Signature + temporal bounds under the venue's DID verifier, so a
+		// did:web-identified issuer (covia#343) verifies exactly like did:key.
+		if (UCANValidator.validateJWT(jwt, now, engine.didVerifier()) == null) return null;
 		requireAudience(token.getAudience());
 		return new VerifiedPrincipal(issuer, issuer, true);
 	}

--- a/venue/src/main/java/covia/venue/auth/VenueDIDVerifier.java
+++ b/venue/src/main/java/covia/venue/auth/VenueDIDVerifier.java
@@ -1,0 +1,186 @@
+package covia.venue.auth;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import convex.auth.did.DIDVerifier;
+import convex.core.crypto.ASignature;
+import convex.core.crypto.util.Multikey;
+import convex.core.data.ACell;
+import convex.core.data.AString;
+import convex.core.data.AVector;
+import convex.core.data.AccountKey;
+import convex.core.data.Blob;
+import convex.core.lang.RT;
+import convex.core.util.JSON;
+import covia.venue.Config;
+import covia.venue.Engine;
+
+/**
+ * DID signature verifier for the identities a venue accepts (covia#343).
+ *
+ * <p>Resolution order, all fail-closed per the {@link DIDVerifier} contract
+ * (unresolvable or erroring verifies {@code false}, never throws):</p>
+ *
+ * <ol>
+ *   <li>{@code did:key} — stateless multikey verification
+ *       ({@link DIDVerifier#CONVEX}).</li>
+ *   <li>The venue's own identity (declared did:web or key-derived did:key,
+ *       in either published form) — the venue's current key.</li>
+ *   <li>Locally managed users ({@code did:web:<host>:u:<name>}) — the user's
+ *       <b>active</b> registered authentication keys, match-any, resolved
+ *       from venue state with no outbound fetch.</li>
+ *   <li>Remote {@code did:web} — verification methods resolved from the DID
+ *       document over HTTPS (the did:web resolution algorithm), cached on
+ *       success. Consumers respect the presented identity: resolution never
+ *       re-binds through {@code alsoKnownAs}.</li>
+ * </ol>
+ */
+public final class VenueDIDVerifier implements DIDVerifier {
+
+	private static final Logger log = LoggerFactory.getLogger(VenueDIDVerifier.class);
+
+	/** Successful remote resolutions are cached this long — the bound on how
+	 *  stale a rotated remote key set can be at this venue. */
+	private static final long REMOTE_CACHE_TTL_MILLIS = 300_000;
+
+	private static final Duration FETCH_TIMEOUT = Duration.ofSeconds(5);
+
+	private final Engine engine;
+	private final ConcurrentHashMap<String, CachedKeys> remoteCache = new ConcurrentHashMap<>();
+
+	private record CachedKeys(List<AccountKey> keys, long expiresAtMillis) {}
+
+	public VenueDIDVerifier(Engine engine) {
+		if (engine == null) throw new IllegalArgumentException("engine is required");
+		this.engine = engine;
+	}
+
+	@Override
+	public boolean verifies(AString did, Blob message, Blob signature) {
+		if (did == null || message == null || signature == null) return false;
+		try {
+			String d = did.toString();
+			if (d.startsWith("did:key:")) {
+				return DIDVerifier.CONVEX.verifies(did, message, signature);
+			}
+			if (!d.startsWith("did:web:")) return false;
+			if (isOwnVenue(did)) {
+				return verifyWith(engine.getAccountKey(), message, signature);
+			}
+			AString userId = engine.managedUserName(did);
+			if (userId != null) {
+				return verifyManagedUser(userId, message, signature);
+			}
+			return verifyRemote(d, message, signature);
+		} catch (Throwable t) {
+			return false; // fail closed, never throw
+		}
+	}
+
+	/** The venue's own identity in either published form. */
+	private boolean isOwnVenue(AString did) {
+		if (did.equals(engine.getDIDString())) return true;
+		AString web = engine.config().getWebDID();
+		return web != null && web.equals(did);
+	}
+
+	private boolean verifyManagedUser(AString userId, Blob message, Blob signature) {
+		AVector<ACell> active = engine.getAuth().getActiveAuthenticationKeys(userId);
+		for (long i = 0; i < active.count(); i++) {
+			AString keyDID = RT.ensureString(active.get(i));
+			if (keyDID == null || !keyDID.toString().startsWith("did:key:")) continue;
+			AccountKey key = Multikey.decodePublicKey(
+				keyDID.toString().substring("did:key:".length()));
+			if (verifyWith(key, message, signature)) return true;
+		}
+		return false;
+	}
+
+	private boolean verifyRemote(String did, Blob message, Blob signature) {
+		List<AccountKey> keys = resolveRemoteKeys(did);
+		if (keys == null) return false;
+		for (AccountKey key : keys) {
+			if (verifyWith(key, message, signature)) return true;
+		}
+		return false;
+	}
+
+	/** Resolves a remote did:web document's verification keys, cached on success. */
+	private List<AccountKey> resolveRemoteKeys(String did) {
+		CachedKeys cached = remoteCache.get(did);
+		long now = System.currentTimeMillis();
+		if (cached != null && now < cached.expiresAtMillis()) return cached.keys();
+
+		String url = didWebDocumentURL(did);
+		if (url == null) return null;
+		try {
+			HttpClient client = HttpClient.newBuilder().connectTimeout(FETCH_TIMEOUT).build();
+			HttpResponse<String> resp = client.send(
+				HttpRequest.newBuilder(URI.create(url)).timeout(FETCH_TIMEOUT).GET().build(),
+				HttpResponse.BodyHandlers.ofString());
+			if (resp.statusCode() != 200) return null;
+			ACell doc = JSON.parse(resp.body());
+			// Resolution integrity: the document must be about the DID we asked for.
+			AString id = RT.ensureString(RT.getIn(doc, "id"));
+			if (id == null || !did.equals(id.toString())) return null;
+			List<AccountKey> keys = new ArrayList<>();
+			ACell methods = RT.getIn(doc, "verificationMethod");
+			if (methods instanceof AVector<?> mv) {
+				for (long i = 0; i < mv.count(); i++) {
+					AString mk = RT.ensureString(RT.getIn(mv.get(i), "publicKeyMultibase"));
+					AccountKey key = (mk != null) ? Multikey.decodePublicKey(mk.toString()) : null;
+					if (key != null) keys.add(key);
+				}
+			}
+			if (keys.isEmpty()) return null;
+			remoteCache.put(did, new CachedKeys(List.copyOf(keys), now + REMOTE_CACHE_TTL_MILLIS));
+			return keys;
+		} catch (Exception e) {
+			log.debug("did:web resolution failed for {}: {}", did, e.getMessage());
+			return null;
+		}
+	}
+
+	/**
+	 * The did:web resolution URL: colon-separated segments after the host map
+	 * to URL path segments; a bare host resolves to {@code /.well-known/did.json}.
+	 * HTTPS only, and only for plausible public hostnames (SSRF containment —
+	 * loopback, bare names, and IP literals never resolve).
+	 */
+	public static String didWebDocumentURL(String did) {
+		if (did == null || !did.startsWith("did:web:")) return null;
+		String rest = did.substring("did:web:".length());
+		String[] segments = rest.split(":", -1); // keep trailing empties: "host:" is malformed
+		String host = segments[0];
+		if (!Config.isPublicHostname(host)) return null;
+		if (segments.length == 1) {
+			return "https://" + host + "/.well-known/did.json";
+		}
+		StringBuilder sb = new StringBuilder("https://").append(host);
+		for (int i = 1; i < segments.length; i++) {
+			if (segments[i].isEmpty()) return null;
+			sb.append('/').append(segments[i]);
+		}
+		return sb.append("/did.json").toString();
+	}
+
+	private static boolean verifyWith(AccountKey key, Blob message, Blob signature) {
+		if (key == null) return false;
+		try {
+			ASignature sig = ASignature.fromBlob(signature);
+			return sig != null && sig.verify(message, key);
+		} catch (Throwable t) {
+			return false;
+		}
+	}
+}

--- a/venue/src/main/java/covia/venue/server/AuthMiddleware.java
+++ b/venue/src/main/java/covia/venue/server/AuthMiddleware.java
@@ -370,10 +370,22 @@ public class AuthMiddleware {
 	 */
 	public static RequestContext withTransportAuth(RequestContext rctx, AString bearer,
 			AVector<ACell> ucans, AString venueDID) {
-		// Verify signatures at ingress with an explicit DID verifier. DIDVerifier.CONVEX
-		// handles did:key; swap to DIDVerifier.forState(state) to also verify did:convex
-		// issuers when those arrive (covia#100).
-		AVector<ACell> proofs = UCANValidator.parseTransportUCANsWithBearer(bearer, ucans, DIDVerifier.CONVEX);
+		return withTransportAuth(rctx, bearer, ucans, venueDID, DIDVerifier.CONVEX);
+	}
+
+	/**
+	 * As {@link #withTransportAuth(RequestContext, AString, AVector, AString)},
+	 * verifying token signatures with the supplied DID verifier. Venue call
+	 * sites pass {@code engine.didVerifier()} so did:web-identified issuers
+	 * (covia#343) verify at ingress exactly like did:key ones; the
+	 * {@link DIDVerifier#CONVEX} default of the shorter overloads remains
+	 * did:key-only.
+	 */
+	public static RequestContext withTransportAuth(RequestContext rctx, AString bearer,
+			AVector<ACell> ucans, AString venueDID, DIDVerifier verifier) {
+		// Verify signatures at ingress with an explicit DID verifier.
+		AVector<ACell> proofs = UCANValidator.parseTransportUCANsWithBearer(bearer, ucans,
+			(verifier != null) ? verifier : DIDVerifier.CONVEX);
 		if (proofs == null) return rctx;
 
 		// Identity from the proof channel: only for an unauthenticated transport

--- a/venue/src/main/java/covia/venue/server/VenueServer.java
+++ b/venue/src/main/java/covia/venue/server/VenueServer.java
@@ -34,6 +34,7 @@ import convex.core.data.Blob;
 import convex.core.lang.RT;
 import convex.core.util.FileUtils;
 import convex.core.store.AStore;
+import convex.etch.EtchConfig;
 import convex.etch.EtchStore;
 import convex.core.data.prim.CVMLong;
 import convex.core.util.Utils;
@@ -243,7 +244,7 @@ public class VenueServer {
 	 * </ul>
 	 */
 	private static AStore createStore(Config config) throws IOException {
-		convex.etch.EtchConfig etchConfig = config.getEtchConfig();
+		EtchConfig etchConfig = config.getEtchConfig();
 		if (!config.isStoreConfigured()) {
 			log.warn("No 'store' configured — falling back to ephemeral temp Etch store; data will be deleted on JVM exit. Set 'store' to a file path for persistence, or to \"temp\"/\"memory\" to silence this warning.");
 			return (etchConfig != null) ? EtchStore.createTemp(etchConfig) : EtchStore.createTemp();
@@ -311,6 +312,7 @@ public class VenueServer {
 			Path keyFile = Path.of(storePath).resolveSibling("venue.key");
 			if (Files.exists(keyFile)) {
 				restrictVenueKeyPermissions(keyFile);
+				warnIfPlaintextKeyBesideEncryptedStore(config, keyFile);
 				String hex = Files.readString(keyFile).trim();
 				AKeyPair kp = AKeyPair.create(Blob.fromHex(hex));
 				log.info("Using venue identity from key file: {}", kp.getAccountKey());
@@ -331,6 +333,7 @@ public class VenueServer {
 			// First launch of a new persistent store: generate and save.
 			AKeyPair kp = AKeyPair.generate();
 			writeVenueKey(keyFile, kp.getSeed().toHexString());
+			warnIfPlaintextKeyBesideEncryptedStore(config, keyFile);
 			log.info("Generated venue identity (saved to {}): {}", keyFile, kp.getAccountKey());
 			return kp;
 		}
@@ -341,6 +344,21 @@ public class VenueServer {
 		AKeyPair kp = AKeyPair.generate();
 		log.info("Generated ephemeral venue identity: {}", kp.getAccountKey());
 		return kp;
+	}
+
+	/**
+	 * An encrypted Etch store with a plaintext {@code venue.key} beside it
+	 * protects the data but hands the venue <b>identity</b> to anyone holding
+	 * the disk — an inconsistent threat posture. Call it out so the operator
+	 * moves the identity seed to config/env or a keystore.
+	 */
+	private static void warnIfPlaintextKeyBesideEncryptedStore(Config config, Path keyFile) {
+		EtchConfig ec = config.getEtchConfig();
+		if (ec != null && ec.getCipherMode() != EtchConfig.CipherMode.NONE) {
+			log.warn("Venue identity seed sits in plaintext at {} beside an ENCRYPTED Etch store — "
+				+ "disk theft still yields the venue identity. Prefer 'seed' or a 'keystore' "
+				+ "in configuration, and remove the key file.", keyFile);
+		}
 	}
 
 	/** Creates a raw venue seed with owner-only POSIX permissions from birth. */

--- a/venue/src/main/java/covia/venue/server/VenueServer.java
+++ b/venue/src/main/java/covia/venue/server/VenueServer.java
@@ -243,24 +243,32 @@ public class VenueServer {
 	 * </ul>
 	 */
 	private static AStore createStore(Config config) throws IOException {
+		convex.etch.EtchConfig etchConfig = config.getEtchConfig();
 		if (!config.isStoreConfigured()) {
 			log.warn("No 'store' configured — falling back to ephemeral temp Etch store; data will be deleted on JVM exit. Set 'store' to a file path for persistence, or to \"temp\"/\"memory\" to silence this warning.");
-			return EtchStore.createTemp();
+			return (etchConfig != null) ? EtchStore.createTemp(etchConfig) : EtchStore.createTemp();
 		}
 		String storePath = config.getStore();
 		if ("memory".equals(storePath)) {
+			if (etchConfig != null) {
+				// An operator asking for encryption must never silently get an
+				// unencrypted (or non-Etch) store.
+				throw new IllegalArgumentException(
+					"'etch' configuration requires an Etch store; 'store: memory' is not one");
+			}
 			log.info("Using in-memory store (no persistence)");
 			return new convex.core.store.MemoryStore();
 		}
 		if ("temp".equals(storePath)) {
 			log.info("Using temporary Etch store (deleted on exit)");
-			return EtchStore.createTemp();
+			return (etchConfig != null) ? EtchStore.createTemp(etchConfig) : EtchStore.createTemp();
 		}
 		// Persistent file store
 		File f = new File(storePath).getAbsoluteFile();
 		f.getParentFile().mkdirs();
-		log.info("Using persistent Etch store: {}", f);
-		return EtchStore.create(f);
+		log.info("Using persistent Etch store: {}{}", f,
+			(etchConfig != null) ? " (configured Etch policy)" : "");
+		return (etchConfig != null) ? EtchStore.create(f, etchConfig) : EtchStore.create(f);
 	}
 
 	/**

--- a/venue/src/main/java/covia/venue/server/VenueServer.java
+++ b/venue/src/main/java/covia/venue/server/VenueServer.java
@@ -245,6 +245,13 @@ public class VenueServer {
 	 */
 	private static AStore createStore(Config config) throws IOException {
 		EtchConfig etchConfig = config.getEtchConfig();
+		if (etchConfig != null && etchConfig.getCipherMode() != EtchConfig.CipherMode.NONE
+				&& "file".equals(String.valueOf(config.getStorageType()))) {
+			log.warn("Encrypted Etch store with 'storage.content: file' — asset content bytes "
+				+ "are written OUTSIDE the encrypted store as plaintext files. Use lattice "
+				+ "content storage for an encrypted vault, or encrypt the content directory "
+				+ "separately.");
+		}
 		if (!config.isStoreConfigured()) {
 			log.warn("No 'store' configured — falling back to ephemeral temp Etch store; data will be deleted on JVM exit. Set 'store' to a file path for persistence, or to \"temp\"/\"memory\" to silence this warning.");
 			return (etchConfig != null) ? EtchStore.createTemp(etchConfig) : EtchStore.createTemp();

--- a/venue/src/test/java/covia/adapter/FileAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/FileAdapterTest.java
@@ -898,6 +898,64 @@ public class FileAdapterTest {
 	}
 
 	@Test
+	public void testDLFSBackedRootMoveAndCopyAreNative() {
+		// Convex 0.8.11 (#675/#677) implements DLFSProvider.move/copy, so the
+		// file: surface's direct NIO dispatch works natively on a DLFS root — a
+		// rename is a drive metadata operation, never a byte round-trip through
+		// the caller (covia#321).
+		Engine eng = Engine.createTemp(Maps.of(
+			Config.USERS, Maps.of(Config.AUTO_CREATE, true),
+			"file", Maps.of("roots", Maps.of(
+				"docs", Maps.of("dlfs", "docs-drive")
+			))
+		));
+		Engine.addDemoAssets(eng);
+		RequestContext ctx = RequestContext.of(convex.core.data.Strings.create(
+			"did:key:z6Mk-test-FileAdapterTest-dlfs-move"));
+
+		Job write = eng.jobs().invokeOperation("v/ops/file/write",
+			Maps.of("root", "docs", "path", "draft.txt", "content", "final text"), ctx);
+		write.awaitResult(2000);
+		assertEquals(Status.COMPLETE, write.getStatus());
+		eng.jobs().invokeOperation("v/ops/file/mkdir",
+			Maps.of("root", "docs", "path", "filed"), ctx).awaitResult(2000);
+
+		// Native move: source gone, destination carries the content.
+		Job move = eng.jobs().invokeOperation("v/ops/file/move",
+			Maps.of("root", "docs", "from", "draft.txt", "to", "filed/letter.txt"), ctx);
+		move.awaitResult(2000);
+		assertEquals(Status.COMPLETE, move.getStatus());
+		assertTrue(RT.bool(RT.getIn(move.getOutput(), "moved")));
+
+		Job readMoved = eng.jobs().invokeOperation("v/ops/file/read",
+			Maps.of("root", "docs", "path", "filed/letter.txt"), ctx);
+		readMoved.awaitResult(2000);
+		assertEquals("final text",
+			RT.ensureString(RT.getIn(readMoved.getOutput(), "content")).toString());
+
+		Job listRoot = eng.jobs().invokeOperation("v/ops/file/list",
+			Maps.of("root", "docs", "path", ""), ctx);
+		listRoot.awaitResult(2000);
+		AVector<?> entries = RT.ensureVector(RT.getIn(listRoot.getOutput(), "entries"));
+		assertEquals(1, entries.count(), "the moved source must be gone: " + entries);
+
+		// Native copy: both endpoints carry the content afterwards.
+		Job copy = eng.jobs().invokeOperation("v/ops/file/copy",
+			Maps.of("root", "docs", "from", "filed/letter.txt",
+				"to", "filed/letter-backup.txt"), ctx);
+		copy.awaitResult(2000);
+		assertEquals(Status.COMPLETE, copy.getStatus());
+		assertTrue(RT.bool(RT.getIn(copy.getOutput(), "copied")));
+		for (String p : new String[] {"filed/letter.txt", "filed/letter-backup.txt"}) {
+			Job read = eng.jobs().invokeOperation("v/ops/file/read",
+				Maps.of("root", "docs", "path", p), ctx);
+			read.awaitResult(2000);
+			assertEquals("final text",
+				RT.ensureString(RT.getIn(read.getOutput(), "content")).toString());
+		}
+	}
+
+	@Test
 	public void testDLFSSubpathRootConfinesPathsAndUsesLogicalCapabilities() {
 		Engine eng = Engine.createTemp(Maps.of(
 			Config.USERS, Maps.of(Config.AUTO_CREATE, true),

--- a/venue/src/test/java/covia/adapter/GridForwardingFilterTest.java
+++ b/venue/src/test/java/covia/adapter/GridForwardingFilterTest.java
@@ -54,7 +54,7 @@ public class GridForwardingFilterTest {
 		RequestContext ctx = ctxWith(BOB, grantToBob, identityForTarget);
 
 		List<String> out = GridAdapter.admissibleTokens(ctx,
-			GridAdapter.parsedRawUcans(ctx), BOB);
+			GridAdapter.parsedRawUcans(ctx, convex.auth.did.DIDVerifier.CONVEX), BOB);
 		assertNotNull(out);
 		assertEquals(2, out.size(), "both tokens are admissible in passthrough mode");
 	}
@@ -69,7 +69,7 @@ public class GridForwardingFilterTest {
 		RequestContext ctx = ctxWith(BOB, grantToBob, chainToVenue);
 
 		List<String> out = GridAdapter.admissibleTokens(ctx,
-			GridAdapter.parsedRawUcans(ctx), VENUE);
+			GridAdapter.parsedRawUcans(ctx, convex.auth.did.DIDVerifier.CONVEX), VENUE);
 		assertNotNull(out);
 		assertEquals(List.of(chainToVenue), out,
 			"only the venue-audienced token is relayed when the venue is the principal");
@@ -80,7 +80,7 @@ public class GridForwardingFilterTest {
 		String expired = token(aliceKP, BOB, ALICE + "/w/", "crud/read", -3600);
 		RequestContext ctx = ctxWith(BOB, expired, "not-a-jwt");
 		assertNull(GridAdapter.admissibleTokens(ctx,
-			GridAdapter.parsedRawUcans(ctx), BOB),
+			GridAdapter.parsedRawUcans(ctx, convex.auth.did.DIDVerifier.CONVEX), BOB),
 			"expired and unparseable tokens are provably inert — nothing to relay");
 	}
 
@@ -90,12 +90,12 @@ public class GridForwardingFilterTest {
 		// Bob presenting his own instruction → recognised.
 		RequestContext bobCtx = ctxWith(BOB, bobRelay);
 		assertTrue(GridAdapter.hasRelayInstruction(
-			GridAdapter.parsedRawUcans(bobCtx), BOB, VENUE));
+			GridAdapter.parsedRawUcans(bobCtx, convex.auth.did.DIDVerifier.CONVEX), BOB, VENUE));
 		// Carol presenting Bob's instruction → issuer != caller → not an instruction.
 		AString CAROL = UCAN.toDIDKey(AKeyPair.generate().getAccountKey());
 		RequestContext carolCtx = ctxWith(CAROL, bobRelay);
 		assertFalse(GridAdapter.hasRelayInstruction(
-			GridAdapter.parsedRawUcans(carolCtx), CAROL, VENUE));
+			GridAdapter.parsedRawUcans(carolCtx, convex.auth.did.DIDVerifier.CONVEX), CAROL, VENUE));
 	}
 
 	@Test
@@ -105,6 +105,6 @@ public class GridForwardingFilterTest {
 		String grantOnly = token(bobKP, VENUE, ALICE + "/w/", "crud/read", 3600);
 		RequestContext ctx = ctxWith(BOB, grantOnly);
 		assertFalse(GridAdapter.hasRelayInstruction(
-			GridAdapter.parsedRawUcans(ctx), BOB, VENUE));
+			GridAdapter.parsedRawUcans(ctx, convex.auth.did.DIDVerifier.CONVEX), BOB, VENUE));
 	}
 }

--- a/venue/src/test/java/covia/adapter/HITLAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/HITLAdapterTest.java
@@ -353,8 +353,7 @@ public class HITLAdapterTest {
 	}
 
 	@Test
-	public void testExplicitNullGrantExpiryUsesTemporaryFarFutureEncoding() {
-		long before = System.currentTimeMillis() / 1000;
+	public void testExplicitNullGrantExpiryMintsNonExpiringToken() {
 		Job job = request(ALICE, Hitl.request("g")
 			.ask(Hitl.approval("access", "Grant?")
 				.grant("w/reports/", "crud/read", (Long) null))
@@ -365,9 +364,8 @@ public class HITLAdapterTest {
 			.build());
 
 		UCAN token = UCAN.fromJWT(RT.ensureString(RT.getIn(job.getOutput(), Hitl.TOKEN)));
-		long lifetime = token.getExpiry() - before;
-		assertTrue(lifetime >= 98L * 365 * 24 * 60 * 60);
-		assertTrue(lifetime <= 100L * 365 * 24 * 60 * 60);
+		assertNull(token.getExpiry(),
+			"an explicit no-expiry grant mints a genuinely non-expiring token (Convex #678)");
 		assertNull(RT.getIn(job.getOutput(), Hitl.GRANTS, 0L, Hitl.EXP),
 			"the consent record retains the caller's explicit no-expiry intent");
 	}

--- a/venue/src/test/java/covia/venue/AudienceBoundAuthTest.java
+++ b/venue/src/test/java/covia/venue/AudienceBoundAuthTest.java
@@ -110,4 +110,26 @@ public class AudienceBoundAuthTest {
 			Maps.of(Fields.PATH, victimDID + "/" + path)),
 			"a signed sub claim alone must not grant access to that subject's workspace");
 	}
+
+	@Test
+	public void absentIssuerClaimIsAccepted() throws Exception {
+		// `iss` is OPTIONAL (RFC 7519): a did:key token without it still
+		// verifies — the subject's own key is the proof. (Note #323, closed by
+		// design: a mismatched `iss` is likewise not grounds for rejection —
+		// identity binds to the signing key, and admission is a separate gate.)
+		String venueDID = TestServer.ENGINE.getDIDString().toString();
+		AKeyPair kp = AKeyPair.generate();
+		AString subDID = UCAN.toDIDKey(kp.getAccountKey());
+		long now = System.currentTimeMillis() / 1000;
+		String token = JWT.signPublic(Maps.of(
+			JWT.SUB, subDID,
+			JWT.AUD, Strings.create(venueDID),
+			JWT.IAT, CVMLong.create(now),
+			JWT.EXP, CVMLong.create(now + 300)), kp).toString();
+		VenueHTTP client = VenueHTTP.create(
+			URI.create(TestServer.BASE_URL), VenueAuth.bearer(token));
+		Job job = client.invokeAndWait(Strings.create("v/test/ops/echo"),
+			Maps.of(Fields.VALUE, Strings.create("no-iss")));
+		assertEquals(Status.COMPLETE, job.getStatus());
+	}
 }

--- a/venue/src/test/java/covia/venue/EtchV3VenueTest.java
+++ b/venue/src/test/java/covia/venue/EtchV3VenueTest.java
@@ -1,0 +1,161 @@
+package covia.venue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import convex.core.data.ACell;
+import convex.core.data.AMap;
+import convex.core.data.AString;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import convex.core.data.prim.CVMLong;
+import convex.core.lang.RT;
+import covia.api.Fields;
+import covia.venue.server.VenueServer;
+
+/**
+ * Venue creation on a configured Etch store (covia `etch` config block,
+ * Convex 0.8.11): the operator's Etch creation policy — version, cipher,
+ * encryption key source — passes through to the store the venue opens.
+ * Covers the headline case: an <b>encrypted Etch v3</b> venue that persists
+ * across restarts, with fail-closed behaviour for a wrong or missing key.
+ */
+public class EtchV3VenueTest {
+
+	private static final String KEY_HEX =
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+	private static final String WRONG_KEY_HEX =
+		"20ff030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f01";
+	private static final String SEED_HEX =
+		"5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f";
+
+	private static AMap<AString, ACell> config(String storePath, String keyHex) {
+		AMap<AString, ACell> etch = Maps.of(
+			Strings.intern("version"), CVMLong.create(3),
+			Strings.intern("cipher"), Strings.create("aes-256-ctr"),
+			Strings.intern("encryptIndex"), true);
+		if (keyHex != null) etch = etch.assoc(Strings.intern("key"), Strings.create(keyHex));
+		return Maps.of(
+			Config.PORT, 0,
+			Config.STORE, Strings.create(storePath),
+			Config.SEED, Strings.create(SEED_HEX),
+			Config.ETCH, etch,
+			Config.USERS, Maps.of(Config.AUTO_CREATE, true));
+	}
+
+	@Test
+	public void encryptedEtchV3VenuePersistsAcrossRestart() throws Exception {
+		File dir = Files.createTempDirectory("etch-v3-venue").toFile();
+		String storePath = new File(dir, "venue.etch").getAbsolutePath().replace('\\', '/');
+		AString value = Strings.create("survives encrypted restart");
+		AString userDID = Strings.create("did:key:z6Mk-test-etch-v3");
+
+		VenueServer first = VenueServer.launch(config(storePath, KEY_HEX));
+		try {
+			first.getEngine().jobs().invokeInternal("v/ops/covia/write",
+				Maps.of(Fields.PATH, "w/etch-v3-proof", Fields.VALUE, value),
+				RequestContext.of(userDID)).get(5, TimeUnit.SECONDS);
+			first.getEngine().flush();
+		} finally {
+			first.close();
+		}
+		assertTrue(new File(storePath).exists(), "the store file must exist on disk");
+
+		// Same config, fresh venue: state must be readable through the
+		// encrypted store — proving the Etch policy applied on create AND open.
+		VenueServer second = VenueServer.launch(config(storePath, KEY_HEX));
+		try {
+			ACell read = second.getEngine().jobs().invokeInternal("v/ops/covia/read",
+				Maps.of(Fields.PATH, "w/etch-v3-proof"),
+				RequestContext.of(userDID)).get(5, TimeUnit.SECONDS);
+			assertEquals(value, RT.getIn(read, Fields.VALUE),
+				"workspace state must survive an encrypted Etch v3 restart");
+		} finally {
+			second.close();
+		}
+	}
+
+	@Test
+	public void wrongKeyAndPlainOpenFailClosed() throws Exception {
+		File dir = Files.createTempDirectory("etch-v3-keys").toFile();
+		String storePath = new File(dir, "venue.etch").getAbsolutePath().replace('\\', '/');
+
+		VenueServer server = VenueServer.launch(config(storePath, KEY_HEX));
+		try {
+			server.getEngine().flush();
+		} finally {
+			server.close();
+		}
+
+		// Wrong key must never open the store as if empty or corrupt it.
+		assertThrows(Exception.class,
+			() -> VenueServer.launch(config(storePath, WRONG_KEY_HEX)).close(),
+			"a wrong Etch encryption key must fail the launch");
+
+		// Opening without any etch policy must not succeed either — the file
+		// is encrypted, and a silent plain open would be a downgrade.
+		assertThrows(Exception.class,
+			() -> VenueServer.launch(Maps.of(
+				Config.PORT, 0,
+				Config.STORE, Strings.create(storePath),
+				Config.SEED, Strings.create(SEED_HEX))).close(),
+			"an encrypted store must not open without its key");
+
+		// The right key still works after the failed attempts.
+		VenueServer again = VenueServer.launch(config(storePath, KEY_HEX));
+		again.close();
+	}
+
+	@Test
+	public void encryptedTempStoreVenueLaunches() throws Exception {
+		// The etch policy applies to "temp" stores too — useful for ephemeral
+		// venues handling sensitive data.
+		AMap<AString, ACell> cfg = config("temp", KEY_HEX);
+		VenueServer server = VenueServer.launch(cfg);
+		try {
+			ACell echo = server.getEngine().jobs().invokeInternal("v/test/ops/echo",
+				Maps.of(Fields.VALUE, "encrypted temp"),
+				RequestContext.of(Strings.create("did:key:z6Mk-test-etch-temp")))
+				.get(5, TimeUnit.SECONDS);
+			assertEquals(Strings.create("encrypted temp"), RT.getIn(echo, Fields.VALUE));
+		} finally {
+			server.close();
+		}
+	}
+
+	@Test
+	public void etchConfigIsRejectedForMemoryStores() {
+		assertThrows(Exception.class, () -> VenueServer.launch(Maps.of(
+			Config.PORT, 0,
+			Config.STORE, Strings.create("memory"),
+			Config.ETCH, Maps.of(Strings.intern("version"), CVMLong.create(3)))).close(),
+			"an etch policy on a non-Etch store must fail closed");
+	}
+
+	@Test
+	public void malformedEtchConfigFailsAtConstruction() {
+		// Unknown cipher
+		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
+			Config.ETCH, Maps.of(Strings.intern("cipher"), Strings.create("rot13")))));
+		// Encryption without a key source
+		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
+			Config.ETCH, Maps.of(Strings.intern("cipher"), Strings.create("aes-256-ctr")))));
+		// Key of the wrong size
+		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
+			Config.ETCH, Maps.of(
+				Strings.intern("cipher"), Strings.create("aes-256-ctr"),
+				Strings.intern("key"), Strings.create("abcd")))));
+		// Malformed key source shape
+		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
+			Config.ETCH, Maps.of(
+				Strings.intern("cipher"), Strings.create("aes-256-ctr"),
+				Strings.intern("key"), Maps.of(Strings.intern("wat"), Strings.create("x"))))));
+	}
+}

--- a/venue/src/test/java/covia/venue/EtchV3VenueTest.java
+++ b/venue/src/test/java/covia/venue/EtchV3VenueTest.java
@@ -178,9 +178,6 @@ public class EtchV3VenueTest {
 		// Unknown cipher
 		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
 			Config.ETCH, Maps.of(Strings.intern("cipher"), Strings.create("rot13")))));
-		// Encryption without a key source
-		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
-			Config.ETCH, Maps.of(Strings.intern("cipher"), Strings.create("aes-256-ctr")))));
 		// Key of the wrong size
 		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
 			Config.ETCH, Maps.of(
@@ -191,5 +188,81 @@ public class EtchV3VenueTest {
 			Config.ETCH, Maps.of(
 				Strings.intern("cipher"), Strings.create("aes-256-ctr"),
 				Strings.intern("key"), Maps.of(Strings.intern("wat"), Strings.create("x"))))));
+	}
+
+	@Test
+	public void encryptionWithoutAnyKeySourceConstructsButFailsOperatorLaunch() {
+		// An embedder may supply the key function at runtime, so construction
+		// tolerates a keyless encrypted policy — but an operator launch (no
+		// adopted store, no function) still fails closed at store creation.
+		AMap<AString, ACell> keyless = Maps.of(
+			Config.PORT, 0,
+			Config.STORE, Strings.create("temp"),
+			Config.ETCH, Maps.of(
+				Strings.intern("version"), CVMLong.create(3),
+				Strings.intern("cipher"), Strings.create("aes-256-ctr")));
+		new Config(keyless); // constructs — embedder path stays open
+		assertThrows(Exception.class, () -> VenueServer.launch(keyless).close(),
+			"an encrypted policy with no key source must fail an operator launch");
+	}
+
+	@Test
+	public void configKeyAndEmbedderFunctionAreMutuallyExclusive() {
+		Config cfg = new Config(Maps.of(Config.ETCH, Maps.of(
+			Strings.intern("version"), CVMLong.create(3),
+			Strings.intern("cipher"), Strings.create("aes-256-ctr"),
+			Strings.intern("key"), Strings.create(KEY_HEX))));
+		assertThrows(RuntimeException.class,
+			() -> cfg.getEtchConfig(hint -> new byte[32]),
+			"two key sources is an ambiguity, not a fallback chain");
+	}
+
+	@Test
+	public void embedderSuppliedKeyFunctionAndAdoptedStoreWork() throws Exception {
+		// The embedder vault shape (e.g. GetMine): key material lives in the
+		// embedder's code (KMS / passphrase-derived), the etch policy compiles
+		// with a key FUNCTION, the embedder opens the store itself and adopts
+		// it into the venue. No key ever touches config, env, or disk.
+		File dir = Files.createTempDirectory("etch-v3-embedder").toFile();
+		File storeFile = new File(dir, "vault.etch");
+		byte[] vaultKey = convex.core.data.Blob.fromHex(KEY_HEX).getBytes();
+
+		AMap<AString, ACell> etchPolicy = Maps.of(
+			Strings.intern("version"), CVMLong.create(3),
+			Strings.intern("cipher"), Strings.create("chacha20"),
+			Strings.intern("encryptIndex"), true);
+		AMap<AString, ACell> venueConfig = Maps.of(
+			Config.PORT, 0,
+			Config.SEED, Strings.create(SEED_HEX),
+			Config.USERS, Maps.of(Config.AUTO_CREATE, true));
+		AString userDID = Strings.create("did:key:z6Mk-test-embedder-vault");
+		AString value = Strings.create("vault contents");
+
+		convex.etch.EtchConfig policy = new Config(Maps.of(Config.ETCH, etchPolicy))
+			.getEtchConfig(hint -> vaultKey);
+		VenueServer first = VenueServer.launch(venueConfig,
+			convex.etch.EtchStore.create(storeFile, policy));
+		try {
+			first.getEngine().jobs().invokeInternal("v/ops/covia/write",
+				Maps.of(Fields.PATH, "w/vault-entry", Fields.VALUE, value),
+				RequestContext.of(userDID)).get(5, TimeUnit.SECONDS);
+			first.getEngine().flush();
+		} finally {
+			first.close();
+		}
+
+		convex.etch.EtchConfig reopenPolicy = new Config(Maps.of(Config.ETCH, etchPolicy))
+			.getEtchConfig(hint -> vaultKey);
+		VenueServer second = VenueServer.launch(venueConfig,
+			convex.etch.EtchStore.create(storeFile, reopenPolicy));
+		try {
+			ACell read = second.getEngine().jobs().invokeInternal("v/ops/covia/read",
+				Maps.of(Fields.PATH, "w/vault-entry"),
+				RequestContext.of(userDID)).get(5, TimeUnit.SECONDS);
+			assertEquals(value, RT.getIn(read, Fields.VALUE),
+				"the embedder-keyed encrypted vault must persist across venue restarts");
+		} finally {
+			second.close();
+		}
 	}
 }

--- a/venue/src/test/java/covia/venue/EtchV3VenueTest.java
+++ b/venue/src/test/java/covia/venue/EtchV3VenueTest.java
@@ -94,10 +94,14 @@ public class EtchV3VenueTest {
 			server.close();
 		}
 
-		// Wrong key must never open the store as if empty or corrupt it.
-		assertThrows(Exception.class,
+		// Wrong key must never open the store as if empty or corrupt it — and
+		// the failure is at key IDENTIFICATION (the file's public-key hint vs
+		// the configured key's derived identity), not a decrypt failure.
+		Exception wrongKey = assertThrows(Exception.class,
 			() -> VenueServer.launch(config(storePath, WRONG_KEY_HEX)).close(),
 			"a wrong Etch encryption key must fail the launch");
+		assertTrue(failureContains(wrongKey, "encrypted under key"),
+			"wrong key must fail at hint identification with a diagnostic, got: " + wrongKey);
 
 		// Opening without any etch policy must not succeed either — the file
 		// is encrypted, and a silent plain open would be a downgrade.
@@ -111,6 +115,36 @@ public class EtchV3VenueTest {
 		// The right key still works after the failed attempts.
 		VenueServer again = VenueServer.launch(config(storePath, KEY_HEX));
 		again.close();
+	}
+
+	private static boolean failureContains(Throwable failure, String text) {
+		for (Throwable current = failure; current != null; current = current.getCause()) {
+			if (String.valueOf(current.getMessage()).contains(text)) return true;
+		}
+		return false;
+	}
+
+	@Test
+	public void operatorPinnedHintOverridesTheDerivedIdentity() throws Exception {
+		// An explicit publicKeyHint passes through as-is: the file is stamped
+		// with the operator's label and the key function verifies against it,
+		// so create → reopen round-trips under the pinned hint.
+		File dir = Files.createTempDirectory("etch-v3-hint").toFile();
+		String storePath = new File(dir, "venue.etch").getAbsolutePath().replace('\\', '/');
+		String pinnedHint =
+			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+		java.util.function.Function<String, AMap<AString, ACell>> cfg = path -> Maps.of(
+			Config.PORT, 0,
+			Config.STORE, Strings.create(path),
+			Config.SEED, Strings.create(SEED_HEX),
+			Config.ETCH, Maps.of(
+				Strings.intern("version"), CVMLong.create(3),
+				Strings.intern("cipher"), Strings.create("aes-256-ctr"),
+				Strings.intern("publicKeyHint"), Strings.create(pinnedHint),
+				Strings.intern("key"), Strings.create(KEY_HEX)));
+		VenueServer.launch(cfg.apply(storePath)).close();
+		VenueServer reopened = VenueServer.launch(cfg.apply(storePath));
+		reopened.close();
 	}
 
 	@Test

--- a/venue/src/test/java/covia/venue/NamedUserAuthTest.java
+++ b/venue/src/test/java/covia/venue/NamedUserAuthTest.java
@@ -167,6 +167,35 @@ public class NamedUserAuthTest {
 		assertTrue(duplicate.getCause().getMessage().contains("already bound"));
 	}
 
+	@Test
+	void expiredAndNotYetValidTokensAreRejected() {
+		AString venueDID = server.getEngine().getDIDString();
+		long now = System.currentTimeMillis() / 1000;
+		// Expired, beyond the clock-skew leeway.
+		assertRejected(JWT.signPublic(Maps.of(
+			JWT.SUB, aliceDID, JWT.ISS, aliceDID, JWT.AUD, venueDID,
+			JWT.IAT, CVMLong.create(now - 900),
+			JWT.EXP, CVMLong.create(now - 300)), aliceKey).toString());
+		// Not yet valid: nbf in the future.
+		assertRejected(JWT.signPublic(Maps.of(
+			JWT.SUB, aliceDID, JWT.ISS, aliceDID, JWT.AUD, venueDID,
+			JWT.NBF, CVMLong.create(now + 300),
+			JWT.IAT, CVMLong.create(now),
+			JWT.EXP, CVMLong.create(now + 600)), aliceKey).toString());
+	}
+
+	@Test
+	void namedTokenWithoutIssuerIsRejected() {
+		// A named-user self-issued token REQUIRES iss == sub (#296); iss is
+		// optional only for did:key subjects.
+		long now = System.currentTimeMillis() / 1000;
+		assertRejected(JWT.signPublic(Maps.of(
+			JWT.SUB, aliceDID,
+			JWT.AUD, server.getEngine().getDIDString(),
+			JWT.IAT, CVMLong.create(now),
+			JWT.EXP, CVMLong.create(now + 300)), aliceKey).toString());
+	}
+
 	private String namedToken(AKeyPair key, AString sub, AString iss, AString audience) {
 		long now = System.currentTimeMillis() / 1000;
 		return JWT.signPublic(Maps.of(

--- a/venue/src/test/java/covia/venue/UCANTest.java
+++ b/venue/src/test/java/covia/venue/UCANTest.java
@@ -134,7 +134,7 @@ public class UCANTest {
 	}
 
 	@Test
-	public void testIssueExplicitNullExpiryUsesTemporaryFarFutureEncoding() {
+	public void testIssueExplicitNullExpiryMintsNonExpiringToken() {
 		long before = System.currentTimeMillis() / 1000;
 		Job job = engine.jobs().invokeOperation("v/ops/ucan/issue",
 			Maps.of(
@@ -147,18 +147,16 @@ public class UCANTest {
 		AString jwt = RT.ensureString(RT.getIn(job.awaitResult(5000), "token"));
 		UCAN parsed = UCAN.fromJWT(jwt);
 		assertNotNull(parsed);
-		long lifetime = parsed.getExpiry() - before;
-		assertTrue(lifetime >= 98L * 365 * 24 * 60 * 60,
-			"exp:null must produce a practically non-expiring token during the Convex #678 workaround");
-		assertTrue(lifetime <= 100L * 365 * 24 * 60 * 60,
-			"the workaround must remain an intentional 99-year approximation, not an arbitrary sentinel");
+		assertNull(parsed.getExpiry(),
+			"exp:null must mint a genuinely non-expiring token (Convex #678, covia#322)");
 		assertNotNull(UCANValidator.validateJWT(jwt, before),
-			"the temporary encoding must remain usable by the current Convex validator");
+			"a non-expiring token must validate now");
+		assertNotNull(UCANValidator.validateJWT(jwt, Long.MAX_VALUE - 1),
+			"a non-expiring token must validate at any future horizon");
 	}
 
 	@Test
 	public void testIssueMissingExpiryDefaultsToNoExpiry() {
-		long before = System.currentTimeMillis() / 1000;
 		Job job = engine.jobs().invokeOperation("v/ops/ucan/issue",
 			Maps.of(
 				UCAN.AUD, BOB_DID,
@@ -167,10 +165,9 @@ public class UCANTest {
 			CUSTODIAL);
 		AString jwt = RT.ensureString(RT.getIn(job.awaitResult(5000), "token"));
 		UCAN parsed = UCAN.fromJWT(jwt);
-		long lifetime = parsed.getExpiry() - before;
-		assertTrue(lifetime >= 98L * 365 * 24 * 60 * 60);
-		assertTrue(lifetime <= 100L * 365 * 24 * 60 * 60,
-			"omitted API input must emit the same strict 99-year compatibility expiry as null");
+		assertNotNull(parsed);
+		assertNull(parsed.getExpiry(),
+			"omitted API input mints the same explicit exp: null as an explicit null");
 	}
 
 	@Test

--- a/venue/src/test/java/covia/venue/VenueIdentityTest.java
+++ b/venue/src/test/java/covia/venue/VenueIdentityTest.java
@@ -1,0 +1,230 @@
+package covia.venue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import convex.core.crypto.AKeyPair;
+import convex.core.crypto.util.Multikey;
+import convex.core.data.ACell;
+import convex.core.data.AString;
+import convex.core.data.Maps;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+import convex.core.lang.RT;
+import covia.api.Fields;
+import covia.grid.Job;
+import covia.grid.Status;
+import covia.grid.auth.VenueAuth;
+import covia.grid.client.VenueHTTP;
+import covia.venue.auth.VenueDIDVerifier;
+import covia.venue.server.VenueServer;
+
+/**
+ * Operator-declared venue identity (covia#343): a venue with a public hostname
+ * may declare {@code did:web:<hostname>} as its identity via the {@code did}
+ * config key; declarations are validated fail-closed, and did:web-identified
+ * principals verify at every ingress seam exactly like did:key ones.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+public class VenueIdentityTest {
+
+	private static final String HOST = "identity.example";
+	private static final AString WEB_DID = Strings.create("did:web:" + HOST);
+
+	private VenueServer server;
+	private AKeyPair venueKey;
+	private AKeyPair userKey;
+
+	/** Deterministic 32-byte seed so the test knows the venue's key pair. */
+	private static String seedHex(int fill) {
+		byte[] seed = new byte[32];
+		java.util.Arrays.fill(seed, (byte) fill);
+		return convex.core.data.Blob.wrap(seed).toHexString();
+	}
+
+	@BeforeAll
+	void setup() {
+		String seed = seedHex(0x51);
+		venueKey = AKeyPair.create(convex.core.data.Blob.fromHex(seed));
+		userKey = AKeyPair.generate();
+		server = VenueServer.launch(Maps.of(
+			Config.PORT, 0,
+			Config.HOSTNAME, HOST,
+			Config.DID, WEB_DID,
+			Config.SEED, Strings.create(seed),
+			Config.AUTH, Maps.of(Config.PUBLIC, Maps.of(Config.ENABLED, false)),
+			Config.USERS, Maps.of(
+				Config.AUTO_CREATE, true,
+				Config.BOOTSTRAP, Maps.of("sabine", Maps.of(
+					Fields.AUTHENTICATION_KEYS, Vectors.of(Strings.create("did:key:"
+						+ Multikey.encodePublicKey(userKey.getAccountKey()))))))));
+	}
+
+	@AfterAll
+	void close() {
+		if (server != null) server.close();
+	}
+
+	// ========== Declaration ==========
+
+	@Test
+	void declaredWebDidIsTheVenueIdentity() {
+		assertEquals(WEB_DID, server.getEngine().getDIDString());
+		assertEquals(WEB_DID.toString(), server.getEngine().getDID().toString());
+	}
+
+	@Test
+	void didDocumentPresentsTheDeclaredIdentity() {
+		ACell ddo = server.getEngine().getDIDDocument("https://" + HOST + "/api/v1");
+		assertEquals(WEB_DID, RT.getIn(ddo, "id"));
+		// Identity == did:web, so there is no alias and no alsoKnownAs entry:
+		// the did:key appears only as key material in verificationMethod.
+		assertNull(RT.getIn(ddo, "alsoKnownAs"));
+	}
+
+	// ========== Config validation (fail closed) ==========
+
+	@Test
+	void mismatchedWebHostIsRejected() {
+		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
+			Config.HOSTNAME, HOST,
+			Config.DID, Strings.create("did:web:other.example"))));
+	}
+
+	@Test
+	void nonPublicWebHostIsRejected() {
+		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
+			Config.HOSTNAME, "localhost",
+			Config.DID, Strings.create("did:web:localhost"))));
+	}
+
+	@Test
+	void pathSegmentsInDeclaredWebDidAreRejected() {
+		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
+			Config.HOSTNAME, HOST,
+			Config.DID, Strings.create("did:web:" + HOST + ":u:alice"))));
+	}
+
+	@Test
+	void unsupportedMethodAndMalformedKeyAreRejected() {
+		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
+			Config.DID, Strings.create("did:example:12345"))));
+		assertThrows(RuntimeException.class, () -> new Config(Maps.of(
+			Config.DID, Strings.create("did:key:not-a-multikey"))));
+	}
+
+	@Test
+	void declaredKeyDidMustMatchTheVenueKeyPair() {
+		AString foreign = Strings.create("did:key:"
+			+ Multikey.encodePublicKey(AKeyPair.generate().getAccountKey()));
+		assertThrows(RuntimeException.class, () -> VenueServer.launch(Maps.of(
+			Config.PORT, 0,
+			Config.SEED, Strings.create(seedHex(0x52)),
+			Config.DID, foreign)),
+			"a did:key identity pin must refuse a mismatched key pair");
+	}
+
+	@Test
+	void matchingKeyDidPinIsAccepted() {
+		String seed = seedHex(0x53);
+		AKeyPair kp = AKeyPair.create(convex.core.data.Blob.fromHex(seed));
+		AString pinned = Strings.create("did:key:"
+			+ Multikey.encodePublicKey(kp.getAccountKey()));
+		VenueServer pinnedServer = VenueServer.launch(Maps.of(
+			Config.PORT, 0,
+			Config.SEED, Strings.create(seed),
+			Config.DID, pinned));
+		try {
+			assertEquals(pinned, pinnedServer.getEngine().getDIDString());
+		} finally {
+			pinnedServer.close();
+		}
+	}
+
+	// ========== Verification through the identity ==========
+
+	// NOTE: the ucan:issue → ucan:verify roundtrip under a did:web identity is
+	// deliberately not tested here — venue minting still hand-rolls its JWTs,
+	// and migrating it to the Convex UCAN profile API is covia#322. These tests
+	// pin the Phase A surface: the verifier resolves did:web principals.
+
+	@Test
+	void venueWebIdentityVerifiesVenueSignatures() {
+		VenueDIDVerifier verifier = server.getEngine().didVerifier();
+		convex.core.data.Blob message = convex.core.data.Blob.wrap(
+			"venue identity proof".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+		convex.core.data.Blob sig = venueKey.sign(message).toFlatBlob();
+		assertTrue(verifier.verifies(WEB_DID, message, sig),
+			"the declared did:web identity must verify the venue's own signatures");
+		// The key-derived form verifies identically (stateless did:key path).
+		AString keyForm = Strings.create("did:key:"
+			+ Multikey.encodePublicKey(venueKey.getAccountKey()));
+		assertTrue(verifier.verifies(keyForm, message, sig));
+		// A foreign key's signature must not verify as the venue.
+		convex.core.data.Blob forged = AKeyPair.generate().sign(message).toFlatBlob();
+		assertTrue(!verifier.verifies(WEB_DID, message, forged));
+	}
+
+	@Test
+	void managedUserWebDidVerifiesRegisteredKeys() {
+		VenueDIDVerifier verifier = server.getEngine().didVerifier();
+		AString userDID = server.getEngine().managedUserDID(Strings.create("sabine"));
+		convex.core.data.Blob message = convex.core.data.Blob.wrap(
+			"user proof".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+		assertTrue(verifier.verifies(userDID, message, userKey.sign(message).toFlatBlob()),
+			"a managed user's did:web must verify against their active registered key");
+		assertTrue(!verifier.verifies(userDID, message,
+			AKeyPair.generate().sign(message).toFlatBlob()),
+			"an unregistered key must not verify as the managed user");
+	}
+
+	@Test
+	void clientsMayAudienceBindToEitherPublishedForm() throws Exception {
+		String keyForm = "did:key:" + Multikey.encodePublicKey(venueKey.getAccountKey());
+		assertEchoWorks(VenueAuth.keyPair(AKeyPair.generate(), WEB_DID.toString()));
+		assertEchoWorks(VenueAuth.keyPair(AKeyPair.generate(), keyForm));
+	}
+
+	private void assertEchoWorks(VenueAuth auth) throws Exception {
+		VenueHTTP client = VenueHTTP.create(
+			URI.create("http://localhost:" + server.port()), auth);
+		client.setTimeout(5000);
+		Job job = client.invokeAndWait(Strings.create("v/test/ops/echo"),
+			Maps.of(Fields.VALUE, Strings.create("identity")));
+		assertEquals(Status.COMPLETE, job.getStatus());
+	}
+
+	// ========== did:web resolution URL (SSRF containment) ==========
+
+	@Test
+	void didWebDocumentUrlFollowsTheResolutionAlgorithm() {
+		assertEquals("https://venue.example/.well-known/did.json",
+			VenueDIDVerifier.didWebDocumentURL("did:web:venue.example"));
+		assertEquals("https://venue.example/u/alice/did.json",
+			VenueDIDVerifier.didWebDocumentURL("did:web:venue.example:u:alice"));
+		assertNull(VenueDIDVerifier.didWebDocumentURL("did:web:localhost"));
+		assertNull(VenueDIDVerifier.didWebDocumentURL("did:web:127.0.0.1"));
+		assertNull(VenueDIDVerifier.didWebDocumentURL("did:web:venue.example:"));
+		assertNull(VenueDIDVerifier.didWebDocumentURL("did:key:z6Mk"));
+		assertNull(VenueDIDVerifier.didWebDocumentURL(null));
+	}
+
+	@Test
+	void verifierFailsClosedOnUnknownMethods() {
+		VenueDIDVerifier verifier = server.getEngine().didVerifier();
+		assertTrue(!verifier.verifies(Strings.create("did:example:zzz"),
+			convex.core.data.Blob.wrap(new byte[] {1}),
+			convex.core.data.Blob.wrap(new byte[64])));
+		assertTrue(!verifier.verifies(null, null, null));
+	}
+}


### PR DESCRIPTION
Nine commits spanning the 0.8.11 update cycle and the venue-identity work:

## Convex 0.8.11 (#322, #321)
- Pin **released Convex 0.8.11** (build reproducible from Maven Central again)
- `ucan:issue` mints the Convex UCAN JWT profile natively: explicit `exp: null` = non-expiring (UCAN v0.10.0), 99-year workaround removed, unbounded-horizon granting-right check (a non-expiring mint requires a non-expiring enabling right)
- Native DLFS move/copy verified end-to-end on the `file:` surface (drive metadata operation, no byte round-trip)

## Venue identity (#343 Phase 0 + A)
- No consumer rebinding: the presented DID is the identity; `alsoKnownAs` is informational
- The `did` config key validated fail-closed (did:web must match the public hostname; did:key pins the venue key pair — wrong seed refuses to start)
- `VenueDIDVerifier` resolves did:web principals at every ingress seam (own identity + managed users from venue state; remote did:web via cached HTTPS resolution, SSRF-contained); key-derived did:key always remains an accepted audience

## Auth design (#297) and #296 closeout
- `venue/docs/AUTH.md`: agreed authentication design — AuthResult contract, embedder-extensible method registry, opaque `covia_` sessions with per-user records, single login endpoint with single-use codes, RFC 9470 step-up, standard/strong/hard assurance ladder (NIST-mapped), (issuer, subject) provider binding
- #296 acceptance negatives (expired, nbf-future, missing-iss) — mismatched `iss` stays accepted by design (#323, closed)

## Docs and semantics
- UCAN temporal model documented: execution-time validity (UCAN 1.0), time bounds are not attenuation; containment only at granting surfaces
- COG-19 comment fixes; CHANGELOG, AGENTS.md, DX_PLAN version updates

Full suite green against 0.8.11 (2068 tests; two pre-existing timing flakes pass in isolation: `LLMAgentAdapterTest.testScopedInvokeDeniesOutOfScopeTool`, `A2AAgentCardTest.longTurnReattachesAndPollingConvergesWithSse`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)