### PR TITLE
docs: reconcile 0.9.0 release status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ covia/                          # ai.covia:covia (parent POM)
 │       ├── grid/auth/          #   Auth strategies: NoAuth, BearerAuth, KeyPairAuth, LocalAuth
 │       ├── grid/client/        #   HTTP client implementation (VenueHTTP)
 │       └── grid/impl/          #   Content implementations (BlobContent, LatticeContent)
+├── covia-python/               # Dependency-light Java FFM bridge to embedded CPython
+├── covia-python-adapter/       # Optional Python operations venue module
+│                               #   (shaded "module" jar, not in covia.jar)
 ├── venue/                      # Main venue server runtime (produces covia.jar)
 │   └── src/main/java/covia/
 │       ├── adapter/            #   Adapter framework and implementations
@@ -96,7 +99,7 @@ mvn test -pl covia-core
 | MCP SDK | 2.0.0 | Model Context Protocol |
 | A2A | 1.2.0.Final | Agent-to-Agent protocol |
 | JUnit | 6.1.3 | Testing |
-| SLF4J/Logback | 2.0.18/1.6.0 | Logging |
+| SLF4J/Logback | 2.0.18/1.6.1 | Logging |
 
 ## Architecture Overview
 
@@ -220,16 +223,17 @@ The list below tracks engineering tasks. For the developer-experience and open-s
 - [ ] **Wire LatticeContent into pinned content-addressable storage** — the `AContent` view over content pinned in the lattice `:data` region (content rides state replication, addressed by hash; pairs with `asset:pin`). Implemented and unit-tested; awaiting its consumer in the storage backend / client SDK.
   - File: `covia-core/.../grid/impl/LatticeContent.java`
 
-- [ ] **Add VenueHTTP test coverage** — HTTP client layer has zero tests. Cover invoke, polling, content upload/download, error handling.
+- [x] **Add VenueHTTP test coverage** — real-venue contract tests cover direct run, status, polling and caller-side timeouts, content round-trips, concurrent use, authentication, and error paths. Deterministic client tests cover 429 retry/backoff behavior.
+  - Files: `venue/src/test/java/covia/grid/client/VenueHTTPTest.java`, `covia-core/src/test/java/covia/grid/client/VenueHTTPRetryTest.java`
+
+- [ ] **Complete auth strategy tests** — `KeyPairAuth` has deterministic claim/signing tests, bearer authentication and rejection paths run against real venues, and unsupported token minting is covered. Remaining: focused constructor/header tests for `NoAuth` and `BearerAuth`, plus `LocalAuth` DID propagation and no-header behavior (the local strategy is in-process and should not be tested as HTTP authentication).
   - Directory: `covia-core/src/test/java/`
 
-- [ ] **Add auth strategy tests** — No tests for BearerAuth, KeyPairAuth, NoAuth, LocalAuth.
-  - Directory: `covia-core/src/test/java/`
+- [x] **Add SSRF and CORS regression coverage** — HTTPAdapter allow/block policy, private/loopback targets, invalid schemes, configured CORS origins, loopback/PNA behavior, and disabled CORS are covered.
+  - Files: `venue/src/test/java/covia/adapter/http/HTTPTest.java`, `venue/src/test/java/covia/venue/VenueServerTest.java`
 
-- [ ] **Add missing test coverage** — Several implemented features lack dedicated tests:
-  - SSRF protection in HTTPAdapter (URL allowlist/blocklist validation)
-  - CORS configuration (`Config.CORS`)
-  - /config endpoint redaction (public info only)
+- [ ] **Add remaining focused test coverage**:
+  - `/config` page redaction (public info only)
   - LangChainAdapter IO timeout
   - Thread safety of `Asset.meta()` (concurrent access)
 
