### PR TITLE
docs: remove fragile venue references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 - Made deployment and optional-module examples version-neutral, refreshed the
   module maps and contribution link, and removed obsolete A2A limitations that
   shipped in 0.9.0.
+- Centralized the hosted quickstart on a configurable stable-venue URL and
+  replaced deployment-specific hostnames in generic examples and test fixtures
+  with RFC-reserved domains. The venue inventory now flags venue-3's expired
+  TLS certificate and avoids duplicating dev-host coordinates in usage examples.
 
 ## [0.9.0] - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -39,19 +39,25 @@ It's built on the [Convex](https://github.com/Convex-Dev/convex) lattice platfor
 ## Quickstart
 
 The fastest way to try Covia is against a hosted venue — no install required.
+Choose a current stable endpoint from [`VENUES.md`](VENUES.md) and keep it in
+one environment variable. This example uses the first stable venue:
+
+```bash
+COVIA_VENUE_URL=https://venue-1.covia.ai
+```
 
 ### 1. Call a live venue
 
 Every venue exposes the same REST API. List the operations it offers:
 
 ```bash
-curl https://venue-3.covia.ai/api/v1/operations
+curl "$COVIA_VENUE_URL/api/v1/operations"
 ```
 
 Invoke one and wait for the result inline. `v/ops/schema/infer` derives a JSON Schema from an example value — one of many built-in operations:
 
 ```bash
-curl -X POST https://venue-3.covia.ai/api/v1/invoke \
+curl -X POST "$COVIA_VENUE_URL/api/v1/invoke" \
   -H "Content-Type: application/json" \
   -d '{
         "operation": "v/ops/schema/infer",
@@ -79,7 +85,8 @@ The venue returns a job record whose `output` carries the result:
 }
 ```
 
