### PR TITLE
fix: emit DID URL kid for named tokens

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,8 +44,7 @@ jobs:
         if [[ "$CONVEX_VERSION" == *-SNAPSHOT ]]; then
           echo "convex.version=$CONVEX_VERSION — building convex develop from source"
           git clone --depth 1 --branch develop https://github.com/Convex-Dev/convex.git /tmp/convex
-          mvn -f /tmp/convex/pom.xml install -DskipTests -q \
-            -pl convex-core,convex-peer,convex-dlfs,convex-java,convex-restapi -am
+          mvn -f /tmp/convex/pom.xml install -DskipTests -q
         else
           echo "convex.version=$CONVEX_VERSION (released) — skipping source build"
         fi

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -66,8 +66,7 @@ jobs:
         if [[ "$CONVEX_VERSION" == *-SNAPSHOT ]]; then
           echo "convex.version=$CONVEX_VERSION — building convex develop from source"
           git clone --depth 1 --branch develop https://github.com/Convex-Dev/convex.git /tmp/convex
-          mvn -f /tmp/convex/pom.xml install -DskipTests -q \
-            -pl convex-core,convex-peer,convex-dlfs,convex-java,convex-restapi -am
+          mvn -f /tmp/convex/pom.xml install -DskipTests -q
         else
           echo "convex.version=$CONVEX_VERSION (released) — skipping source build"
         fi

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -50,8 +50,7 @@ jobs:
         if [[ "$CONVEX_VERSION" == *-SNAPSHOT ]]; then
           echo "convex.version=$CONVEX_VERSION — building convex develop from source"
           git clone --depth 1 --branch develop https://github.com/Convex-Dev/convex.git /tmp/convex
-          mvn -f /tmp/convex/pom.xml install -DskipTests -q \
-            -pl convex-core,convex-peer,convex-dlfs,convex-java,convex-restapi -am
+          mvn -f /tmp/convex/pom.xml install -DskipTests -q
         else
           echo "convex.version=$CONVEX_VERSION (released) — skipping source build"
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,7 @@ jobs:
         if [[ "$CONVEX_VERSION" == *-SNAPSHOT ]]; then
           echo "convex.version=$CONVEX_VERSION — building convex develop from source"
           git clone --depth 1 --branch develop https://github.com/Convex-Dev/convex.git /tmp/convex
-          mvn -f /tmp/convex/pom.xml install -DskipTests -q \
-            -pl convex-core,convex-peer,convex-dlfs,convex-java,convex-restapi -am
+          mvn -f /tmp/convex/pom.xml install -DskipTests -q
         else
           echo "convex.version=$CONVEX_VERSION (released) — skipping source build"
         fi
@@ -98,8 +97,7 @@ jobs:
         CONVEX_VERSION=$(sed -n 's/.*<convex.version>\(.*\)<\/convex.version>.*/\1/p' pom.xml | head -1)
         if [[ "$CONVEX_VERSION" == *-SNAPSHOT ]]; then
           git clone --depth 1 --branch develop https://github.com/Convex-Dev/convex.git /tmp/convex
-          mvn -f /tmp/convex/pom.xml install -DskipTests -q \
-            -pl convex-core,convex-peer,convex-dlfs,convex-java,convex-restapi -am
+          mvn -f /tmp/convex/pom.xml install -DskipTests -q
         fi
 
     - name: Verify Java 21 fallback without FFM backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ covia/                          # ai.covia:covia (parent POM)
 
 - **Java 21+** (JDK; the published Docker image runs on Java 25)
 - **Maven 3.7+** (enforced by maven-enforcer-plugin)
-- **Convex 0.8.11** — pinned to the Maven Central release. A clean clone builds in one command (`mvn clean install`); no local Convex build is needed. To track an unreleased Convex, build it locally (`mvn install -DskipTests` from `../convex`) and point `convex.version` at its `-SNAPSHOT`; CI compiles Convex from source automatically whenever `convex.version` ends in `-SNAPSHOT`.
+- **Convex 0.8.12-SNAPSHOT** — temporarily tracks unreleased Convex for the explicit JWT `kid` API required by #352. Build it locally first (`mvn install -DskipTests` from `../convex`); CI compiles Convex from `develop` automatically whenever `convex.version` ends in `-SNAPSHOT`. Pin the next Maven Central release before a Covia release.
 
 ## Build & Run
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,7 @@ This document describes how to build the Covia project using Maven.
 - **Maven 3.7+**: Minimum Maven version required (enforced by maven-enforcer-plugin)
 - **Git**: For cloning the repository
 
