### PR TITLE
Fix caller-scoped asset resolution for 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,17 @@ Covia is pre-1.0, so minor versions may include breaking changes.
   replaced deployment-specific hostnames in generic examples and test fixtures
   with RFC-reserved domains. The venue inventory now flags venue-3's expired
   TLS certificate and avoids duplicating dev-host coordinates in usage examples.
+- Strengthened DLFS regression coverage for long sibling names and concurrent
+  staged-file promotion, directory listing, lattice sync, and encrypted Etch v3
+  restart. The reported corruption does not reproduce locally on either Convex
+  0.8.11 or 0.8.12, so no dependency-level fix is claimed (#342).
 
 ### Fixed
 
-- DLFS sibling filenames that share their first 32 characters now remain
-  distinct instead of the second write silently replacing the first. Convex
-  0.8.12 supplies the fix; Covia pins the reported write/read/list regression
-  through its DLFS adapter (#342).
+- Scoped caller-facing asset hashes to the current caller's `/a` namespace,
+  including metadata and content reads and writes. Venue catalog access is now
+  explicit for federation and no longer acts as an authorization-bypassing
+  fallback for user requests (#368).
 
 ## [0.9.0] - 2026-08-10
 

--- a/covia-core/src/main/java/covia/grid/client/VenueHTTP.java
+++ b/covia-core/src/main/java/covia/grid/client/VenueHTTP.java
@@ -865,6 +865,21 @@ public class VenueHTTP extends Venue {
 			return BlobContent.of(blob);
 		});
 	}
+
+	/** Fetches content explicitly from the connected venue's published catalog. */
+	public CompletableFuture<AContent> getVenueContent(Hash assetID) {
+		HttpRequest req = requestBuilder(
+			"assets/" + assetID.toHexString() + "/content?namespace=venue")
+			.GET().build();
+		return dispatch(req, HttpResponse.BodyHandlers.ofByteArray()).thenApply(response -> {
+			int code=response.statusCode();
+			if (code != 200) {
+				throw new ResponseException("Venue content get failed with status: " +code
+					+" -- asset ID: "+assetID);
+			}
+			return BlobContent.of(convex.core.data.Blob.wrap(response.body()));
+		});
+	}
 	
 	@Override
 	protected AContent getAssetContent(Hash assetID) {
@@ -1029,7 +1044,13 @@ public class VenueHTTP extends Venue {
 
 	@Override
 	public Asset getAsset(Hash id) throws IOException {
-		HttpRequest request=requestBuilder("assets/"+id.toHexString())
+		return getAsset(id, false);
+	}
+
+	private Asset getAsset(Hash id, boolean venueCatalog) throws IOException {
+		String path="assets/"+id.toHexString();
+		if (venueCatalog) path += "?namespace=venue";
+		HttpRequest request=requestBuilder(path)
 				.GET()
 				.build();
 			
@@ -1047,6 +1068,11 @@ public class VenueHTTP extends Venue {
 			return null;
 		}
 		
+	}
+
+	/** Fetches a definition explicitly from the connected venue's catalog. */
+	public Asset getVenueAsset(Hash id) throws IOException {
+		return getAsset(id, true);
 	}
 
 	/**

--- a/venue/src/main/java/covia/adapter/AssetAdapter.java
+++ b/venue/src/main/java/covia/adapter/AssetAdapter.java
@@ -305,7 +305,10 @@ public class AssetAdapter extends AAdapter {
 			ACell value = engine.resolvePath(idStr, ctx);
 			if (value instanceof AMap) {
 				Hash derived = ((AMap<AString, ACell>) value).getHash();
-				record = engine.getAssetRecord(derived, readAs);
+				String source = idStr.toString();
+				AString recordOwner = (source.startsWith("v/") || source.startsWith("/v/"))
+					? engine.getDIDString() : readAs;
+				record = engine.getAssetRecord(derived, recordOwner);
 			}
 		}
 

--- a/venue/src/main/java/covia/venue/Engine.java
+++ b/venue/src/main/java/covia/venue/Engine.java
@@ -81,6 +81,7 @@ import covia.grid.Asset;
 import covia.grid.Grid;
 import covia.grid.Operation;
 import covia.grid.Venue;
+import covia.grid.client.VenueHTTP;
 import covia.lattice.Covia;
 import covia.venue.api.CoviaAPI;
 import covia.venue.storage.AStorage;
@@ -966,38 +967,39 @@ public class Engine {
 	}
 
 	/**
-	 * Get an asset record by Hash — checks user namespace first, then venue.
-	 * This is the single resolution point for all asset lookups by hash.
+	 * Compatibility lookup for internal hash-based operation resolution.
+	 *
+	 * <p>Checks the caller first, then the venue catalog because installed
+	 * operations have historically been invoked by hash. User-facing asset APIs,
+	 * where a bare hash means {@code <callerDID>/a/<hash>}, use the exact-DID
+	 * overload and never enter this compatibility fallback.</p>
 	 */
 	public AVector<?> getAssetRecord(Hash assetID, RequestContext ctx) {
-		// Check user's /a/ first
-		if (ctx != null && ctx.getUserDID() != null) {
-			User user = getVenueState().users().get(ctx.getUserDID());
-			if (user != null) {
-				AVector<?> arec = user.assets().getRecord(assetID);
-				if (arec != null) return arec;
-			}
-		}
-		// Fall back to venue-level assets
+		AString callerDID = (ctx != null) ? ctx.getUserDID() : null;
+		AVector<?> callerRecord = getAssetRecord(assetID, callerDID);
+		if (callerRecord != null) return callerRecord;
+		// Compatibility for internal operation resolution: many installed
+		// definitions are invoked by their hash. User-facing REST resolution does
+		// not use this fallback; it calls the exact-DID overload above.
 		return venueState.assets().getRecord(assetID);
 	}
 
 	/**
-	 * Get an asset record by Hash — checks a specific user, then venue.
+	 * Get an asset record by Hash from one explicitly named DID namespace.
+	 * The venue DID names the venue catalog; every other DID names exactly that
+	 * user's {@code /a} store. There is deliberately no cross-namespace fallback.
 	 */
 	public AVector<?> getAssetRecord(Hash assetID, AString userDID) {
-		if (userDID != null) {
-			User user = getVenueState().users().get(userDID);
-			if (user != null) {
-				AVector<?> arec = user.assets().getRecord(assetID);
-				if (arec != null) return arec;
-			}
-		}
-		return venueState.assets().getRecord(assetID);
+		if (assetID == null || userDID == null) return null;
+		if (userDID.equals(getDIDString())) return venueState.assets().getRecord(assetID);
+		AString webDID = config.getWebDID();
+		if (webDID != null && userDID.equals(webDID)) return venueState.assets().getRecord(assetID);
+		User user = getVenueState().users().get(userDID);
+		return (user != null) ? user.assets().getRecord(assetID) : null;
 	}
 
 	/**
-	 * Get an Asset by its Hash ID — checks user namespace first, then venue.
+	 * Compatibility Asset lookup: caller namespace first, then venue catalog.
 	 */
 	public Asset getAsset(Hash assetID, RequestContext ctx) {
 		AVector<?> arec = getAssetRecord(assetID, ctx);
@@ -1352,13 +1354,7 @@ public class Engine {
 		return null;
 	}
 
-	/**
-	 * Looks up a parsed asset reference in local stores: the named
-	 * principal's asset records first, then the venue store. Content
-	 * addressing makes any local copy authoritative — the hash alone
-	 * identifies the value, so WHO the reference names cannot change
-	 * what is returned, only where we look first.
-	 */
+	/** Looks up a parsed asset reference in exactly the named DID's store. */
 	private Asset lookupLocalAsset(AssetRef r) {
 		AVector<?> rec = getAssetRecord(r.hash(), Strings.create(r.didString()));
 		if (rec == null) return null;
@@ -1537,10 +1533,16 @@ public class Engine {
 			ACell contentMeta = RT.getIn(def.meta(), Fields.CONTENT);
 			if (contentMeta == null) return null;   // metadata declares no content — genuine
 
-			// Venue-bound handle for the content stream itself.
-			Asset handle = Asset.create(id, def.getMetadata());
-			handle.setVenue(remote);
-			AContent content = handle.getContent();
+			// HTTP federation names the publisher's explicit venue catalog; a bare
+			// hash on the normal user API would instead mean the remote caller's /a/.
+			AContent content;
+			if (remote instanceof VenueHTTP http) {
+				content = http.getVenueContent(id).join();
+			} else {
+				Asset handle = Asset.create(id, def.getMetadata());
+				handle.setVenue(remote);
+				content = handle.getContent();
+			}
 			if (content == null) return null;
 			ABlob blob = content.getBlob().toFlatBlob();
 
@@ -1584,7 +1586,8 @@ public class Engine {
 	public Asset fetchRemoteAsset(Venue remote, Hash id) {
 		String venue = venueLabel(remote);
 		try {
-			Asset fetched = remote.getAsset(id);
+			Asset fetched = (remote instanceof VenueHTTP http)
+				? http.getVenueAsset(id) : remote.getAsset(id);
 			if (fetched == null) return null;   // genuine absence: the remote answered but has no such asset
 			// getID() recomputes the CAD3 hash from the returned metadata —
 			// equality with the requested id IS the integrity check. (Also
@@ -1772,7 +1775,8 @@ public class Engine {
 				if (hop != null) record = getAssetRecord(hop, ctx);
 				if (record != null) meta = record.get(AssetStore.POS_META);
 			} else if (value instanceof AMap) {
-				record = getAssetRecord(((AMap<?, ?>) value).getHash(), ctx);
+				RequestContext recordContext = isVenuePath(ref) ? venueContext() : ctx;
+				record = getAssetRecord(((AMap<?, ?>) value).getHash(), recordContext);
 				meta = (record != null) ? record.get(AssetStore.POS_META) : value;
 			} else if (value instanceof convex.core.data.ABlob b) {
 				return new covia.venue.storage.ContentProvider.Resolved(
@@ -1834,6 +1838,12 @@ public class Engine {
 			return new covia.venue.storage.ContentProvider.Resolved(r.content(), type);
 		}
 		return null;
+	}
+
+	private static boolean isVenuePath(AString ref) {
+		if (ref == null) return false;
+		String s = ref.toString();
+		return s.startsWith("v/") || s.startsWith("/v/");
 	}
 
 	/** Consults adapter-registered content providers for a reference; null when
@@ -2393,13 +2403,11 @@ public class Engine {
 	 */
 	public boolean crossUserAllows(RequestContext ctx, AString resource, AString ability) {
 		if (ctx == null || resource == null || ability == null) return false;
-		// The venue's own asset catalog is public. getAssetRecord resolves every
-		// caller's bare-hash reads through the venue store, so the venue's own
-		// <venueDID>/a/<hash> assets are readable by anyone; the DID-scoped form of
-		// the same read is therefore allowed too. This is NOT true of another
-		// user's /a/ — that is their private asset store, reached (covia:read →
-		// resolveLocalDIDURL) via the named DID, and needs a proof: knowing a hash
-		// is not authorisation to read someone else's asset.
+		// The venue's explicitly addressed asset catalog is public. This is NOT
+		// true of another user's /a/: knowing a hash is not authorisation to read
+		// someone else's asset. On user-facing APIs a bare hash names the caller's
+		// own /a/; internal operation resolution retains a documented compatibility
+		// fallback for installed venue operations.
 		if (isVenueCatalogRead(resource, ability)) return true;
 		if (auth.isPublicAccessEnabled()) {
 			String publicDIDStr = getDIDString().toString() + ":public";
@@ -2417,10 +2425,9 @@ public class Engine {
 		return proofsCover(ctx, resource, ability, System.currentTimeMillis() / 1000);
 	}
 
-	/** A read of the venue's OWN content-addressed catalog ({@code <venueDID>/a/…}).
-	 *  These assets live in the shared venue store that every caller's bare-hash
-	 *  read already falls back to, so the catalog is public — but only for reads,
-	 *  and only for the venue's own DID (another user's {@code /a/} is private). */
+	/** A read of the venue's explicitly addressed content catalog
+	 *  ({@code <venueDID>/a/…}). It is public only for reads and only for the
+	 *  venue's own DID; bare hashes and another user's {@code /a/} are private. */
 	private boolean isVenueCatalogRead(AString resource, AString ability) {
 		if (!Capability.CRUD_READ.equals(ability) && !Abilities.ASSET_READ.equals(ability)) return false;
 		return resource.toString().startsWith(getDIDString().toString() + "/a/");

--- a/venue/src/main/java/covia/venue/LocalVenue.java
+++ b/venue/src/main/java/covia/venue/LocalVenue.java
@@ -150,8 +150,13 @@ public class LocalVenue extends Venue {
 		// /assets/{id}/content endpoint and the client Asset.getContent() reach
 		// here, so routing through it (rather than the blob-only getContent) is
 		// what makes inline content fetchable over HTTP (covia#289).
+		// A LocalVenue with no caller context represents the venue's published
+		// catalog (used by the explicit HTTP namespace=venue path). A caller-bound
+		// LocalVenue continues to resolve the same bare hash in that caller's /a/.
+		RequestContext rctx = (requestContext == null && getUser() == null)
+			? engine.venueContext() : context();
 		covia.venue.storage.ContentProvider.Resolved resolved =
-			engine.resolveContent(convex.core.data.Strings.create(id.toHexString()), context());
+			engine.resolveContent(convex.core.data.Strings.create(id.toHexString()), rctx);
 		return (resolved == null) ? null : resolved.content();
 	}
 

--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -41,6 +41,7 @@ import covia.grid.Venue;
 import covia.venue.api.model.ErrorResponse;
 import covia.venue.api.model.InvokeRequest;
 import covia.venue.api.model.InvokeResult;
+import covia.venue.AssetStore;
 import covia.venue.RequestContext;
 import covia.venue.SecretStore;
 import covia.venue.User;
@@ -302,7 +303,9 @@ public class CoviaAPI extends ACoviaAPI {
 			engine().requireAuthority(rctx, Strings.create(""), Abilities.ASSET_STORE);
 
 			AString meta=Strings.fromStream(ctx.bodyInputStream());
-			Hash id=venue.registerAsset(meta);
+			// A caller-created asset belongs to that caller's /a namespace. Venue
+			// catalog assets are installed internally and addressed explicitly.
+			Hash id=engine().storeUserAsset(meta, null, rctx);
 			buildResult(ctx,201,id.toHexString());
 			ctx.header("Location",ROUTE+"assets/"+id.toHexString());
 		} catch (AuthException e) {
@@ -331,6 +334,26 @@ public class CoviaAPI extends ACoviaAPI {
 	protected void getAsset(Context ctx) {
 		String ref=ctx.pathParam("id");
 		if (ref==null || ref.isEmpty()) throw new BadRequestResponse("Missing asset reference");
+		if ("venue".equals(ctx.queryParam("namespace"))) {
+			Hash hash = Hash.parse(ref);
+			if (hash == null) {
+				buildError(ctx,400,"Venue catalog lookup requires a bare asset hash");
+				return;
+			}
+			try {
+				Asset asset = venue.getAsset(hash);
+				if (asset == null) {
+					buildError(ctx,404,"Venue asset not found: "+ref);
+					return;
+				}
+				ctx.header("ETag","\"0x"+hash.toHexString()+"\"");
+				ctx.result(asset.getMetadata().toString());
+				ctx.status(200);
+			} catch (IOException e) {
+				buildError(ctx,500,"Error retrieving venue asset: "+e.getMessage());
+			}
+			return;
+		}
 
 		// Caller identity + transport UCAN authority (a bearer UCAN supplies the
 		// proof for cross-DID reads, per the IETF UCAN-HTTP convention).
@@ -374,14 +397,18 @@ public class CoviaAPI extends ACoviaAPI {
 	 */
 	private Asset resolveAssetReference(String ref, RequestContext ctx) throws IOException {
 		AString refStr = Strings.create(ref);
-		engine().requireAuthority(ctx,refStr, Abilities.ASSET_READ);
+		engine().requireResourceAccess(ctx,refStr, Abilities.ASSET_READ);
 
-		// Content-addressed forms (bare hex, a/<hash>, did:.../a/<hash>) — fetch
+		// Caller-relative content-addressed forms (bare hex and a/<hash>) — fetch
 		// the stored record so the returned bytes are byte-identical to the legacy
 		// assets/<hash> route, keeping content-addressed lookups self-verifying.
-		Hash hash = parseContentAddressedId(ref);
+		Hash hash = parseCallerAssetId(ref);
 		if (hash != null) {
-			return venue.getAsset(hash);
+			AString owner = engine().requireLocalAccess(ctx, refStr, Abilities.ASSET_READ);
+			AVector<?> record = engine().getAssetRecord(hash, owner);
+			if (record == null) return null;
+			AString metadata = RT.ensureString(record.get(AssetStore.POS_JSON));
+			return (metadata != null) ? Asset.create(hash, metadata) : null;
 		}
 
 		// Any other lattice address — resolve via the universal resolver (the same
@@ -401,15 +428,15 @@ public class CoviaAPI extends ACoviaAPI {
 	}
 
 	/**
-	 * Strict parse of a content-addressed asset id: a bare hex CAD3 hash,
-	 * {@code a/<hash>}, or a DID URL ending in {@code /a/<hash>}. Returns null
-	 * for mutable lattice paths ({@code w/…}, {@code o/…}), which are resolved
-	 * through the lattice instead.
+	 * Strict parse of a caller-relative content-addressed asset id: a bare hex
+	 * CAD3 hash or {@code a/<hash>}. DID URLs and mutable lattice paths return
+	 * null and are resolved with their explicit owner/path semantics.
 	 */
-	private static Hash parseContentAddressedId(String ref) {
-		int aPos = ref.indexOf("/a/");
-		if (aPos >= 0) return Hash.parse(ref.substring(aPos + 3));
+	private static Hash parseCallerAssetId(String ref) {
+		if (ref == null) return null;
+		if (ref.startsWith("/a/")) return Hash.parse(ref.substring(3));
 		if (ref.startsWith("a/")) return Hash.parse(ref.substring(2));
+		if (ref.startsWith("did:")) return null;
 		return Hash.parse(ref);
 	}
 	
@@ -440,30 +467,79 @@ public class CoviaAPI extends ACoviaAPI {
 					})	
 	protected void getContent(Context ctx) {
 		String id=ctx.pathParam("id");
-		Hash assetID=Hash.parse(id);
-
 		try {
-			Asset asset=venue.getAsset(assetID);
-			if (asset==null) {
+			if ("venue".equals(ctx.queryParam("namespace"))) {
+				Hash venueAssetID=Hash.parse(id);
+				if (venueAssetID==null) {
+					buildError(ctx,400,"Venue catalog lookup requires a bare asset hash");
+					return;
+				}
+				Asset asset=venue.getAsset(venueAssetID);
+				if (asset==null) {
+					buildError(ctx,404,"Venue asset not found: "+id);
+					return;
+				}
+				AMap<AString,ACell> meta=asset.meta();
+				if (!meta.containsKey(Fields.CONTENT)) {
+					buildError(ctx,404,"Asset metadata does not specify any content object: "+id);
+					return;
+				}
+				AContent content=asset.getContent();
+				if (content==null) {
+					buildError(ctx,404,"Asset did not have any content available: "+id);
+					return;
+				}
+				ACell contentMeta=meta.get(Fields.CONTENT);
+				ACell contentType=RT.getIn(contentMeta,Fields.CONTENT_TYPE);
+				if (contentType instanceof AString ct) ctx.contentType(ct.toString());
+				if (ctx.queryParam("inline")!=null) ctx.header("Content-Disposition","inline");
+				ACell fileName=RT.getIn(contentMeta,Fields.FILE_NAME);
+				if (fileName instanceof AString fn) ctx.header("filename",fn.toString());
+				ctx.result(content.getInputStream());
+				ctx.status(200);
+				return;
+			}
+
+			Hash assetID=parseCallerAssetId(id);
+			if (assetID==null) {
+				buildError(ctx,400,"Invalid caller asset reference: "+id);
+				return;
+			}
+
+			RequestContext rctx = AuthMiddleware.callerContext(ctx);
+			AString bearer = ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR);
+			rctx = AuthMiddleware.withTransportAuth(rctx, bearer, null, null, engine().didVerifier());
+			AString ref = Strings.create(id);
+			AString readAs = engine().requireLocalAccess(rctx, ref, Abilities.ASSET_READ);
+			AVector<?> record = engine().getAssetRecord(assetID, readAs);
+			if (record==null) {
 				buildError(ctx,404,"Asset not found: "+id);
 				return;
 			}
 
-			AMap<AString,ACell> meta=asset.meta();
+			AMap<AString,ACell> meta=RT.ensureMap(record.get(AssetStore.POS_META));
+			if (meta==null) {
+				buildError(ctx,500,"Stored asset metadata is invalid: "+id);
+				return;
+			}
 			if (!meta.containsKey(Fields.CONTENT)) {
 				buildError(ctx,404,"Asset metadata does not specify any content object: "+id);
 				return;
 			}
 
 			ACell contentMeta=meta.get(Fields.CONTENT);
-			AContent content = asset.getContent();
-			if (content==null) {
+			covia.venue.storage.ContentProvider.Resolved resolved =
+				engine().resolveContent(ref, rctx);
+			if (resolved==null) {
 				buildError(ctx,404,"Asset did not have any content available: "+id);
 				return;
 			}
+			AContent content = resolved.content();
 			ACell contentType=RT.getIn(contentMeta,Fields.CONTENT_TYPE);
 			if (contentType instanceof AString ct) {
 				ctx.contentType(ct.toString());
+			} else if (resolved.contentType()!=null) {
+				ctx.contentType(resolved.contentType());
 			}
 			if (ctx.queryParam("inline")!=null) {
 				ctx.header("Content-Disposition","inline");
@@ -476,8 +552,10 @@ public class CoviaAPI extends ACoviaAPI {
 
 			ctx.result(content.getInputStream());
 			ctx.status(200);
+		} catch (AuthException e) {
+			buildError(ctx,403,"Not authorised to read asset content: "+id);
 		} catch (IOException e) {
-			ctx.status(500);
+			buildError(ctx,500,"Error retrieving asset content: "+e.getMessage());
 		}
 	}
 	
@@ -500,14 +578,29 @@ public class CoviaAPI extends ACoviaAPI {
 					})	
 	protected void putContent(Context ctx) {
 		String idString=ctx.pathParam("id");
-		Hash assetID=Hash.parse(idString);
-
 		try {
-			Asset asset=venue.getAsset(assetID);
-			if (asset==null) {
+			Hash assetID=parseCallerAssetId(idString);
+			if (assetID==null) {
+				buildError(ctx,400,"Invalid caller asset reference: "+idString);
+				return;
+			}
+
+			RequestContext rctx = AuthMiddleware.callerContext(ctx);
+			AString bearer = ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR);
+			rctx = AuthMiddleware.withTransportAuth(rctx, bearer, null, null, engine().didVerifier());
+			AString ref = Strings.create(idString);
+			AString writeAs=engine().requireLocalAccess(rctx, ref, Abilities.ASSET_STORE);
+			AVector<?> record=engine().getAssetRecord(assetID, writeAs);
+			if (record==null) {
 				buildError(ctx,404,"Asset not found: "+idString);
 				return;
 			}
+			AString metadata=RT.ensureString(record.get(AssetStore.POS_JSON));
+			if (metadata==null) {
+				buildError(ctx,500,"Stored asset metadata is invalid: "+idString);
+				return;
+			}
+			Asset asset=Asset.create(assetID, metadata);
 
 			AMap<AString,ACell> meta=asset.meta();
 			if (!meta.containsKey(Fields.CONTENT)) {
@@ -516,9 +609,11 @@ public class CoviaAPI extends ACoviaAPI {
 			}
 
 			InputStream is=ctx.bodyInputStream();
-			Hash contentHash= venue.putAssetContent(asset,is);
+			Hash contentHash= engine().putContent(asset,is);
 			buildResult(ctx,200,contentHash);
 
+		} catch (AuthException e) {
+			buildError(ctx,403,"Not authorised to store asset content: "+idString);
 		} catch (IllegalArgumentException e) {
 			this.buildError(ctx, 400, "Cannot PUT asset content: "+e.getMessage());
 		} catch (IOException | OutOfMemoryError e) {

--- a/venue/src/test/java/covia/adapter/DLFSAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/DLFSAdapterTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -105,11 +107,20 @@ public class DLFSAdapterTest {
 		String second = "x".repeat(32) + " (2).txt";
 		run("v/ops/dlfs/create-drive", Maps.of("name", drive));
 
-		run("v/ops/dlfs/write", Maps.of(
-			"drive", drive, "path", first, "content", "one"));
-		run("v/ops/dlfs/write", Maps.of(
-			"drive", drive, "path", second, "content", "two"));
+		// Use the exact NIO shape from #342/GetMine rather than two adapter
+		// invocations. The old Convex provider truncated the directory-entry
+		// lookup key on this long-lived filesystem view, so a fresh cursor per
+		// adapter call could accidentally miss the original reproducer.
+		DLFSAdapter adapter = (DLFSAdapter) engine.getAdapter("dlfs");
+		Path dir = adapter.getDriveForIdentity(ALICE_DID.toString(), drive).getPath("/");
+		assertDoesNotThrow(() -> {
+			Files.writeString(dir.resolve(first), "one");
+			Files.writeString(dir.resolve(second), "two");
+		});
+		assertDoesNotThrow(() -> assertEquals("one", Files.readString(dir.resolve(first))));
+		assertDoesNotThrow(() -> assertEquals("two", Files.readString(dir.resolve(second))));
 
+		// A separate adapter/cursor view must observe both values as well.
 		ACell firstRead = run("v/ops/dlfs/read", Maps.of("drive", drive, "path", first));
 		ACell secondRead = run("v/ops/dlfs/read", Maps.of("drive", drive, "path", second));
 		assertEquals("one", RT.ensureString(RT.getIn(firstRead, "content")).toString());

--- a/venue/src/test/java/covia/grid/client/ClientTest.java
+++ b/venue/src/test/java/covia/grid/client/ClientTest.java
@@ -47,7 +47,7 @@ public class ClientTest {
 	}
 	
 	@Test
-	public void testAddAsset() throws InterruptedException, ExecutionException, TimeoutException {
+	public void testAddAsset() throws InterruptedException, ExecutionException, TimeoutException, IOException {
 		// Create test metadata
 		ACell metadata = Maps.of(
 			Keyword.intern("name"), Strings.create("Test Asset"),
@@ -61,6 +61,8 @@ public class ClientTest {
 		// Verify the asset was created
 		assertNotNull(assetId, "Asset ID should be returned");
 		assertTrue(assetId instanceof Hash, "Asset ID should be a Hash");
+		assertNotNull(client.getAsset(assetId),
+			"A bare hash should resolve from the authenticated caller's asset store");
 	}
 	
 	@Test
@@ -198,6 +200,12 @@ public class ClientTest {
 		
 		String retrievedContentString = new String(retrievedBlob.getBytes());
 		assertEquals(testContent, retrievedContentString, "Retrieved content should match original content");
+
+		// Asset.getContent follows the same caller-relative hash semantics as the
+		// direct content API; it must not switch to the venue catalog internally.
+		Asset retrievedAsset = client.getAsset(assetId);
+		assertNotNull(retrievedAsset);
+		assertEquals(contentBlob, retrievedAsset.getContent().getBlob().toFlatBlob());
 	}
 	
 	@Test
@@ -279,7 +287,7 @@ public class ClientTest {
 	@Test 
 	public void testGridConnect() throws IOException {
 		Venue v= Grid.connect(TestServer.BASE_URL);
-		Asset a = v.getAsset(TestOps.ECHO);
+		Asset a = v.resolveAsset("v/test/ops/echo");
 		assertNotNull(a);
 		
 		Job job=a.invoke(Vectors.empty()).join();
@@ -288,4 +296,4 @@ public class ClientTest {
 		
 		assertEquals(Maps.empty(),a.run(Maps.empty()));
 	}
-} 
+}

--- a/venue/src/test/java/covia/venue/CoviaAssetRefTest.java
+++ b/venue/src/test/java/covia/venue/CoviaAssetRefTest.java
@@ -14,9 +14,12 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import convex.core.data.ACell;
+import convex.core.crypto.AKeyPair;
+import convex.auth.ucan.UCAN;
 import convex.core.data.Hash;
 import convex.core.data.Maps;
 import convex.core.data.Strings;
+import convex.core.data.Vectors;
 import convex.core.util.JSON;
 import covia.grid.Asset;
 import covia.grid.client.VenueHTTP;
@@ -49,6 +52,20 @@ public class CoviaAssetRefTest {
 		return http.send(
 			HttpRequest.newBuilder().uri(new URI(base + path)).GET().build(),
 			HttpResponse.BodyHandlers.ofString());
+	}
+
+	private HttpResponse<String> get(String path, String bearer) throws Exception {
+		return http.send(
+			HttpRequest.newBuilder().uri(new URI(base + path))
+				.header("Authorization", "Bearer " + bearer).GET().build(),
+			HttpResponse.BodyHandlers.ofString());
+	}
+
+	private static String identityToken(AKeyPair keyPair) {
+		long exp = (System.currentTimeMillis() / 1000) + 3600;
+		UCAN token = UCAN.create(keyPair, TestServer.ENGINE.getAccountKey(), exp,
+			Vectors.empty(), Vectors.empty());
+		return token.toJWT(keyPair).toString();
 	}
 
 	private static String etagHash(HttpResponse<String> r) {
@@ -102,6 +119,36 @@ public class CoviaAssetRefTest {
 		assertEquals(404, r.statusCode());
 		assertTrue(r.body().contains("does not specify any content"),
 			"the /content route must take precedence over the <id> wildcard, got: " + r.body());
+	}
+
+	@Test
+	public void bareHashContentIsScopedToCurrentUsersAssetStore() throws Exception {
+		AKeyPair aliceKey = AKeyPair.generate();
+		AKeyPair bobKey = AKeyPair.generate();
+		var aliceDID = UCAN.toDIDKey(aliceKey.getAccountKey());
+		String metadata = """
+			{"name":"Private content","content":{"inline":"alice only","contentType":"text/plain"}}
+			""";
+
+		Hash id = TestServer.ENGINE.storeUserAsset(
+			Strings.create(metadata), null, RequestContext.of(aliceDID));
+		// A matching venue-catalog record makes this a strong regression test:
+		// the old caller-aware lookup silently fell through to this shared store.
+		assertEquals(id, TestServer.ENGINE.storeAsset(Strings.create(metadata), null));
+
+		String path = "/api/v1/assets/" + id.toHexString();
+		HttpResponse<String> aliceMeta = get(path, identityToken(aliceKey));
+		assertEquals(200, aliceMeta.statusCode());
+		HttpResponse<String> aliceContent = get(path + "/content", identityToken(aliceKey));
+		assertEquals(200, aliceContent.statusCode());
+		assertEquals("alice only", aliceContent.body());
+
+		HttpResponse<String> bobMeta = get(path, identityToken(bobKey));
+		assertEquals(404, bobMeta.statusCode(),
+			"a bare hash must mean Bob's /a, not Alice's or the venue catalog");
+		HttpResponse<String> bobContent = get(path + "/content", identityToken(bobKey));
+		assertEquals(404, bobContent.statusCode(),
+			"content lookup must not fall through to another asset namespace");
 	}
 
 	@Test

--- a/venue/src/test/java/covia/venue/EtchV3VenueTest.java
+++ b/venue/src/test/java/covia/venue/EtchV3VenueTest.java
@@ -1,12 +1,21 @@
 package covia.venue;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +26,7 @@ import convex.core.data.Maps;
 import convex.core.data.Strings;
 import convex.core.data.prim.CVMLong;
 import convex.core.lang.RT;
+import covia.adapter.DLFSAdapter;
 import covia.api.Fields;
 import covia.venue.server.VenueServer;
 
@@ -263,6 +273,123 @@ public class EtchV3VenueTest {
 				"the embedder-keyed encrypted vault must persist across venue restarts");
 		} finally {
 			second.close();
+		}
+	}
+
+	/**
+	 * Release regression for GetMine #303. The product writes staged files via
+	 * short-lived DLFS views while unrelated venue traffic synchronises the root
+	 * lattice and the UI lists the same directory. The field report was a fresh
+	 * encrypted-v3 store whose directory nodes became unreadable without any
+	 * reported write failure.
+	 *
+	 * <p>All ordering in this test is explicit: writers rendezvous before the
+	 * concurrent sync loop starts, every future is joined, and verification runs
+	 * only after the syncer has stopped. Concurrency is the behaviour under test,
+	 * not a timing assumption.</p>
+	 */
+	@Test
+	public void concurrentDlfsPromotionsRemainReadableAcrossSyncAndRestart() throws Exception {
+		File dir = Files.createTempDirectory("etch-v3-dlfs-promotions").toFile();
+		String storePath = new File(dir, "venue.etch").getAbsolutePath().replace('\\', '/');
+		AString userDID = Strings.create("did:key:z6Mk-test-dlfs-promotions");
+		String driveName = "drive";
+		int writerCount = 6;
+		int filesPerWriter = 20;
+		Map<String, byte[]> expected = new LinkedHashMap<>();
+		String commonPrefix = "2026-08-13 - NHS health document "; // >32 shared chars
+		for (int writer = 0; writer < writerCount; writer++) {
+			for (int item = 0; item < filesPerWriter; item++) {
+				String name = commonPrefix + writer + "-" + item + ".pdf";
+				expected.put(name, ("writer=" + writer + ",item=" + item)
+					.getBytes(StandardCharsets.UTF_8));
+			}
+		}
+
+		VenueServer first = VenueServer.launch(config(storePath, KEY_HEX));
+		try {
+			Engine engine = first.getEngine();
+			DLFSAdapter dlfs = (DLFSAdapter) engine.getAdapter("dlfs");
+			Path uploads = driveRoot(dlfs, userDID, driveName).resolve("Uploads");
+			Files.createDirectories(uploads);
+
+			CountDownLatch ready = new CountDownLatch(writerCount);
+			CountDownLatch start = new CountDownLatch(1);
+			AtomicBoolean syncing = new AtomicBoolean(true);
+			try (var tasks = Executors.newVirtualThreadPerTaskExecutor()) {
+				var writers = new java.util.ArrayList<java.util.concurrent.Future<?>>();
+				for (int writer = 0; writer < writerCount; writer++) {
+					int writerId = writer;
+					writers.add(tasks.submit(() -> {
+						ready.countDown();
+						start.await();
+						for (int item = 0; item < filesPerWriter; item++) {
+							String name = commonPrefix + writerId + "-" + item + ".pdf";
+							byte[] content = expected.get(name);
+							// Fresh cursor/filesystem per request, as in DLFSAdapter dispatch.
+							Path freshUploads = driveRoot(dlfs, userDID, driveName).resolve("Uploads");
+							Path target = freshUploads.resolve(name);
+							Path staged = freshUploads.resolve(name + ".part");
+							Files.write(staged, content);
+							Files.move(staged, target, StandardCopyOption.ATOMIC_MOVE);
+							assertArrayEquals(content, Files.readAllBytes(target));
+							try (var listing = Files.list(
+									driveRoot(dlfs, userDID, driveName).resolve("Uploads"))) {
+								listing.count();
+							}
+						}
+						return null;
+					}));
+				}
+				ready.await();
+				var syncer = tasks.submit(() -> {
+					start.countDown();
+					while (syncing.get()) {
+						engine.syncState();
+						Thread.yield();
+					}
+					return null;
+				});
+				try {
+					for (var writer : writers) writer.get();
+				} finally {
+					syncing.set(false);
+				}
+				syncer.get();
+			}
+
+			assertDlfsContents(dlfs, userDID, driveName, expected);
+			engine.flush();
+		} finally {
+			first.close();
+		}
+
+		VenueServer reopened = VenueServer.launch(config(storePath, KEY_HEX));
+		try {
+			DLFSAdapter dlfs = (DLFSAdapter) reopened.getEngine().getAdapter("dlfs");
+			assertDlfsContents(dlfs, userDID, driveName, expected);
+		} finally {
+			reopened.close();
+		}
+	}
+
+	private static Path driveRoot(DLFSAdapter dlfs, AString userDID, String driveName) {
+		return dlfs.getDriveForIdentity(userDID.toString(), driveName).getPath("/");
+	}
+
+	private static void assertDlfsContents(DLFSAdapter dlfs, AString userDID,
+			String driveName, Map<String, byte[]> expected) throws Exception {
+		Path uploads = driveRoot(dlfs, userDID, driveName).resolve("Uploads");
+		try (var listing = Files.list(uploads)) {
+			var paths = listing.toList();
+			assertEquals(expected.size(), paths.size(),
+				"every promoted sibling must remain reachable");
+			assertTrue(paths.stream().noneMatch(path -> path.toString().endsWith(".part")),
+				"no staged file may remain after promotion");
+		}
+		for (var entry : expected.entrySet()) {
+			assertArrayEquals(entry.getValue(), Files.readAllBytes(uploads.resolve(entry.getKey())),
+				"content mismatch for " + entry.getKey());
 		}
 	}
 }

--- a/venue/src/test/java/covia/venue/JobCancellationTest.java
+++ b/venue/src/test/java/covia/venue/JobCancellationTest.java
@@ -244,8 +244,10 @@ public class JobCancellationTest {
 
 	@Test
 	public void testCancelledRequestJobNotCompletedByAgent() {
-		// Agent picks a cancelled task Job — should not overwrite CANCELLED status
-		createChatAgent("req-cancel-agent2");
+		// Hold the transition open so cancellation deterministically wins before
+		// the agent's completion/error path. A fast chat transition made this test
+		// race: it could legitimately fail before cancel() committed.
+		createNeverAgent("req-cancel-agent2");
 
 		Job reqJob = engine.jobs().invokeOperation(
 			"v/ops/agent/request",
@@ -255,11 +257,18 @@ public class JobCancellationTest {
 
 		pollUntilStatus(reqJob, "STARTED", 5000);
 		reqJob.cancel();
+		assertEquals("CANCELLED", reqJob.getStatus().toString(),
+			"the explicit cancellation must win before the worker is released");
 
-		// Wait for the agent to complete its cycle
-		pollUntilFinished(reqJob, 5000);
-		// The Job should stay CANCELLED — the agent's completeWith should
-		// be a no-op because isFinished() is already true
+		// Suspending cancels the never-ending transition and drives the agent's
+		// late error/queue-drain path, which will attempt to settle the task.
+		// That path must not replace the already-committed terminal state.
+		engine.jobs().invokeOperation(
+			"v/ops/agent/suspend",
+			Maps.of(Fields.AGENT_ID, "req-cancel-agent2"),
+			ctx).awaitResult(5000);
+		pollUntilTaskRemoved("req-cancel-agent2", reqJob.getID(), 5000);
+
 		assertEquals("CANCELLED", reqJob.getStatus().toString(),
 			"Cancelled request should stay CANCELLED even after agent processes it");
 	}
@@ -474,5 +483,17 @@ public class JobCancellationTest {
 		while (!job.isFinished() && System.currentTimeMillis() < deadline) {
 			Thread.yield();
 		}
+	}
+
+	private void pollUntilTaskRemoved(String agentId, Blob taskId, long timeoutMs) {
+		long deadline = System.currentTimeMillis() + timeoutMs;
+		while (System.currentTimeMillis() < deadline) {
+			User user = engine.getVenueState().users().get(ALICE_DID);
+			AgentState agent = (user != null) ? user.agent(agentId) : null;
+			if (agent == null || agent.getTasks() == null
+					|| agent.getTasks().get(taskId) == null) return;
+			Thread.yield();
+		}
+		fail("Timed out waiting for agent to remove cancelled task " + taskId);
 	}
 }

--- a/venue/src/test/java/covia/venue/OperationResolutionTest.java
+++ b/venue/src/test/java/covia/venue/OperationResolutionTest.java
@@ -314,26 +314,23 @@ public class OperationResolutionTest {
 		assertNull(engine.resolveAsset(Strings.create("w/config/internal-test")));
 	}
 
-	// ========== DID URL self-reference round-trip ==========
+	// ========== DID URL namespace isolation ==========
 	//
-	// asset_store returns the venue's own DID URL form (e.g.
-	// did:key:VENUE:public/a/<hash>). Feeding that back into resolveAsset
-	// must work without crashing — it used to fall through to Grid.connect
-	// which only handles did:web.
+	// The venue catalog and its public user's /a are distinct namespaces even
+	// when an identical content hash exists in both.
 
 	@Test
-	public void testResolveLocalDidKeyUrlForVenueAsset() {
+	public void testPublicUserDidDoesNotFallThroughToVenueAsset() {
 		// Pick any venue-installed asset hash
 		Hash echoHash = engine.resolveAsset(Strings.create("v/test/ops/echo")).getID();
 		assertNotNull(echoHash);
 
-		// Construct the DID URL form: <venue-did>:public/a/<hash>
-		// (matches what asset_store returns when called by an anonymous user)
+		// Construct a URL in the public user's namespace, not the venue catalog.
 		String didUrl = engine.getDIDString().toString() + ":public/a/" + echoHash.toHexString();
 
 		Asset asset = engine.resolveAsset(Strings.create(didUrl), alice);
-		assertNotNull(asset, "did:key:VENUE:public/a/<hash> should resolve as local");
-		assertEquals(echoHash, asset.getID());
+		assertNull(asset,
+			"the public user's /a must not fall through to an identically hashed venue asset");
 	}
 
 	@Test

--- a/venue/src/test/java/covia/venue/grid/RemoteAssetFetchTest.java
+++ b/venue/src/test/java/covia/venue/grid/RemoteAssetFetchTest.java
@@ -45,9 +45,9 @@ import covia.venue.TwoVenueTestServer;
  *   <li>An asset is identified by the CAD3 value hash of its metadata.
  *       The same metadata held on any venue has the same id — location is
  *       not part of identity.</li>
- *   <li>{@code Venue.getAsset(hash)} over HTTP returns the published
- *       metadata for an asset the remote venue holds, and null for one it
- *       does not hold.</li>
+	 *   <li>Federated fetch uses the remote venue's explicitly named published
+	 *       catalog. An ordinary HTTP {@code getAsset(hash)} remains relative to
+	 *       the authenticated caller's asset namespace.</li>
  *   <li>{@code Engine.fetchRemoteAsset} verifies that fetched metadata
  *       hashes to the requested id. Content addressing is the trust
  *       boundary: a remote venue is purely an availability provider and
@@ -253,9 +253,9 @@ public class RemoteAssetFetchTest {
 		Hash id = TwoVenueTestServer.ENGINE_B.storeAsset(meta, null);
 		TwoVenueTestServer.ENGINE_B.putContent(id, new ByteArrayInputStream(content.getBytes()));
 
-		Asset fetched = TwoVenueTestServer.COVIA_B.getAsset(id);
+		Asset fetched = TwoVenueTestServer.COVIA_B.getVenueAsset(id);
 		assertNotNull(fetched);
-		AContent fetchedContent = fetched.getContent();
+		AContent fetchedContent = TwoVenueTestServer.COVIA_B.getVenueContent(id).join();
 		assertNotNull(fetchedContent, "Stored content must be retrievable over HTTP");
 		assertEquals(content, fetchedContent.getBlob().toFlatBlob(),
 			"Content bytes must round-trip unchanged");


### PR DESCRIPTION
## Summary
- scope caller-facing asset hashes to the caller asset namespace
- make venue-catalog access explicit for federation
- add deterministic cancellation and DLFS/Etch release regressions
- correct the 0.9.1 changelog claims

## Validation
- focused release suite: 134 tests passed
- formerly flaky cancellation regression: 10/10 consecutive passes
- complete seven-module Maven reactor: passed