-Browse the full API interactively at [`/swagger`](https://venue-3.covia.ai/swagger) or [`/redoc`](https://venue-3.covia.ai/redoc).
+Browse the full API interactively at `$COVIA_VENUE_URL/swagger` or
+`$COVIA_VENUE_URL/redoc`.
 
 ### 2. Invoke from your code
 
@@ -92,7 +99,9 @@ npm install @covia/covia-sdk
 ```typescript
 import { Grid } from "@covia/covia-sdk";
 
-const venue = await Grid.connect("https://venue-3.covia.ai");
+const venueUrl = process.env.COVIA_VENUE_URL;
+if (!venueUrl) throw new Error("Set COVIA_VENUE_URL to a current venue URL");
+const venue = await Grid.connect(venueUrl);
 const result = await venue.operations.run("v/ops/schema/infer", {
   value: { name: "Ada", age: 36, admin: true },
 });
@@ -107,9 +116,11 @@ pip install covia
 ```
 
 ```python
+import os
+
 from covia import Grid
 
-venue = Grid.connect("https://venue-3.covia.ai")
+venue = Grid.connect(os.environ["COVIA_VENUE_URL"])
 result = venue.run("v/ops/schema/infer", {"value": {"name": "Ada", "age": 36, "admin": True}})
 print(result)  # {'schema': {'type': 'object', ...}}
 ```
@@ -210,7 +221,7 @@ A venue exposes the same capabilities over multiple protocols:
 ```json
 {
   "mcpServers": {
-    "covia": { "url": "https://venue-3.covia.ai/mcp" }
+    "covia": { "url": "https://your-venue.example.com/mcp" }
   }
 }
 ```

--- a/VENUES.md
+++ b/VENUES.md
@@ -40,7 +40,7 @@ The trio gives a stable federation set for cross-venue work on one host (`35.213
 
 ## Dev Venues
 
-### venue-3.covia.ai (AWS)
+### venue-3.covia.ai (AWS — degraded)
 
 - **URL:** https://venue-3.covia.ai
 - **Status:** https://venue-3.covia.ai/api/v1/status
@@ -50,6 +50,8 @@ The trio gives a stable federation set for cross-venue work on one host (`35.213
 - **Region:** AWS us-east-1 (N. Virginia)
 - **Spec:** 2 vCPU, 4 GB RAM
 - **TLS:** Let's Encrypt (auto-renew)
+- **Availability:** TLS certificate expired as of 2026-08-10; do not use until
+  certificate renewal is restored
 
 ### venue-4.covia.ai (Azure)
 
@@ -72,9 +74,9 @@ Venues within a tier run the same Covia server version. Data (assets, workspace,
 import { Venue, KeyPairAuth } from "@covia/covia-sdk";
 
 const auth = KeyPairAuth.generate();
-const venue = await Venue.connect("https://venue-3.covia.ai", auth);
-// or
-const venue = await Venue.connect("https://venue-4.covia.ai", auth);
+const venueUrl = process.env.COVIA_VENUE_URL;
+if (!venueUrl) throw new Error("Set COVIA_VENUE_URL to a venue listed above");
+const venue = await Venue.connect(venueUrl, auth);
 ```
 
 ### Connecting via MCP
@@ -84,15 +86,14 @@ Use the venue's MCP endpoint as a server URL in your MCP client configuration:
 ```json
 {
   "mcpServers": {
-    "covia-aws": { "url": "https://venue-3.covia.ai/mcp" },
-    "covia-azure": { "url": "https://venue-4.covia.ai/mcp" }
+    "covia": { "url": "https://your-venue.example.com/mcp" }
   }
 }
 ```
 
 ### API Endpoints
 
-Both venues expose the same API surface:
+All venues expose the same API surface:
 
 - `GET  /api/v1/status` — Venue health and stats
 - `GET  /api/v1/operations` — List available operations

--- a/deploy/ec2/README.md
+++ b/deploy/ec2/README.md
@@ -1,6 +1,6 @@
 # EC2 Deployment
 
-Docker-based deployment for `venue-3.covia.ai` (`13.213.76.110`).
+Docker-based deployment for `venue-3.covia.ai` on AWS.
 
 ## One-Time EC2 Setup
 

--- a/venue/docs/CONFIG.md
+++ b/venue/docs/CONFIG.md
@@ -558,7 +558,7 @@ A runtime user ID is always a DID and may use any DID method. `user:create`
 accepts a full DID directly (for example a self-sovereign `did:key`) or a
 venue-managed `username`. A username requires a public `hostname` and derives
 `did:web:<hostname>:u:<username>` — for example
-`did:web:venue-1.covia.ai:u:alice`. `user:create` and `user:list` are
+`did:web:venue.example.com:u:alice`. `user:create` and `user:list` are
 venue-administrative operations: invoke directly as the venue, or present a
 venue-issued UCAN covering `<venueDID>/users` with `user/create` or
 `user/read`. Operator code can use `engine.venueContext()` to invoke the

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -2050,7 +2050,7 @@ public class Engine {
 	/**
 	 * Converts a venue-managed username to its canonical user DID. Publicly
 	 * named venues use their did:web alias (for example
-	 * {@code did:web:venue-1.covia.ai:u:alice}). A public hostname is required
+	 * {@code did:web:venue.example.com:u:alice}). A public hostname is required
 	 * because a did:key identifies one key and is not a namespace for managed
 	 * usernames.
 	 */

--- a/venue/src/main/resources/adapters/mcp/toolCall.json
+++ b/venue/src/main/resources/adapters/mcp/toolCall.json
@@ -13,7 +13,7 @@
 				"server": {
 					"type": "string",
 					"description": "HTTP(S) base URL or explicit /mcp endpoint for the MCP server; trailing slashes are accepted",
-					"examples":["https://venue-3.covia.ai","https://venue-3.covia.ai/mcp"]
+					"examples":["https://mcp.example.com","https://mcp.example.com/mcp"]
 				},
 				"toolName": {
 					"type": "string",

--- a/venue/src/main/resources/adapters/mcp/toolList.json
+++ b/venue/src/main/resources/adapters/mcp/toolList.json
@@ -13,7 +13,7 @@
 				"server": {
 					"type": "string",
 					"description": "HTTP(S) base URL or explicit /mcp endpoint for the MCP server; trailing slashes are accepted",
-					"examples":["https://venue-3.covia.ai","https://venue-3.covia.ai/mcp"]
+					"examples":["https://mcp.example.com","https://mcp.example.com/mcp"]
 				},
 				"token": {
 					"type": "string",

--- a/venue/src/test/java/covia/adapter/UserAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/UserAdapterTest.java
@@ -38,7 +38,7 @@ class UserAdapterTest {
 	@BeforeAll
 	static void setup() {
 		engine = Engine.createTemp(Maps.of(
-			Config.HOSTNAME, Strings.create("venue-1.covia.ai")));
+			Config.HOSTNAME, Strings.create("venue.example.com")));
 		Engine.addDemoAssets(engine);
 	}
 
@@ -76,7 +76,7 @@ class UserAdapterTest {
 		assertEquals(external, RT.getIn(create(Maps.of(Fields.DID, external)), Fields.DID));
 
 		ACell managed = create(Maps.of("username", "alice"));
-		AString expected = Strings.create("did:web:venue-1.covia.ai:u:alice");
+		AString expected = Strings.create("did:web:venue.example.com:u:alice");
 		assertEquals(expected, RT.getIn(managed, Fields.DID));
 		assertNotNull(engine.getVenueState().users().get(expected));
 		assertEquals(expected,
@@ -100,7 +100,7 @@ class UserAdapterTest {
 	void venueRootAuthorityIsLimitedToItsManagedUsers() {
 		RootAuthorityPolicy policy = engine.rootAuthorityPolicy();
 		AString venue = engine.getDIDString();
-		AString managed = Strings.create("did:web:venue-1.covia.ai:u:alice");
+		AString managed = Strings.create("did:web:venue.example.com:u:alice");
 		AString self = UCAN.toDIDKey(AKeyPair.generate().getAccountKey());
 		AString external = Strings.create("did:web:identity.example:u:bob");
 
@@ -111,7 +111,7 @@ class UserAdapterTest {
 		assertFalse(policy.acceptsRoot(venue, Strings.create(external + "/w/notes")),
 			"a similarly shaped DID on another domain is not locally custodial");
 		assertFalse(policy.acceptsRoot(venue,
-			Strings.create("did:web:venue-1.covia.ai.evil:u:alice/w/notes")),
+			Strings.create("did:web:venue.example.com.evil:u:alice/w/notes")),
 			"a hostname-prefix lookalike must not enter the managed namespace");
 		assertFalse(policy.acceptsRoot(venue,
 			Strings.create(managed + ":admin/w/notes")),

--- a/venue/src/test/java/covia/venue/ConfigTest.java
+++ b/venue/src/test/java/covia/venue/ConfigTest.java
@@ -223,8 +223,8 @@ public class ConfigTest {
 
 	@Test
 	public void testWebDIDForPublicDomain() {
-		Config c = new Config(Maps.of(Config.HOSTNAME, Strings.create("venue-1.covia.ai")));
-		assertEquals("did:web:venue-1.covia.ai", c.getWebDID().toString());
+		Config c = new Config(Maps.of(Config.HOSTNAME, Strings.create("venue.example.com")));
+		assertEquals("did:web:venue.example.com", c.getWebDID().toString());
 	}
 
 	@Test

--- a/venue/src/test/java/covia/venue/api/A2ACodecTest.java
+++ b/venue/src/test/java/covia/venue/api/A2ACodecTest.java
@@ -352,8 +352,8 @@ public class A2ACodecTest {
 
 	@Test
 	public void agentEndpoint_buildUsesExternalBaseUrl() {
-		String url = A2ACodec.agentEndpointUrl("https://venue-3.covia.ai", "did:key:z6MkX", "Bob");
-		assertEquals("https://venue-3.covia.ai/a2a/did:key:z6MkX/g/Bob", url);
+		String url = A2ACodec.agentEndpointUrl("https://venue.example.com", "did:key:z6MkX", "Bob");
+		assertEquals("https://venue.example.com/a2a/did:key:z6MkX/g/Bob", url);
 	}
 
 	@Test
@@ -383,7 +383,7 @@ public class A2ACodecTest {
 	@Test
 	public void agentCard_buildsFromNameDescriptionProviderAndEndpoint() {
 		AgentProvider provider = new AgentProvider("Covia", "https://covia.ai");
-		String endpoint = "https://venue-3.covia.ai/a2a/did:key:z6MkX/g/Alice";
+		String endpoint = "https://venue.example.com/a2a/did:key:z6MkX/g/Alice";
 		AgentCard card = A2ACodec.agentCard("Alice", "A test agent", "0.3.0", provider, endpoint);
 
 		assertEquals("Alice", card.name());


### PR DESCRIPTION
## Summary

- centralize the public hosted quickstart on one configurable stable-venue URL instead of duplicating venue-3
- use environment variables or RFC-reserved domains in generic SDK, MCP, documentation, and test examples
- retain real hostnames only in the operational venue inventory/deployment files
- flag venue-3 as degraded because its TLS certificate is currently expired, and remove its stale EC2 IP from prose

## Validation

- git diff --check
- MCP JSON resources parsed successfully
- mvn -pl venue -am test (78 core + 2,078 venue tests)
- live checks: venue-1, venue-2, venue-test, and venue-4 returned HTTP 200; venue-3 failed TLS validation with an expired certificate