### PR TITLE
fix: accept legacy UCAN profile omissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 
 ### Changed
 
+- Restored compatibility with correctly signed legacy UCAN JWTs that omit the
+  `ucv` profile marker and empty `prf` claim. Venues still emit the explicit
+  UCAN 0.10.0 profile, reject explicit unsupported versions, advertise the
+  emitted profile in `/api/v1/status`, and return claim-specific verification
+  diagnostics (#353).
 - Reconciled the engineering and DX roadmaps with the 0.9.0 codebase: current
   artifact versions, shipped VenueHTTP/SSRF/CORS test coverage, narrowed auth
   and focused-test gaps, resolved Java baseline, and per-caller rate limiting.

--- a/covia-core/src/main/java/covia/api/Fields.java
+++ b/covia-core/src/main/java/covia/api/Fields.java
@@ -148,6 +148,9 @@ public class Fields {
 
 	// Venue status
 	public static final StringShort VERSION = Strings.intern("version");
+	/** UCAN JWT profile emitted by this venue. Older tokens without an explicit
+	 * profile marker may still be accepted through the compatibility boundary. */
+	public static final StringShort UCAN_PROFILE = Strings.intern("ucanProfile");
 
 	// Lattice navigation
 	public static final StringShort PATH = Strings.intern("path");

--- a/venue/docs/UCAN.md
+++ b/venue/docs/UCAN.md
@@ -244,6 +244,15 @@ per UCAN v0.10.0 (Convex #678), in the Convex UCAN JWT profile (`ucv` claim +
 mint under a granting right requires the enabling right to be non-expiring too
 (the §4.1 horizon check evaluates at an unbounded horizon).
 
+Venues always emit `ucv: "0.10.0"` and an explicit `prf` array, and advertise
+that emitted profile as `ucanProfile` in `GET /api/v1/status`. At verification
+the venue remains compatible with correctly signed older client tokens: an
+absent `ucv` defaults to the current profile and an absent `prf` defaults to an
+empty proof chain. An explicitly different `ucv`, malformed claim, invalid
+signature, or invalid proof chain still fails closed with a specific diagnostic.
+Defaults are applied only after the signature over the original JWT bytes has
+been verified.
+
 The venue signs the token with the **venue key pair** (the venue is the
 issuer — custodial attestation on the authenticated caller's instruction)
 and returns the complete signed token. A self-sovereign owner (`did:key`, or

--- a/venue/src/main/java/covia/adapter/GridAdapter.java
+++ b/venue/src/main/java/covia/adapter/GridAdapter.java
@@ -24,6 +24,7 @@ import covia.grid.Venue;
 import covia.grid.auth.VenueAuth;
 import covia.venue.LocalVenue;
 import covia.venue.RequestContext;
+import covia.venue.UcanJwtValidator;
 
 /**
  * Adapter that proxies Covia grid operations to the local engine or a remote venue.
@@ -346,7 +347,7 @@ public class GridAdapter extends AAdapter {
             AString jwt = RT.ensureString(raw.get(i));
             if (jwt != null) {
                 try {
-                    token = UCANValidator.validateJWT(jwt, now, verifier);
+                    token = UcanJwtValidator.validateJWT(jwt, now, verifier);
                 } catch (Exception e) {
                     // defective token: null slot, grants nothing
                 }

--- a/venue/src/main/java/covia/adapter/HITLAdapter.java
+++ b/venue/src/main/java/covia/adapter/HITLAdapter.java
@@ -29,6 +29,7 @@ import covia.grid.Job;
 import covia.grid.Status;
 import covia.grid.hitl.Hitl;
 import covia.venue.RequestContext;
+import covia.venue.UcanJwtValidator;
 import covia.venue.User;
 
 /**
@@ -361,9 +362,12 @@ public class HITLAdapter extends AAdapter {
 	 * @throws AuthException / IllegalArgumentException on any failure
 	 */
 	private void verifyTransportedToken(AString jwt, AString responder, AString expectedAud, long now) {
-		UCAN token = UCAN.fromJWT(jwt);
+		UcanJwtValidator.Validation validation =
+			UcanJwtValidator.validate(jwt, now, engine.didVerifier());
+		UCAN token = validation.token();
 		if (token == null) {
-			throw new IllegalArgumentException("token answer is not a valid UCAN JWT");
+			throw new IllegalArgumentException(
+				"token answer is not a valid UCAN JWT: " + validation.reason());
 		}
 		// iss must be the answering human — not something an agent slipped in.
 		AString issuer = token.getIssuer();

--- a/venue/src/main/java/covia/adapter/UCANAdapter.java
+++ b/venue/src/main/java/covia/adapter/UCANAdapter.java
@@ -20,6 +20,7 @@ import covia.api.Fields;
 import covia.exception.AuthException;
 import covia.lattice.CapabilityChecker;
 import covia.venue.RequestContext;
+import covia.venue.UcanJwtValidator;
 
 /**
  * Adapter for UCAN token operations.
@@ -260,12 +261,20 @@ public class UCANAdapter extends AAdapter {
 		AString venueDID = engine.getDIDString();
 
 		// Full verification (signature at every hop, temporal bounds, chain structure).
+		// JWTs pass through the same narrow legacy-profile compatibility boundary
+		// used by transport enforcement, so diagnostics and real calls agree.
 		UCAN token = null;
 		String failure = null;
 		try {
-			token = (tokenStr != null)
-				? convex.auth.ucan.UCANValidator.validateJWT(tokenStr, now, engine.didVerifier())
-				: convex.auth.ucan.UCANValidator.validate(UCAN.parse(tokenMap), now, engine.didVerifier());
+			if (tokenStr != null) {
+				UcanJwtValidator.Validation validation =
+					UcanJwtValidator.validate(tokenStr, now, engine.didVerifier());
+				token = validation.token();
+				failure = validation.reason();
+			} else {
+				token = convex.auth.ucan.UCANValidator.validate(
+					UCAN.parse(tokenMap), now, engine.didVerifier());
+			}
 		} catch (Exception e) {
 			failure = e.getMessage();
 		}
@@ -277,8 +286,10 @@ public class UCANAdapter extends AAdapter {
 				unverified = (tokenStr != null) ? UCAN.parseJWT(tokenStr) : UCAN.parse(tokenMap);
 			} catch (Exception ignored) {}
 			String reason;
-			if (unverified == null) {
-				reason = "unparseable: not a well-formed UCAN" + (failure != null ? " (" + failure + ")" : "");
+			if (failure != null) {
+				reason = failure;
+			} else if (unverified == null) {
+				reason = "unparseable: not a well-formed UCAN";
 			} else if (!convex.auth.ucan.UCANValidator.checkTemporalBounds(unverified, now)) {
 				reason = "expired or not yet valid (exp/nbf out of bounds)";
 			} else {
@@ -299,7 +310,7 @@ public class UCANAdapter extends AAdapter {
 			UCAN parent = null;
 			AString parentJwt = RT.ensureString(entry);
 			if (parentJwt != null) {
-				parent = UCAN.parseJWT(parentJwt);
+				parent = UcanJwtValidator.validateJWT(parentJwt, now, engine.didVerifier());
 			} else {
 				AMap<AString, ACell> parentMap = RT.castMap(entry);
 				if (parentMap != null) parent = UCAN.parse(parentMap);

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -19,6 +19,7 @@ import convex.auth.did.DID;
 import convex.auth.did.DIDURL;
 import convex.auth.ucan.Capability;
 import convex.auth.ucan.RootAuthorityPolicy;
+import convex.auth.ucan.UCAN;
 import convex.core.crypto.AKeyPair;
 import convex.core.crypto.Hashing;
 import convex.core.crypto.util.Multikey;
@@ -1928,6 +1929,7 @@ public class Engine {
 		// jarVersion() reads the (shaded) jar's Implementation-Version and falls
 		// back to "dev" when running from classes — never null. See #139.
 		status=status.assoc(Fields.VERSION, Strings.create(jarVersion()));
+		status=status.assoc(Fields.UCAN_PROFILE, UCAN.VERSION);
 
 		return status;
 	}

--- a/venue/src/main/java/covia/venue/RequestContext.java
+++ b/venue/src/main/java/covia/venue/RequestContext.java
@@ -185,7 +185,7 @@ public class RequestContext {
 	 * bounds and policy (audience, issuer, attenuation) at use time.</p>
 	 *
 	 * <p>The canonical way to obtain a verified proof vector is via
-	 * {@code UCANValidator.parseTransportUCANs(...)}, which is the single
+	 * {@link UcanJwtValidator#parseTransportUCANs}, which is the single
 	 * trust boundary for inbound transport tokens. Tests that fabricate
 	 * CAD3-signed tokens directly are implicitly trusted by construction.</p>
 	 */

--- a/venue/src/main/java/covia/venue/UcanJwtValidator.java
+++ b/venue/src/main/java/covia/venue/UcanJwtValidator.java
@@ -1,0 +1,197 @@
+package covia.venue;
+
+import java.nio.charset.StandardCharsets;
+
+import convex.auth.did.DID;
+import convex.auth.did.DIDVerifier;
+import convex.auth.jwt.JWT;
+import convex.auth.ucan.UCAN;
+import convex.core.crypto.ASignature;
+import convex.core.data.ACell;
+import convex.core.data.AMap;
+import convex.core.data.AString;
+import convex.core.data.AVector;
+import convex.core.data.Blob;
+import convex.core.data.Strings;
+import convex.core.data.Vectors;
+import convex.core.data.prim.CVMLong;
+import convex.core.lang.RT;
+
+/**
+ * Venue UCAN JWT compatibility boundary.
+ *
+ * <p>Current tokens must emit the Convex UCAN {@code 0.10.0} profile. For
+ * compatibility with clients that predate that profile marker, verification
+ * also accepts an absent {@code ucv} as the current version and an absent
+ * {@code prf} as an empty proof chain. Explicit unsupported versions and
+ * malformed claims remain failures.</p>
+ *
+ * <p>The signature is always checked over the original JWT signing input
+ * before defaults are added to the in-memory payload. Compatibility therefore
+ * cannot make a modified or unsigned token valid.</p>
+ */
+public final class UcanJwtValidator {
+
+	private static final AString JWT_TYPE = Strings.intern("JWT");
+	private static final int ED25519_SIGNATURE_LENGTH = 64;
+
+	private UcanJwtValidator() {}
+
+	/** Result of validation, including a safe diagnostic on failure. */
+	public record Validation(UCAN token, String reason) {
+		public boolean valid() {
+			return token != null;
+		}
+	}
+
+	/** Validate a UCAN JWT with the venue's narrow legacy-profile defaults. */
+	public static Validation validate(AString jwtString, long nowSeconds, DIDVerifier verifier) {
+		if (jwtString == null) return failure("missing token");
+		if (verifier == null) return failure("no DID signature verifier is configured");
+
+		JWT jwt = JWT.parse(jwtString);
+		if (jwt == null) {
+			return failure("unparseable JWT: expected three base64url-encoded segments");
+		}
+		if (!"EdDSA".equals(jwt.getAlgorithm())) {
+			return failure("unsupported JWT algorithm: expected EdDSA, got "
+				+ printable(jwt.getAlgorithm()));
+		}
+		if (jwt.getSignatureBytes().length != ED25519_SIGNATURE_LENGTH) {
+			return failure("malformed EdDSA signature: expected 64 bytes, got "
+				+ jwt.getSignatureBytes().length);
+		}
+		AString type = RT.ensureString(jwt.getHeader().get(JWT.TYP));
+		if (!JWT_TYPE.equals(type)) {
+			return failure("unsupported JWT type: expected \"JWT\", got " + printable(type));
+		}
+
+		AMap<AString, ACell> claims = jwt.getClaims();
+		if (claims == null) return failure("missing JWT claims");
+
+		ACell version = claims.get(UCAN.UCV);
+		if (claims.containsKey(UCAN.UCV) && !UCAN.VERSION.equals(version)) {
+			return failure("unsupported UCAN version: expected \"" + UCAN.VERSION
+				+ "\", got " + printable(version));
+		}
+
+		AString issuer = RT.ensureString(claims.get(UCAN.ISS));
+		if (!isDID(issuer)) return failure("missing or malformed required claim \"iss\": expected a DID");
+		AString audience = RT.ensureString(claims.get(UCAN.AUD));
+		if (!isDID(audience)) return failure("missing or malformed required claim \"aud\": expected a DID");
+
+		if (!claims.containsKey(UCAN.EXP)) {
+			return failure("missing required claim \"exp\" (use null for a non-expiring token)");
+		}
+		ACell expiry = claims.get(UCAN.EXP);
+		if (expiry != null && !(expiry instanceof CVMLong)) {
+			return failure("malformed claim \"exp\": expected an integer Unix timestamp or null");
+		}
+		if (claims.containsKey(UCAN.NBF) && !(claims.get(UCAN.NBF) instanceof CVMLong)) {
+			return failure("malformed claim \"nbf\": expected an integer Unix timestamp");
+		}
+		if (!(claims.get(UCAN.ATT) instanceof AVector)) {
+			return failure("missing or malformed required claim \"att\": expected an array");
+		}
+		ACell proofsCell = claims.get(UCAN.PRF);
+		if (claims.containsKey(UCAN.PRF) && !(proofsCell instanceof AVector)) {
+			return failure("malformed claim \"prf\": expected an array");
+		}
+
+		Blob signingInput = Blob.wrap(jwt.getSigningInput().getBytes(StandardCharsets.UTF_8));
+		Blob signature = Blob.wrap(jwt.getSignatureBytes());
+		boolean signatureValid;
+		try {
+			signatureValid = verifier.verifies(issuer, signingInput, signature);
+		} catch (Throwable t) {
+			signatureValid = false;
+		}
+		if (!signatureValid) return failure("bad signature for issuer " + issuer);
+
+		// Normalise only after verifying the bytes the client actually signed.
+		AMap<AString, ACell> normalised = claims;
+		if (!normalised.containsKey(UCAN.UCV)) normalised = normalised.assoc(UCAN.UCV, UCAN.VERSION);
+		if (!normalised.containsKey(UCAN.PRF)) normalised = normalised.assoc(UCAN.PRF, Vectors.empty());
+
+		UCAN token;
+		try {
+			token = UCAN.fromPayload(normalised, ASignature.fromBlob(signature));
+		} catch (RuntimeException e) {
+			return failure("malformed UCAN payload or signature");
+		}
+
+		Long exp = token.getExpiry();
+		if (exp != null && exp <= nowSeconds) {
+			return failure("expired: exp " + exp + " is not after current time " + nowSeconds);
+		}
+		Long nbf = token.getNotBefore();
+		if (nbf != null && nbf > nowSeconds) {
+			return failure("not yet valid: nbf " + nbf + " is after current time " + nowSeconds);
+		}
+
+		@SuppressWarnings("unchecked")
+		AVector<ACell> proofs = (AVector<ACell>) normalised.get(UCAN.PRF);
+		for (long i = 0; i < proofs.count(); i++) {
+			AString proofJwt = RT.ensureString(proofs.get(i));
+			if (proofJwt == null) {
+				return failure("invalid proof[" + i + "]: expected a UCAN JWT string");
+			}
+			Validation parent = validate(proofJwt, nowSeconds, verifier);
+			if (!parent.valid()) {
+				return failure("invalid proof[" + i + "]: " + parent.reason());
+			}
+			if (!issuer.equals(parent.token().getAudience())) {
+				return failure("invalid proof[" + i + "]: audience does not match child issuer");
+			}
+		}
+
+		return new Validation(token, null);
+	}
+
+	/** Validate and return only the token, for fail-closed enforcement paths. */
+	public static UCAN validateJWT(AString jwtString, long nowSeconds, DIDVerifier verifier) {
+		return validate(jwtString, nowSeconds, verifier).token();
+	}
+
+	/** Parse transport proof JWTs through the same compatibility boundary. */
+	public static AVector<ACell> parseTransportUCANs(AVector<ACell> ucans,
+			DIDVerifier verifier) {
+		if (ucans == null || ucans.isEmpty() || verifier == null) return null;
+		long now = System.currentTimeMillis() / 1000;
+		AVector<ACell> result = Vectors.empty();
+		for (long i = 0; i < ucans.count(); i++) {
+			AString jwt = RT.ensureString(ucans.get(i));
+			if (jwt == null) continue;
+			UCAN token = validateJWT(jwt, now, verifier);
+			if (token != null) result = result.conj(token.toMap());
+		}
+		return result.isEmpty() ? null : result;
+	}
+
+	/** Parse a bearer plus body proofs through one validation boundary. */
+	public static AVector<ACell> parseTransportUCANsWithBearer(AString bearer,
+			AVector<ACell> bodyUcans, DIDVerifier verifier) {
+		if (bearer == null) return parseTransportUCANs(bodyUcans, verifier);
+		AVector<ACell> combined = Vectors.of(bearer);
+		if (bodyUcans != null && !bodyUcans.isEmpty()) combined = combined.concat(bodyUcans);
+		return parseTransportUCANs(combined, verifier);
+	}
+
+	private static Validation failure(String reason) {
+		return new Validation(null, reason);
+	}
+
+	private static boolean isDID(AString value) {
+		if (value == null || value.isEmpty()) return false;
+		try {
+			DID did = DID.fromString(value.toString());
+			return did != null && !did.getMethod().isEmpty() && !did.getID().isEmpty();
+		} catch (RuntimeException e) {
+			return false;
+		}
+	}
+
+	private static String printable(Object value) {
+		return (value == null) ? "none" : "\"" + value + "\"";
+	}
+}

--- a/venue/src/main/java/covia/venue/auth/VenueAuthenticator.java
+++ b/venue/src/main/java/covia/venue/auth/VenueAuthenticator.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import convex.auth.did.DID;
 import convex.auth.jwt.JWT;
 import convex.auth.ucan.UCAN;
-import convex.auth.ucan.UCANValidator;
 import convex.core.crypto.util.Multikey;
 import convex.core.data.ACell;
 import convex.core.data.AMap;
@@ -25,6 +24,7 @@ import covia.api.Fields;
 import covia.exception.AuthException;
 import covia.venue.Auth;
 import covia.venue.Engine;
+import covia.venue.UcanJwtValidator;
 import covia.venue.server.AuthMiddleware;
 import io.javalin.http.Context;
 
@@ -236,18 +236,17 @@ public final class VenueAuthenticator {
 	}
 
 	private VerifiedPrincipal tryVerifyUCAN(AString jwt) {
-		UCAN token = UCAN.fromJWT(jwt);
-		if (token == null) return null;
 		JWT parsed = JWT.parse(jwt);
 		AMap<AString, ACell> claims = parsed == null ? null : parsed.getClaims();
 		if (claims == null || claims.get(UCAN.ATT) == null) return null;
 
-		AString issuer = token.getIssuer();
-		if (issuer == null) return null;
 		long now = System.currentTimeMillis() / 1000;
 		// Signature + temporal bounds under the venue's DID verifier, so a
 		// did:web-identified issuer (covia#343) verifies exactly like did:key.
-		if (UCANValidator.validateJWT(jwt, now, engine.didVerifier()) == null) return null;
+		UCAN token = UcanJwtValidator.validateJWT(jwt, now, engine.didVerifier());
+		if (token == null) return null;
+		AString issuer = token.getIssuer();
+		if (issuer == null) return null;
 		requireAudience(token.getAudience());
 		return new VerifiedPrincipal(issuer, issuer, true);
 	}

--- a/venue/src/main/java/covia/venue/server/AuthMiddleware.java
+++ b/venue/src/main/java/covia/venue/server/AuthMiddleware.java
@@ -20,6 +20,7 @@ import covia.venue.Auth;
 import covia.venue.Config;
 import covia.venue.Engine;
 import covia.venue.RequestContext;
+import covia.venue.UcanJwtValidator;
 import covia.venue.api.ACoviaAPI;
 import covia.venue.auth.VenueAuthenticator;
 import io.javalin.config.RoutesConfig;
@@ -59,7 +60,7 @@ public class AuthMiddleware {
 	 * {@code Authorization: Bearer ...} header, when the bearer is a valid
 	 * UCAN (and so also serves as caller authentication). Downstream handlers
 	 * merge this into their transport {@code ucans} vector via
-	 * {@link UCANValidator#parseTransportUCANsWithBearer}. Null when the
+	 * {@link UcanJwtValidator#parseTransportUCANsWithBearer}. Null when the
 	 * request has no bearer token or the bearer is not a UCAN.
 	 */
 	public static final String UCAN_BEARER_ATTR = "ucanBearer";
@@ -384,7 +385,7 @@ public class AuthMiddleware {
 	public static RequestContext withTransportAuth(RequestContext rctx, AString bearer,
 			AVector<ACell> ucans, AString venueDID, DIDVerifier verifier) {
 		// Verify signatures at ingress with an explicit DID verifier.
-		AVector<ACell> proofs = UCANValidator.parseTransportUCANsWithBearer(bearer, ucans,
+		AVector<ACell> proofs = UcanJwtValidator.parseTransportUCANsWithBearer(bearer, ucans,
 			(verifier != null) ? verifier : DIDVerifier.CONVEX);
 		if (proofs == null) return rctx;
 

--- a/venue/src/test/java/covia/adapter/HITLAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/HITLAdapterTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import convex.auth.jwt.JWT;
 import convex.auth.ucan.Capability;
 import convex.auth.ucan.UCAN;
 import convex.core.crypto.AKeyPair;
@@ -184,6 +185,27 @@ public class HITLAdapterTest {
 		assertNotEquals(Strings.create(jwt),
 			RT.getIn(rec, Hitl.RESPONSE, Hitl.ANSWERS, Strings.create("b-access")),
 			"the raw token must not be persisted in the durable inbox record");
+	}
+
+	@Test
+	public void testTokenAskAcceptsLegacyTokenWithoutVersionOrProofs() {
+		engine.getVenueState().users().ensure(BOB_DID);
+		AString agentDID = UCAN.toDIDKey(AKeyPair.generate().getAccountKey());
+		Job job = request(BOB, tokenRequest(agentDID));
+		String id = job.getID().toHexString();
+
+		long exp = (System.currentTimeMillis() / 1000) + HOUR;
+		AMap<AString, ACell> legacyClaims = Maps.of(
+			UCAN.ISS, BOB_DID,
+			UCAN.AUD, agentDID,
+			UCAN.EXP, CVMLong.create(exp),
+			UCAN.ATT, Vectors.of(Capability.create(
+				Strings.create(BOB_DID + "/w/invoices/"), Capability.CRUD_READ)));
+		AString jwt = JWT.signPublic(legacyClaims, BOB_KP);
+
+		respond(BOB, tokenAnswer(id, jwt.toString()));
+		assertEquals(Status.COMPLETE, job.getStatus());
+		assertEquals(jwt, RT.getIn(job.getOutput(), Hitl.TOKENS, Strings.create("b-access")));
 	}
 
 	@Test

--- a/venue/src/test/java/covia/venue/UCANBearerTransportTest.java
+++ b/venue/src/test/java/covia/venue/UCANBearerTransportTest.java
@@ -101,6 +101,24 @@ public class UCANBearerTransportTest {
 			"Bearer UCAN's iss must become the caller DID");
 	}
 
+	@Test
+	public void testLegacyBearerWithoutVersionOrProofsIsAccepted() throws Exception {
+		long exp = (System.currentTimeMillis() / 1000) + 3600;
+		AMap<AString, ACell> legacyClaims = Maps.of(
+			UCAN.ISS, ALICE_DID,
+			UCAN.AUD, engine.getDIDString(),
+			UCAN.EXP, CVMLong.create(exp),
+			UCAN.ATT, Vectors.empty());
+		AString invocation = JWT.signPublic(legacyClaims, ALICE_KP);
+
+		HttpResponse<String> resp = postInvoke(
+			"{\"operation\":\"v/test/ops/echo\",\"input\":{\"message\":\"legacy\"}}",
+			invocation.toString());
+		assertTrue(resp.statusCode() == 200 || resp.statusCode() == 201,
+			() -> "Legacy UCAN bearer should verify: " + resp.statusCode() + " / " + resp.body());
+		assertEquals(ALICE_DID, callerDIDOf(resp));
+	}
+
 	/**
 	 * A tampered bearer token is a hard 401 — presenting credentials is an
 	 * explicit identity claim, and failing that claim must be visible. It is

--- a/venue/src/test/java/covia/venue/UCANVerifyTest.java
+++ b/venue/src/test/java/covia/venue/UCANVerifyTest.java
@@ -7,16 +7,19 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import convex.auth.jwt.JWT;
 import convex.auth.ucan.Capability;
 import convex.auth.ucan.UCAN;
 import convex.core.crypto.AKeyPair;
 import convex.core.data.ACell;
+import convex.core.data.AMap;
 import convex.core.data.AString;
 import convex.core.data.AVector;
 import convex.core.data.Maps;
 import convex.core.data.Strings;
 import convex.core.data.Vectors;
 import convex.core.data.prim.CVMBool;
+import convex.core.data.prim.CVMLong;
 import convex.core.lang.RT;
 import covia.grid.auth.UcanTokens;
 
@@ -116,6 +119,24 @@ public class UCANVerifyTest {
 	}
 
 	@Test
+	public void testLegacyJWTWithoutVersionOrProofsVerifies() {
+		long exp = (System.currentTimeMillis() / 1000) + 3600;
+		AMap<AString, ACell> legacyClaims = Maps.of(
+			UCAN.ISS, ALICE_DID,
+			UCAN.AUD, BOB_DID,
+			UCAN.EXP, CVMLong.create(exp),
+			UCAN.ATT, Vectors.of(Capability.create(
+				Strings.create(ALICE_DID + "/w/shared/"), Capability.CRUD_READ)));
+		AString jwt = JWT.signPublic(legacyClaims, ALICE_KP);
+
+		ACell r = verify(Maps.of("token", jwt));
+		assertEquals(CVMBool.TRUE, RT.getIn(r, "valid"));
+		assertEquals(ALICE_DID, RT.getIn(r, "iss"));
+		assertEquals(0L, RT.ensureLong(RT.getIn(r, "chainDepth")).longValue(),
+			"an omitted legacy prf claim means an empty proof chain");
+	}
+
+	@Test
 	public void testChainDepthAndRoot() {
 		// Alice → Bob (root), Bob → Carol (leaf, narrowed). In JWT transport the
 		// prf entries are the parents' JWT strings (validateJWT recurses on them).
@@ -202,6 +223,55 @@ public class UCANVerifyTest {
 		assertEquals(CVMBool.FALSE, RT.getIn(r, "valid"));
 		assertTrue(RT.ensureString(RT.getIn(r, "reason")).toString().contains("unparseable"),
 			"reason should say unparseable: " + RT.getIn(r, "reason"));
+	}
+
+	@Test
+	public void testBadSignatureExplained() {
+		String jwt = UcanTokens.grant(ALICE_KP, BOB_DID.toString(),
+			ALICE_DID + "/w/", "crud/read", 3600);
+		int signatureStart = jwt.lastIndexOf('.') + 1;
+		char first = jwt.charAt(signatureStart);
+		String tampered = jwt.substring(0, signatureStart)
+			+ ((first == 'A') ? 'B' : 'A') + jwt.substring(signatureStart + 1);
+
+		ACell r = verify(Maps.of("token", tampered));
+		assertEquals(CVMBool.FALSE, RT.getIn(r, "valid"));
+		String reason = RT.ensureString(RT.getIn(r, "reason")).toString();
+		assertTrue(reason.contains("bad signature"), reason);
+	}
+
+	@Test
+	public void testExplicitUnsupportedVersionExplained() {
+		long exp = (System.currentTimeMillis() / 1000) + 3600;
+		AMap<AString, ACell> claims = Maps.of(
+			UCAN.ISS, ALICE_DID,
+			UCAN.AUD, BOB_DID,
+			UCAN.UCV, Strings.create("0.9.0"),
+			UCAN.EXP, CVMLong.create(exp),
+			UCAN.ATT, Vectors.empty(),
+			UCAN.PRF, Vectors.empty());
+		AString jwt = JWT.signPublic(claims, ALICE_KP);
+
+		ACell r = verify(Maps.of("token", jwt));
+		assertEquals(CVMBool.FALSE, RT.getIn(r, "valid"));
+		String reason = RT.ensureString(RT.getIn(r, "reason")).toString();
+		assertTrue(reason.contains("unsupported UCAN version"), reason);
+		assertTrue(reason.contains(UCAN.VERSION.toString()), reason);
+	}
+
+	@Test
+	public void testMissingRequiredClaimExplained() {
+		long exp = (System.currentTimeMillis() / 1000) + 3600;
+		AMap<AString, ACell> claims = Maps.of(
+			UCAN.ISS, ALICE_DID,
+			UCAN.AUD, BOB_DID,
+			UCAN.EXP, CVMLong.create(exp));
+		AString jwt = JWT.signPublic(claims, ALICE_KP);
+
+		ACell r = verify(Maps.of("token", jwt));
+		assertEquals(CVMBool.FALSE, RT.getIn(r, "valid"));
+		String reason = RT.ensureString(RT.getIn(r, "reason")).toString();
+		assertTrue(reason.contains("required claim \"att\""), reason);
 	}
 
 	// ========== UcanTokens helpers (shape) ==========

--- a/venue/src/test/java/covia/venue/VenueServerTest.java
+++ b/venue/src/test/java/covia/venue/VenueServerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.io.TempDir;
 
+import convex.auth.ucan.UCAN;
 import convex.core.crypto.Hashing;
 import convex.core.data.ACell;
 import convex.core.data.AMap;
@@ -422,6 +423,8 @@ public class VenueServerTest {
 		ACell version = status.get(Fields.VERSION);
 		assertNotNull(version, "status must include a non-null version");
 		assertFalse(version.toString().isEmpty(), "version must not be empty");
+		assertEquals(UCAN.VERSION, status.get(Fields.UCAN_PROFILE),
+			"status must advertise the UCAN JWT profile emitted by the venue");
 	}
 	
 	@Test


### PR DESCRIPTION
Fixes #353. Accept correctly signed legacy UCAN JWTs when ucv and prf are omitted, while continuing to emit UCAN 0.10.0 and rejecting explicit unsupported versions. Centralizes enforcement and diagnostics across bearer auth, proof ingestion, federation relay, HITL token transport, and ucan:verify. Advertises ucanProfile in venue status and adds regression coverage. Tests: mvn test.