### PR TITLE
fix: enforce asset/store capability on POST /api/v1/assets

### DIFF
--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -295,10 +295,18 @@ public class CoviaAPI extends ACoviaAPI {
 					})	
 	protected void addAsset(Context ctx) {
 		try {
+			// Enforces the asset-store capability (consistent with the asset:store
+			// operation, AssetAdapter.handleStore) — registering new metadata is a
+			// write and must not be reachable by the default read-only public scope.
+			RequestContext rctx = AuthMiddleware.callerContext(ctx);
+			engine().requireAuthority(rctx, Strings.create(""), Abilities.ASSET_STORE);
+
 			AString meta=Strings.fromStream(ctx.bodyInputStream());
 			Hash id=venue.registerAsset(meta);
 			buildResult(ctx,201,id.toHexString());
 			ctx.header("Location",ROUTE+"assets/"+id.toHexString());
+		} catch (AuthException e) {
+			buildError(ctx,403,"Not authorised to register asset metadata");
 		} catch (ClassCastException | IOException | ParseException e) {
 			throw new BadRequestResponse("Unable to parse asset metadata: "+e.getMessage());
 		}

--- a/venue/src/test/java/covia/venue/PublicScopeTest.java
+++ b/venue/src/test/java/covia/venue/PublicScopeTest.java
@@ -1,10 +1,13 @@
 package covia.venue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -16,6 +19,7 @@ import convex.auth.ucan.Capability;
 import convex.auth.ucan.UCAN;
 import convex.core.crypto.AKeyPair;
 import convex.core.data.AString;
+import convex.core.data.Hash;
 import convex.core.data.Maps;
 import convex.core.data.Strings;
 import convex.core.data.Vectors;
@@ -141,6 +145,20 @@ public class PublicScopeTest {
 	}
 
 	@Test
+	public void anonymousAssetRegistrationDeniedByDefault() throws Exception {
+		// covia#360 — POST /api/v1/assets (registerAsset) bypassed the capability
+		// check entirely, so an anonymous caller could register asset metadata
+		// under the nominally read-only default. It must require asset/store,
+		// same as the asset:store operation (AssetAdapter.handleStore).
+		VenueHTTP pub = anon(secureBase);
+		ExecutionException ex = assertThrows(ExecutionException.class, () ->
+			pub.addAsset(Maps.of(Strings.create("name"), Strings.create("probe")))
+				.get(5, TimeUnit.SECONDS));
+		assertTrue(causeChain(ex).contains("403") || causeChain(ex).contains("Not authorised"),
+			"anonymous asset registration must be denied, got: " + causeChain(ex));
+	}
+
+	@Test
 	public void authenticatedMutationAllowed() throws Exception {
 		VenueHTTP client = authed(secureServer);
 		Job job = client.invokeAndWait(OP_WRITE, Maps.of(
@@ -160,5 +178,13 @@ public class PublicScopeTest {
 			Strings.create("value"), Strings.create("ok")));
 		assertEquals(Status.COMPLETE, job.getStatus(),
 			"auth.public.caps=unrestricted re-opens public mutation");
+	}
+
+	@Test
+	public void unrestrictedConfigAllowsAnonymousAssetRegistration() throws Exception {
+		VenueHTTP pub = anon(openBase);
+		Hash id = pub.addAsset(Maps.of(Strings.create("name"), Strings.create("probe")))
+			.get(5, TimeUnit.SECONDS);
+		assertNotNull(id, "auth.public.caps=unrestricted re-opens anonymous asset registration");
 	}
 }


### PR DESCRIPTION
## Summary

- `addAsset` (`POST /api/v1/assets`) was the one write endpoint with no `requireAuthority` check at all — every other write path (`invoke`, `run`, `secrets`) correctly denies an anonymous caller under the default read-only public scope, but asset registration returned `201` regardless.
- Gates it the same way `getAsset` gates reads, using `Abilities.ASSET_STORE` — the ability already enforced by the equivalent `asset:store` operation (`AssetAdapter.handleStore`). A denial now surfaces as a clean `403`, not the generic `500` a raw `AuthException` would otherwise fall through to.

## Test plan

- [x] New `PublicScopeTest.anonymousAssetRegistrationDeniedByDefault` — anonymous registration denied under the secure default
- [x] New `PublicScopeTest.unrestrictedConfigAllowsAnonymousAssetRegistration` — still allowed when an operator opts into `auth.public.caps=unrestricted`
- [x] `mvn -pl venue test -Dtest=PublicScopeTest` — 7/7 pass
- [x] `mvn -pl venue test` (full module) — 2088/2089 pass; the one failure (`CapabilityGateTest.testAgentConfigCapsWithGate`, an agent-chat status-timing assertion unrelated to asset registration) reproduces on `develop` without this change and passes deterministically in isolation, so it's pre-existing flakiness, not a regression from this diff.

Fixes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)