@@ -245,7 +249,7 @@ The list below tracks engineering tasks. For the developer-experience and open-s
 - [ ] **Capability negotiation** — Discovery endpoint for venue capabilities via DID documents
 - [ ] **Signed operations** — Cryptographic attribution for every job submission
 - [ ] **Compliance reporting** — Data lineage tracking and audit log queries
-- [ ] **Workbench expansion** — Currently 3 files / 180 LOC demo; add configuration, multi-operation support, proper logging
+- [ ] **Workbench expansion** — Currently a 3-file / ~155-line demo; add configuration, multi-operation support, proper logging
 - [ ] **Job restart API** — Consider `PUT /api/v1/jobs/{id}/restart` for re-running failed/cancelled/completed jobs. Semantics need thought: new job with same input? Same job ID? How to handle operations that have changed since original invocation? May be better as a client-side convenience (re-invoke with original params) rather than a server primitive.
 
 ## Module-Specific Guides

--- a/BUILD.md
+++ b/BUILD.md
@@ -33,11 +33,13 @@ covia/
 │       ├── main/resources/ # Resources and assets
 │       └── test/java/     # Test source code
 ├── workbench/             # GUI workbench module
-    ├── pom.xml            # Workbench module POM
-    └── src/
-        ├── main/java/     # GUI source code
-        └── main/resources/ # GUI resources
-└── covia-sql/              # Optional loadable SQL adapter module
+│   ├── pom.xml            # Workbench module POM
+│   └── src/
+│       ├── main/java/     # GUI source code
+│       └── main/resources/ # GUI resources
+└── covia-sql/             # Optional loadable SQL adapter module
+    ├── pom.xml            # Venue SPI provided; shaded module classifier
+    └── src/               # SQL operation adapter and tests
 ```
 
 The standard venue does not depend on either Python module. A Java 21 reactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Covia is pre-1.0, so minor versions may include breaking changes.
 
+## [Unreleased]
+
+### Changed
+
+- Reconciled the engineering and DX roadmaps with the 0.9.0 codebase: current
+  artifact versions, shipped VenueHTTP/SSRF/CORS test coverage, narrowed auth
+  and focused-test gaps, resolved Java baseline, and per-caller rate limiting.
+- Made deployment and optional-module examples version-neutral, refreshed the
+  module maps and contribution link, and removed obsolete A2A limitations that
+  shipped in 0.9.0.
+
 ## [0.9.0] - 2026-08-10
 
 Breaking: UCAN JWTs now use the versioned Convex profile (Convex 0.8.11) —
@@ -368,6 +379,7 @@ Initial public release: venue server with the adapter framework, lattice-backed
 content-addressed assets, the async job model with SSE, multi-protocol surface
 (REST / MCP / A2A / DID), and strategy-based authentication.
 
+[Unreleased]: https://github.com/covia-ai/covia/compare/0.9.0...HEAD
 [0.9.0]: https://github.com/covia-ai/covia/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/covia-ai/covia/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/covia-ai/covia/compare/0.6.0...0.7.0

--- a/DX_PLAN.md
+++ b/DX_PLAN.md
@@ -2,7 +2,7 @@
 
 This is our shared, public roadmap for making Covia a joy to **adopt, build on, self-host, and contribute to**. It's deliberately open: if something here resonates, pick it up; if you think we've got a priority wrong, [open a discussion](https://github.com/orgs/covia-ai/discussions) or say so on [Discord](https://discord.gg/fywdrKd8QT). Nothing in this document is set in stone — it's a conversation.
 
-> **TL;DR for the impatient:** the Covia *engine* is in good shape — clean adapter architecture, a real lattice foundation, multi-protocol surface (REST / MCP / A2A / DID), 2,000+ passing tests gating every PR, and published Java, TypeScript, and Python SDKs. What we're focused on now is the *experience around* that engine: getting a newcomer from `git clone` to "I ran my first federated operation" in minutes, and shipping current, coherently-versioned artifacts.
+> **TL;DR for the impatient:** the Covia *engine* is in good shape — clean adapter architecture, a real lattice foundation, multi-protocol surface (REST / MCP / A2A / DID), 2,000+ passing tests gating every PR, and published Java, TypeScript, and Python SDKs. What we're focused on now is the *experience around* that engine: getting a newcomer from `git clone` to "I ran my first federated operation" in minutes, and keeping independently published clients aligned with the platform.
 
 ---
 
@@ -30,19 +30,19 @@ An honest snapshot, so newcomers know what to expect and contributors know where
 
 | Area | State | Notes |
 |------|-------|-------|
-| Core engine & adapters | 💪 Solid | Clean `AAdapter` abstraction, ~20 adapters, lattice-backed state |
+| Core engine & adapters | 💪 Solid | Clean `AAdapter` abstraction, ~25 adapters, lattice-backed state |
 | Test suite (engine) | 💪 Solid | 2,000+ tests, fast in-JVM parallel run |
 | REST API reference docs | 💪 Solid | Comprehensive, hand-written, examples throughout |
 | TypeScript SDK | 💪 Solid | Published to npm, typed, tested |
 | Python SDK | 🔨 Good (alpha) | Published to PyPI, async mirror, well documented |
 | README / first impression | ✅ Done | Rewritten for developers: quickstart, badges, architecture, SDK examples |
 | Onboarding / quickstart (docs) | ✅ Done | README quickstart and the docs "Getting Started" page both go zero-to-first-operation |
-| Published artifacts up to date | ✅ Done | Platform `0.6.0` on GitHub, GHCR, and Maven Central; TS SDK 1.7.3 on npm; Python SDK 0.6.0 on PyPI |
+| Published artifact alignment | ✅ Done | Platform `0.9.0` on GitHub/GHCR; `covia-core` `0.9.0` on Maven Central; TS SDK `1.8.0` on npm; Python SDK `0.9.0` on PyPI. Python mirrors the published `covia-core` release line. |
 | Build reproducibility | ✅ Done | Depends on released Convex 0.8.11 from Maven Central; a clean clone builds in one command |
 | CI quality gate | ✅ Done | `test.yml` runs the full reactor (with tests) on every PR and push to `develop`/`master`; its first run caught three latent flaky tests |
-| Client/auth test coverage | 🔨 In progress | `VenueHTTP` has contract tests against a real venue; dedicated auth-strategy tests remain |
+| Client/auth test coverage | 🔨 In progress | `VenueHTTP`, `KeyPairAuth`, and bearer integration are covered; focused `NoAuth`, `BearerAuth`, and `LocalAuth` strategy tests remain |
 | Community scaffolding | 🔨 In progress | `CONTRIBUTING`, `SECURITY`, `CHANGELOG`, and issue/PR templates in place; a governance note remains |
-| Operability (metrics, health, rate limits) | 🌱 Planned | Tracked below and in `AGENTS.md` |
+| Operability (metrics, health, rate limits) | 🔨 In progress | Per-caller request and concurrent-job limits are shipped; health/readiness, per-operation limits, structured logs, and metrics remain |
 
 **Legend:** 💪 solid · 🔨 in progress · 🌱 good area to contribute · ✅ done
 
@@ -58,7 +58,7 @@ _Goal: a developer who has never seen Covia can understand it, run it, and invok
 
 - [x] **Rewrite the repository `README.md` for developers.** The front page now leads with a copy-paste Quickstart (call a live venue, invoke an operation, run your own via Docker/JAR), badges, an architecture diagram, and links into the docs.
 - [x] **Provide a true five-minute quickstart in the docs.** The docs' "Getting Started" page now mirrors the README quickstart: curl a live venue, invoke an operation from TypeScript or Python, run your own venue — zero to first operation on one page.
-- [ ] 🌱 **Pick one frictionless install and document it end-to-end.** The README now documents a `docker run` one-liner against `ghcr.io/covia-ai/covia:latest`, and the image has its own publish workflow; the JAR download points at the `latest` release (current since `0.1.0`). What remains is choosing the lead path and documenting it end-to-end. (A thin `covia` CLI or a `curl | sh` installer is a stretch goal — see _Open questions_.)
+- [ ] 🌱 **Pick one frictionless install and document it end-to-end.** The README now documents a `docker run` one-liner against `ghcr.io/covia-ai/covia:latest`, and the image has its own publish workflow; the JAR download points at the moving `latest` stable release. What remains is choosing the lead path and documenting it end-to-end. (A thin `covia` CLI or a `curl | sh` installer is a stretch goal — see _Open questions_.)
 - [x] **Fill in or hide the documentation stubs.** The Venues and Grid overviews and the A2A adapter page are now real content; no core-concept page reads as "coming soon" any more.
 - [ ] 🌱 **Add a `troubleshooting` / debugging guide.** "My job failed — how do I inspect it?", "How do I read a venue's logs?", common setup pitfalls.
 
@@ -70,12 +70,12 @@ _Goal: every clone builds reproducibly, every PR is validated automatically, and
 - [x] **Make the gate a required check and fix the build badge.** Branch protection on `develop` and `master` now requires the `build-and-test` check for merges (admin direct pushes exempt), and the README "build" badge points at the `Test` workflow.
 - [x] **Make the build reproducible.** Covia now depends on released **Convex 0.8.11** from Maven Central — a clean clone builds with `mvn clean install`, no Convex source build. CI conditionally builds Convex from source only when `convex.version` deliberately names a snapshot. Restore a released pin before shipping. See [Convex ↔ Covia dependency](#a-note-on-the-convex-dependency).
 - [x] **Add a `CHANGELOG.md`** — in Keep a Changelog format. Keep it current per release, and make the release-notes link point at it for real.
-- [x] **Coherent versioning across the product — and ship a current artifact.** The versioning story is agreed (see _Resolved_ under _Open questions_) and shipped: **platform `0.6.0`** on GitHub, GHCR, and Maven Central, TypeScript SDK **1.7.3** on npm, and Python SDK **0.6.0** on PyPI. Remaining follow-ons live under _Consolidate the SDK story_.
+- [x] **Coherent versioning across the product — and ship a current artifact.** Independent SemVer and the platform-generation model are agreed (see _Resolved_ under _Open questions_), and platform **`0.9.0`** is live on GitHub/GHCR. Current clients are `covia-core` **`0.9.0`** on Maven Central, TypeScript SDK **`1.8.0`** on npm, and Python SDK **`0.9.0`** on PyPI. Python now mirrors the published `covia-core` release line; broader SDK presentation work remains under _Consolidate the SDK story_.
 - [x] **Decouple the public Docker image from deployment.** `publish-docker.yml` is the single source of `ghcr.io/covia-ai/covia` tags. It publishes the exact commit that passed the full `Test` workflow; Azure/EC2/GCP deploy only after that publish succeeds.
-- [x] **Reconcile documentation drift.** `BUILD.md` now lists `covia-core`, uses version-agnostic JAR names, and documents the released-Convex dependency (with the snapshot-override escape hatch); `deploy/README.md`'s truncated Caddy command and leaked local path are fixed (JARs now download from GitHub releases). JDK facts are stated consistently (build target 21; published image runs 25) — picking a single baseline remains an _Open question_.
-- [ ] **Test the client-side auth strategies.** `VenueHTTP` now has contract tests against a real venue (`VenueHTTPTest`); the remaining gap is dedicated coverage for the auth strategies (`NoAuth`, `BearerAuth`, `KeyPairAuth`, `LocalAuth`) — signing round-trips and failure paths against a real `VenueServer`.
+- [x] **Reconcile documentation drift.** `BUILD.md` lists the reactor modules, uses version-agnostic JAR names, and documents the released-Convex dependency (with the snapshot-override escape hatch); deployment downloads use GitHub releases. The Java baseline is resolved and stated consistently: source targets 21 and published containers run the current LTS (25).
+- [ ] **Complete the client-side auth strategy tests.** `VenueHTTP` has real-venue contract tests; `KeyPairAuth` has deterministic signing/claim tests; bearer success and rejection paths are integration-tested. Remaining: focused constructor/header behavior for `NoAuth` and `BearerAuth`, and `LocalAuth` DID propagation/no-header behavior through the in-process path.
 - [x] **Add `Dependabot` and dependency/code scanning.** Dependabot watches Maven and GitHub Actions weekly (Convex excluded — managed manually); CodeQL analyses `develop` pushes and runs weekly.
-- [ ] **Consolidate the SDK story.** Make the supported SDKs obvious and deprecate or redirect older clients. `covia-core` is now published to Maven Central; it still needs a focused client README and an explicit SDK-side licensing decision. Keep the docs compatibility matrix current (platform 0.6.0 ↔ TS SDK 1.7.3 ↔ Python SDK 0.6.0).
+- [ ] **Consolidate the SDK story.** Make the supported SDKs obvious and deprecate or redirect older clients. `covia-core` is published to Maven Central but still needs a focused client README and the resolved Apache-2.0 SDK licensing applied to its publication metadata. Keep the Python/`covia-core` mirror-version policy and compatibility matrix current (platform `0.9.0` ↔ Java `0.9.0` ↔ TS `1.8.0` ↔ Python `0.9.0`).
 
 ### Milestone 3 — Confident Self-Hosting & Ecosystem
 
@@ -85,7 +85,7 @@ _Goal: an operator can run a venue in production, and the surrounding ecosystem 
 
 - [ ] **Health & readiness endpoints** (`/health`, `/ready`) so orchestrators and load balancers can probe a venue meaningfully.
 - [ ] **Structured (JSON) logging and request-ID propagation** for production observability. (Tracked in `AGENTS.md` P2.)
-- [ ] **Rate limiting** — per-user and per-operation. (Tracked in `AGENTS.md` P1.)
+- [ ] **Per-operation rate limiting.** Per-caller HTTP request and concurrent-job caps are shipped; operation-specific limits remain. (Tracked in `AGENTS.md` P1.)
 - [ ] **Metrics export** — Prometheus-compatible counters for operations, jobs, adapters, and storage. (Tracked in `AGENTS.md` P2.)
 - [ ] 🌱 **A runnable `examples/` collection.** Hello-world per SDK, plus the AP-invoice demo as real, clonable code rather than only a tooling skill. Working examples are some of the best documentation we can offer — and because they directly serve Milestone 1's "first success", consider pulling a single hello-world example forward rather than waiting for the full collection. The `ap-demo` skill already contains content to lift from.
 - [ ] **A hardening checklist for operators** — UCAN capabilities, secret management, SSRF protection, CORS — consolidated into one practical page.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Covia is built in the open, and contributions are very welcome. We've written do
 - 🐛 **Found a bug or want a feature:** open an issue
 - 📚 **Documentation:** [docs.covia.ai](https://docs.covia.ai)
 
-A dedicated `CONTRIBUTING` guide is on the way; until then, jump into Discussions or Discord and we'll help you get started.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the build, test, branch, and pull-request workflow. Discussions and Discord are the best places for early questions or help scoping a contribution.
 
 ---
 

--- a/covia-python-adapter/README.md
+++ b/covia-python-adapter/README.md
@@ -9,7 +9,7 @@ the shaded module jar:
 ```json
 {
   "modules": [{
-    "path": "modules/covia-python-adapter-0.8.0-module.jar",
+    "path": "modules/covia-python-adapter-<version>-module.jar",
     "config": {
       "library": "/usr/lib/libpython3.13.so",
       "operations": {

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -49,8 +49,9 @@ sudo caddy start --config /etc/caddy/Caddyfile
 Download `covia.jar` from the GitHub releases on the server:
 
 ```bash
-# A specific version (recommended for production — upgrade deliberately)
-curl -fLo covia.jar https://github.com/covia-ai/covia/releases/download/0.1.0/covia.jar
+# A specific version (recommended for production — set deliberately when upgrading)
+COVIA_VERSION=X.Y.Z
+curl -fLo covia.jar https://github.com/covia-ai/covia/releases/download/${COVIA_VERSION}/covia.jar
 
 # Latest stable release
 curl -fLo covia.jar https://github.com/covia-ai/covia/releases/download/latest/covia.jar

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -104,10 +104,8 @@ back, run the manual deploy with `ghcr.io/covia-ai/covia:<sha>` instead of
 
 ## Notes
 
-- **Bootstrap image:** the initial `:stable` tag on the host was built
-  on-box from the public `latest-snapshot` release JAR (GHCR is private
-  and the last tagged release, 0.0.1, predates the current API). The
-  first Actions deploy after these workflows reach `master` replaces it
-  with the real `:stable` channel.
+- The `:stable` image is published by the image-publication workflow and deployment
+  consumes that registry artifact; hosts do not build a bootstrap image
+  on-box.
 - The host is an `e2-medium` (2 vCPU / 4 GB) — one shared 2 GB heap for
   all three venues. Raise it only if the machine type grows.

--- a/skills/hitl/SKILL.md
+++ b/skills/hitl/SKILL.md
@@ -102,7 +102,7 @@ Resident agents get HITL from the venue skill library (`v/skills/hitl`) — ever
 
 3. **Or instruct per-task** — include "confirm with me via a HITL request before X" in an `agent_request` task; a skills-capable agent will load the skill and ask.
 4. **Timing** — an agent's HITL tool call blocks up to its `toolCallTimeoutMs` (default 5 min). If the human answers within that window the agent continues in the same cycle; otherwise the tool returns the job id and the agent should park the work and re-check the job (`covia_read path=j/<id>`) on a later wake — this is normal, not an error.
-5. **Authority** — the ask goes to the agent's **owner** by default (omit `user`); that needs no delegation. Asking anyone else requires the `hitl/request` token above, and a caps-pinned agent additionally needs its ceiling to permit the op (skill loading grants no authority).
+5. **Authority** — the ask goes to the agent's **owner** by default (omit `user`); that needs no delegation. Asking anyone else requires the `hitl/request` token above, and a caps-pinned agent additionally needs its capability scope to permit the op (skill loading grants no authority).
 
 ### `test` — smoke-test the full loop
 

--- a/venue/CLAUDE.md
+++ b/venue/CLAUDE.md
@@ -21,8 +21,8 @@ venue/
 │   │   ├── VenueState.java      # Lattice state wrapper (assets, jobs, users, auth)
 │   │   ├── Users.java / User.java  # Per-user lattice state (jobs, agents, workspace, h/ inbox)
 │   │   ├── AccessControl.java   # Job ownership enforcement
-│   │   ├── Auth.java            # Auth config, public ceiling, login providers
-│   │   ├── RequestContext.java  # Caller identity, proofs, capability ceiling
+│   │   ├── Auth.java            # Auth config, public capability scope, login providers
+│   │   ├── RequestContext.java  # Caller identity, proofs, capability scope
 │   │   ├── api/                 # REST (CoviaAPI), MCP, A2A, UserAPI
 │   │   ├── server/              # HTTP server, AuthMiddleware, SSE
 │   │   └── storage/             # Content storage backends
@@ -147,14 +147,6 @@ in [`docs/A2A_AGENTS.md`](docs/A2A_AGENTS.md), the implementation companion to
 COG-14. Operator configuration and a minimal request example are in
 [`docs/CONFIG.md`](docs/CONFIG.md#a2a-protocol); the non-owner authority model
 is in [`docs/A2A_INTERACTION_AUTHORITY.md`](docs/A2A_INTERACTION_AUTHORITY.md).
-
-Current boundaries:
-
-- Per-agent continuation with an incoming `taskId` is not implemented (#306).
-- Turns exceeding the synchronous wait boundary need stable reattachment
-  semantics (#305).
-- Outbound `a2a` adapter calls do not yet relay authenticated caller authority
-  to a remote venue (#304); anonymous publication remains usable.
 
 ## Development Guidelines
 

--- a/venue/docs/AGENT_TEMPLATES.md
+++ b/venue/docs/AGENT_TEMPLATES.md
@@ -335,7 +335,7 @@ So for a pipeline of *capped* workers, provision the handoff area explicitly:
 
 Every stage can read the shared `w/pipeline/` area. With structural handoff the
 **manager** needs `crud/write` on each `outputPath`, because the framework writes
-under the requester's captured ceiling; each consumer needs `crud/read` on its
+under the requester's captured capability scope; each consumer needs `crud/read` on its
 input path. The producing worker does not need write authority merely to return
 its result. Uncapped agents need none of these explicit grants — but capping is
 the least-privilege posture for untrusted or externally-facing work, and there

--- a/venue/docs/AUTH.md
+++ b/venue/docs/AUTH.md
@@ -42,7 +42,7 @@ The implementation is further along than #297/#296 suggest:
 | Key enrolment surface (#296) | `UserAdapter` (`user:create` keys, add/revoke ops), `Engine` creation path | Venue-authorised, audited (`addedBy`/`revokedBy`) |
 | Session minting | `LoginProviders` OAuth callback | Inline `JWT.signPublic` — no session id, no revocation, no amr/auth_time |
 | Audience policy | `Auth` config + `requireAudience` | `verify`/`require`, `acceptedAudiences`, did:web alias |
-| Public ceiling | `auth.public.*` (COG-10) | Unchanged by this design |
+| Public capability scope | `auth.public.*` (COG-10) | Unchanged by this design |
 
 **Gaps this design closes:** per-method enable/disable and policy
 config; a common method result (method reference, `amr`, assurance,
@@ -397,5 +397,5 @@ venue-auth state.
 
 - `UCAN.md` — capabilities and the proof channel (authorisation layer)
 - `CONFIG.md` — operator configuration reference (gains §6 on landing)
-- COG-3 / COG-10 — token classes, self-issued rules, public ceiling
+- COG-3 / COG-10 — token classes, self-issued rules, public capability scope
 - covia#297 (this design), #296, #298, #299, #300, #301, #323, #269

--- a/venue/docs/CONFIG.md
+++ b/venue/docs/CONFIG.md
@@ -340,7 +340,7 @@ code execution.
 ```json
 {
   "modules": [{
-    "path": "modules/covia-python-adapter-0.8.0-module.jar",
+    "path": "modules/covia-python-adapter-<version>-module.jar",
     "sha256": "<optional 64-hex module digest>",
     "config": {
       "library": "/usr/lib/libpython3.13.so",
@@ -799,7 +799,7 @@ Agent-side bounds: each level-3 LLM call is bounded by the agent's
 ```json
 {
   "modules": [
-    "modules/covia-sql-0.6.0-module.jar",
+    "modules/covia-sql-<version>-module.jar",
     { "path": "modules/other.jar", "sha256": "9f2a...", "config": { } }
   ]
 }


### PR DESCRIPTION
## Summary

- reconcile engineering and DX roadmaps with the 0.9.0 codebase
- record covia-core 0.9.0 on Maven Central and Python SDK 0.9.0 on PyPI
- refresh module, deployment, testing, authorization, and contribution documentation

## Validation

- git diff --check
- Maven Central 0.9.0 artifacts verified publicly
- Python 0.9.0 CI, TestPyPI, production PyPI, and clean-install verification passed