-All dependencies resolve from Maven Central, including [Convex](https://github.com/Convex-Dev/convex) (`0.8.11`) — the lattice layers the venue state model is built on. A clean clone builds with no extra steps (`mvn clean install`). To track an unreleased Convex, build it from source (`mvn install -DskipTests` in a `develop` checkout of the Convex repo) and point `convex.version` at its `-SNAPSHOT`; CI compiles Convex from source automatically whenever `convex.version` ends in `-SNAPSHOT`, and the step skips itself for a released pin.
+Most dependencies resolve from Maven Central. Convex — the lattice layers the venue state model is built on — temporarily tracks `0.8.12-SNAPSHOT` for the explicit JWT `kid` API required by #352. Build it from source first (`mvn install -DskipTests` in a `develop` checkout of `../convex`), then build Covia normally. CI compiles Convex from `develop` automatically whenever `convex.version` ends in `-SNAPSHOT`; the step skips itself for a released pin. Pin the next Maven Central release before a Covia release.
 
 ## Project Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 
 ### Changed
 
+- Named-user key-pair authentication now emits the verification-method DID URL
+  published by the user's DID document as the JWT `kid`; ordinary `did:key`
+  authentication retains its bare-Multikey header. Covia temporarily tracks
+  Convex `0.8.12-SNAPSHOT` for the explicit-key-ID signing API (#352).
 - Restored compatibility with correctly signed legacy UCAN JWTs that omit the
   `ucv` profile marker and empty `prf` claim. Venues still emit the explicit
   UCAN 0.10.0 profile, reject explicit unsupported versions, advertise the

--- a/covia-core/src/main/java/covia/grid/auth/KeyPairAuth.java
+++ b/covia-core/src/main/java/covia/grid/auth/KeyPairAuth.java
@@ -27,8 +27,9 @@ import convex.auth.jwt.JWT;
  *   <li>{@code exp} — current time + token lifetime</li>
  * </ul>
  *
- * <p>The JWT's {@code kid} header is set automatically by
- * {@link JWT#signPublic} to the Multikey-encoded public key.
+ * <p>For a key-derived identity the JWT's {@code kid} header is the bare
+ * Multikey. For a stable named identity it is the verification-method DID URL
+ * {@code <subject>#<multikey>} published by that identity's DID document.
  */
 class KeyPairAuth extends VenueAuth {
 
@@ -40,6 +41,8 @@ class KeyPairAuth extends VenueAuth {
 	private final String didKey;
 	/** Identity asserted in {@code iss}/{@code sub}; normally {@link #didKey}. */
 	private final String subject;
+	/** JOSE key identifier: bare Multikey, or the named subject's DID URL. */
+	private final AString keyID;
 	/** Target venue DID for the {@code aud} claim; null = no audience binding. */
 	private final String audience;
 
@@ -74,6 +77,9 @@ class KeyPairAuth extends VenueAuth {
 		AString multikey = Multikey.encodePublicKey(keyPair.getAccountKey());
 		this.didKey = "did:key:" + multikey;
 		this.subject = (subject != null) ? subject : didKey;
+		this.keyID = (subject != null)
+			? Strings.create(this.subject + "#" + multikey)
+			: multikey;
 	}
 
 	@Override
@@ -102,7 +108,7 @@ class KeyPairAuth extends VenueAuth {
 			JWT.EXP, nowSecs + tokenLifetime
 		);
 		if (audience != null) claims = claims.assoc(JWT.AUD, Strings.create(audience));
-		return JWT.signPublic(claims, keyPair);
+		return JWT.signPublic(claims, keyPair, keyID);
 	}
 
 	/**

--- a/covia-core/src/test/java/covia/grid/auth/KeyPairAuthTest.java
+++ b/covia-core/src/test/java/covia/grid/auth/KeyPairAuthTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import convex.auth.jwt.JWT;
 import convex.core.crypto.AKeyPair;
+import convex.core.crypto.util.Multikey;
 import convex.core.data.ACell;
 import convex.core.data.AMap;
 import convex.core.data.AString;
@@ -24,24 +25,37 @@ import convex.core.lang.RT;
  */
 public class KeyPairAuthTest {
 
-	/** Applies the auth to a request and returns the verified JWT claims. */
-	private static AMap<AString, ACell> claimsFor(VenueAuth auth) {
+	/** Applies the auth and returns the raw bearer JWT. */
+	private static AString tokenFor(VenueAuth auth) {
 		HttpRequest.Builder b = HttpRequest.newBuilder(URI.create("http://localhost:1/x")).GET();
 		auth.apply(b);
 		Optional<String> header = b.build().headers().firstValue("Authorization");
 		assertTrue(header.isPresent(), "auth must set an Authorization header");
-		String jwt = header.get().substring("Bearer ".length());
-		AMap<AString, ACell> claims = JWT.verifyPublic(Strings.create(jwt));
+		return Strings.create(header.get().substring("Bearer ".length()));
+	}
+
+	/** Applies the auth to a request and returns the verified JWT claims. */
+	private static AMap<AString, ACell> claimsFor(VenueAuth auth) {
+		AMap<AString, ACell> claims = JWT.verifyPublic(tokenFor(auth));
 		assertNotNull(claims, "self-issued JWT must verify against its embedded key");
 		return claims;
+	}
+
+	private static AString kidFor(VenueAuth auth) {
+		JWT jwt = JWT.parse(tokenFor(auth));
+		assertNotNull(jwt);
+		return RT.ensureString(jwt.getHeader().get(JWT.KID));
 	}
 
 	@Test
 	public void testDefaultHasNoAudience() {
 		AKeyPair kp = AKeyPair.generate();
-		AMap<AString, ACell> claims = claimsFor(VenueAuth.keyPair(kp));
+		VenueAuth auth = VenueAuth.keyPair(kp);
+		AMap<AString, ACell> claims = claimsFor(auth);
 		assertNull(claims.get(Strings.intern("aud")), "plain keyPair auth carries no aud");
 		assertEquals(RT.getIn(claims, "iss"), RT.getIn(claims, "sub"), "self-issued: iss == sub");
+		assertEquals(Multikey.encodePublicKey(kp.getAccountKey()), kidFor(auth),
+			"ordinary did:key auth keeps the bare Multikey kid");
 	}
 
 	@Test
@@ -82,6 +96,9 @@ public class KeyPairAuthTest {
 		assertEquals(Strings.create(subject), RT.getIn(claims, "iss"));
 		assertEquals(Strings.create(audience), RT.getIn(claims, "aud"));
 		assertEquals(subject, auth.getDID());
+		AString multikey = Multikey.encodePublicKey(kp.getAccountKey());
+		assertEquals(Strings.create(subject + "#" + multikey), kidFor(auth),
+			"named auth kid must match the verification-method DID URL");
 
 		AMap<AString, ACell> minted =
 			JWT.verifyPublic(Strings.create(auth.mintToken()));

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<maven.compiler.release>21</maven.compiler.release>
 		<maven.compiler.source>21</maven.compiler.source>
 		<junit.version>6.1.3</junit.version>
-		<convex.version>0.8.11</convex.version>
+		<convex.version>0.8.12-SNAPSHOT</convex.version>
 		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		

--- a/venue/src/main/java/covia/venue/auth/VenueAuthenticator.java
+++ b/venue/src/main/java/covia/venue/auth/VenueAuthenticator.java
@@ -305,12 +305,16 @@ public final class VenueAuthenticator {
 			if (kid == null) return null;
 			String value = kid.toString();
 			String multikey;
-			if (value.startsWith("did:key:")) {
+			// A DID-URL kid is meaningful only in the asserted subject's DID
+			// document. Its fragment is the Multikey published by UserAPI.
+			int fragment = value.lastIndexOf('#');
+			if (fragment >= 0) {
+				if (!value.substring(0, fragment).equals(subject.toString())) return null;
+				multikey = value.substring(fragment + 1);
+			} else if (value.startsWith("did:key:")) {
 				multikey = value.substring("did:key:".length());
 			} else {
-				String namedPrefix = subject + "#";
-				multikey = value.startsWith(namedPrefix)
-					? value.substring(namedPrefix.length()) : value;
+				multikey = value;
 			}
 			if (Multikey.decodePublicKey(multikey) == null) return null;
 			return Strings.create("did:key:" + multikey);

--- a/venue/src/test/java/covia/venue/api/UserAPITest.java
+++ b/venue/src/test/java/covia/venue/api/UserAPITest.java
@@ -108,7 +108,8 @@ public class UserAPITest {
 		AMap<AString, ACell> userMethod = RT.ensureMap(methods.get(1));
 		AString multikey = Strings.create(userKey.toString().substring("did:key:".length()));
 		assertEquals(Strings.create(userDID + "#" + multikey),
-			userMethod.get(Strings.create("id")));
+			userMethod.get(Strings.create("id")),
+			"named-token kid must be able to match this verification-method DID URL (#352)");
 		assertEquals(Strings.create(userDID), userMethod.get(Strings.create("controller")));
 		assertEquals(multikey, userMethod.get(Strings.create("publicKeyMultibase")));
 		assertEquals(keyID, RT.ensureVector(doc.get(Strings.create("assertionMethod"))).get(0));


### PR DESCRIPTION
Fixes #352.\n\nNamed key-pair authentication now emits the exact verification-method DID URL published by the subject DID document, while ordinary did:key authentication retains the bare Multikey kid. Server normalization also rejects DID URL kids whose controller prefix does not match the asserted subject.\n\nThis temporarily tracks Convex 0.8.12-SNAPSHOT for the new explicit-kid signing API; it must be pinned to the next Maven Central release before a Covia release.\n\nTests: mvn test