### PR TITLE
fix: resolve any asset reference on the content endpoint (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Covia is pre-1.0, so minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- Asset content retrieval by any asset reference: `GET /api/v1/assets/content/<ref>` (#368)
+
+### Fixed
+
+- Metadata reads for asset refs whose final segment is `content` no longer misroute (#368)
+
 ## [0.9.1] - 2026-08-13
 
 ### Changed

--- a/venue/CLAUDE.md
+++ b/venue/CLAUDE.md
@@ -107,7 +107,7 @@ Base path: `/api/v1/`
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/status` | GET | Venue status and health |
-| `/assets/{id}` | GET | Asset metadata; `/assets` POST registers; `/{id}/content` GET/PUT |
+| `/assets/{ref}` | GET | Asset metadata for any ref form; `/assets/content/{ref}` GET returns content for any ref (#368); `/assets` POST registers; `/{id}/content` GET/PUT (hash-only, deprecated GET) |
 | `/invoke` | POST | Execute an operation — async by default (201 + job record); `?wait=true` blocks up to the 120s cap, `?wait=<ms>` up to that many ms |
 | `/values/{read,list,slice,inspect,aggregate,count}` | GET | Job-free lattice reads (#177) — synchronous, capability-checked, no job persisted. See `docs/READ_API.md` |
 | `/agents`, `/agents/{id}` | GET | Job-free agent listings (#180, #233) |

--- a/venue/src/main/java/covia/venue/api/CoviaAPI.java
+++ b/venue/src/main/java/covia/venue/api/CoviaAPI.java
@@ -73,6 +73,7 @@ public class CoviaAPI extends ACoviaAPI {
 	public static final String ADD_ASSET="addAsset";
 
 	private static final String GET_CONTENT = "getContent";
+	private static final String GET_CONTENT_REF = "getContentByRef";
 
 	private static final String PUT_CONTENT = "putContent";
 	public static final String CANCEL_JOB = "cancelJob";
@@ -104,9 +105,14 @@ public class CoviaAPI extends ACoviaAPI {
 	public void addRoutes(RoutesConfig routes) {
 		routes.get(ROUTE+"status", this::getStatus, COVIA_API);
 		// <id> matches slashes, so the asset metadata route accepts any lattice
-		// address (a/<hash>, w/…, o/…, <DID>/…) as well as a bare hash. The more
-		// specific {id}/content route below is registered too; Javalin prefers
-		// the more specific match (covered by CoviaAssetRefTest).
+		// address (a/<hash>, w/…, o/…, <DID>/…) as well as a bare hash. Content
+		// puts its selector BEFORE the ref (assets/content/<ref>) so the
+		// variable-length ref is always the tail wildcard: "content" is not a
+		// ref namespace prefix, so the selector can never collide with a valid
+		// metadata ref — unlike a trailing /content, which any workspace path
+		// can end in (#368). The single-segment {id}/content route survives for
+		// hash-form compatibility (covered by CoviaAssetRefTest).
+		routes.get(ROUTE+"assets/content/<id>", this::getContentByRef, COVIA_API);
 		routes.get(ROUTE+"assets/{id}/content", this::getContent, COVIA_API);
 		routes.get(ROUTE+"assets/<id>", this::getAsset, COVIA_API);
 		routes.put(ROUTE+"assets/{id}/content", this::putContent, COVIA_API);
@@ -355,6 +361,16 @@ public class CoviaAPI extends ACoviaAPI {
 			return;
 		}
 
+		serveAssetMeta(ctx, ref);
+	}
+
+	/**
+	 * Serves the metadata for an asset reference (any lattice address form).
+	 * The body of {@link #getAsset}, shared with the legacy content route's
+	 * disambiguation path (a non-hash {@code {id}} there is really a metadata
+	 * ref whose final segment is {@code content}, #368).
+	 */
+	private void serveAssetMeta(Context ctx, String ref) {
 		// Caller identity + transport UCAN authority (a bearer UCAN supplies the
 		// proof for cross-DID reads, per the IETF UCAN-HTTP convention).
 		RequestContext rctx = AuthMiddleware.callerContext(ctx);
@@ -440,33 +456,88 @@ public class CoviaAPI extends ACoviaAPI {
 		return Hash.parse(ref);
 	}
 	
-	@OpenApi(path = ROUTE + "assets/{id}/content", 
-			methods = HttpMethod.GET, 
+	@OpenApi(path = ROUTE + "assets/{id}/content",
+			methods = HttpMethod.GET,
 			tags = { "Covia"},
-			summary = "Get the content of a Covia data asset", 
+			summary = "Get the content of a Covia data asset by content-addressed hash. "
+					+ "Legacy single-segment route: prefer assets/content/{id}, which accepts any asset reference.",
+			deprecated = true,
 			operationId = CoviaAPI.GET_CONTENT,
 			queryParams = {
 					@OpenApiParam(
-							name = "inline", 
-							description = "Add if the Content-Disposition should be set to inline", 
-							required = false, 
-							type = String.class, 
+							name = "inline",
+							description = "Add if the Content-Disposition should be set to inline",
+							required = false,
+							type = String.class,
 							example = "true")
 			},
 			pathParams = {
 					@OpenApiParam(
-							name = "id", 
-							description = "Asset ID, as a hex string.", 
-							required = true, 
-							type = String.class, 
+							name = "id",
+							description = "Asset ID, as a hex string.",
+							required = true,
+							type = String.class,
 							example = "0x1234567812345678123456781234567812345678123456781234567812345678") },
 			responses = {
 					@OpenApiResponse(
-							status = "200", 
+							status = "200",
 							description = "Content returned")
-					})	
+					})
 	protected void getContent(Context ctx) {
 		String id=ctx.pathParam("id");
+		// {id} is single-segment, so only hash forms (bare hex, a/<hash>) ever
+		// worked here. A non-hash id means this route's suffix grammar mis-ate a
+		// metadata read for a ref whose final segment is "content" (e.g.
+		// /assets/w/content is the metadata of w/content). Hash and path grammars
+		// cannot collide, so the disambiguation is exact (#368).
+		if (parseCallerAssetId(id)==null && !"venue".equals(ctx.queryParam("namespace"))) {
+			serveAssetMeta(ctx, id+"/content");
+			return;
+		}
+		serveContent(ctx, id);
+	}
+
+	@OpenApi(path = ROUTE + "assets/content/{id}",
+			methods = HttpMethod.GET,
+			tags = { "Covia"},
+			summary = "Get the content of a Covia data asset given any asset reference.",
+			operationId = CoviaAPI.GET_CONTENT_REF,
+			queryParams = {
+					@OpenApiParam(
+							name = "inline",
+							description = "Add if the Content-Disposition should be set to inline",
+							required = false,
+							type = String.class,
+							example = "true")
+			},
+			pathParams = {
+					@OpenApiParam(
+							name = "id",
+							description = "Asset reference: a bare CAD3 hash, a content-addressed "
+									+ "address (a/<hash>), a workspace/operation path (w/…, o/…), "
+									+ "or a DID URL — every form the metadata route accepts.",
+							required = true,
+							type = String.class,
+							example = "w/skills/reviewer") },
+			responses = {
+					@OpenApiResponse(
+							status = "200",
+							description = "Content returned")
+					})
+	protected void getContentByRef(Context ctx) {
+		serveContent(ctx, ctx.pathParam("id"));
+	}
+
+	/**
+	 * Serves asset content for any reference form: the canonical
+	 * {@code assets/content/<ref>} route and the hash-form legacy route both
+	 * land here. Hash-form refs read the caller's asset record directly
+	 * (byte-identical to the historical route); every other lattice address
+	 * resolves through the same universal resolver as the metadata route and
+	 * serves whatever content the resolved value carries — inline, CAS blob,
+	 * or provider-backed (DLFS), with a declared sha256 pin verified (#368).
+	 */
+	private void serveContent(Context ctx, String id) {
 		try {
 			if ("venue".equals(ctx.queryParam("namespace"))) {
 				Hash venueAssetID=Hash.parse(id);
@@ -489,20 +560,8 @@ public class CoviaAPI extends ACoviaAPI {
 					buildError(ctx,404,"Asset did not have any content available: "+id);
 					return;
 				}
-				ACell contentMeta=meta.get(Fields.CONTENT);
-				ACell contentType=RT.getIn(contentMeta,Fields.CONTENT_TYPE);
-				if (contentType instanceof AString ct) ctx.contentType(ct.toString());
-				if (ctx.queryParam("inline")!=null) ctx.header("Content-Disposition","inline");
-				ACell fileName=RT.getIn(contentMeta,Fields.FILE_NAME);
-				if (fileName instanceof AString fn) ctx.header("filename",fn.toString());
-				ctx.result(content.getInputStream());
-				ctx.status(200);
-				return;
-			}
-
-			Hash assetID=parseCallerAssetId(id);
-			if (assetID==null) {
-				buildError(ctx,400,"Invalid caller asset reference: "+id);
+				sendContent(ctx, meta.get(Fields.CONTENT),
+					new covia.venue.storage.ContentProvider.Resolved(content, null));
 				return;
 			}
 
@@ -510,53 +569,81 @@ public class CoviaAPI extends ACoviaAPI {
 			AString bearer = ctx.attribute(AuthMiddleware.UCAN_BEARER_ATTR);
 			rctx = AuthMiddleware.withTransportAuth(rctx, bearer, null, null, engine().didVerifier());
 			AString ref = Strings.create(id);
-			AString readAs = engine().requireLocalAccess(rctx, ref, Abilities.ASSET_READ);
-			AVector<?> record = engine().getAssetRecord(assetID, readAs);
-			if (record==null) {
-				buildError(ctx,404,"Asset not found: "+id);
+
+			Hash assetID=parseCallerAssetId(id);
+			if (assetID!=null) {
+				AString readAs = engine().requireLocalAccess(rctx, ref, Abilities.ASSET_READ);
+				AVector<?> record = engine().getAssetRecord(assetID, readAs);
+				if (record==null) {
+					buildError(ctx,404,"Asset not found: "+id);
+					return;
+				}
+
+				AMap<AString,ACell> meta=RT.ensureMap(record.get(AssetStore.POS_META));
+				if (meta==null) {
+					buildError(ctx,500,"Stored asset metadata is invalid: "+id);
+					return;
+				}
+				if (!meta.containsKey(Fields.CONTENT)) {
+					buildError(ctx,404,"Asset metadata does not specify any content object: "+id);
+					return;
+				}
+
+				covia.venue.storage.ContentProvider.Resolved resolved =
+					engine().resolveContent(ref, rctx);
+				if (resolved==null) {
+					buildError(ctx,404,"Asset did not have any content available: "+id);
+					return;
+				}
+				sendContent(ctx, meta.get(Fields.CONTENT), resolved);
 				return;
 			}
 
-			AMap<AString,ACell> meta=RT.ensureMap(record.get(AssetStore.POS_META));
-			if (meta==null) {
-				buildError(ctx,500,"Stored asset metadata is invalid: "+id);
-				return;
-			}
-			if (!meta.containsKey(Fields.CONTENT)) {
-				buildError(ctx,404,"Asset metadata does not specify any content object: "+id);
-				return;
-			}
-
-			ACell contentMeta=meta.get(Fields.CONTENT);
+			// Any other lattice address (w/…, v/…, o/…, DID URL): the same gate
+			// and resolver as the metadata route, then serve whatever content the
+			// resolved value carries. Metadata is resolved separately only for
+			// error specificity and the content.contentType / fileName headers —
+			// a ref may also resolve to a raw blob with no metadata at all.
+			engine().requireResourceAccess(rctx, ref, Abilities.ASSET_READ);
+			AMap<AString,ACell> meta = RT.ensureMap(engine().resolvePath(ref, rctx));
 			covia.venue.storage.ContentProvider.Resolved resolved =
 				engine().resolveContent(ref, rctx);
 			if (resolved==null) {
-				buildError(ctx,404,"Asset did not have any content available: "+id);
+				if (meta==null) buildError(ctx,404,"Asset not found: "+id);
+				else if (!meta.containsKey(Fields.CONTENT)) buildError(ctx,404,"Asset metadata does not specify any content object: "+id);
+				else buildError(ctx,404,"Asset did not have any content available: "+id);
 				return;
 			}
-			AContent content = resolved.content();
-			ACell contentType=RT.getIn(contentMeta,Fields.CONTENT_TYPE);
-			if (contentType instanceof AString ct) {
-				ctx.contentType(ct.toString());
-			} else if (resolved.contentType()!=null) {
-				ctx.contentType(resolved.contentType());
-			}
-			if (ctx.queryParam("inline")!=null) {
-				ctx.header("Content-Disposition","inline");
-			}
-
-			ACell fileName=RT.getIn(contentMeta,Fields.FILE_NAME);
-			if (fileName instanceof AString ct) {
-				ctx.header("filename",ct.toString());
-			}
-
-			ctx.result(content.getInputStream());
-			ctx.status(200);
+			sendContent(ctx, (meta!=null)?meta.get(Fields.CONTENT):null, resolved);
 		} catch (AuthException e) {
 			buildError(ctx,403,"Not authorised to read asset content: "+id);
 		} catch (IOException e) {
 			buildError(ctx,500,"Error retrieving asset content: "+e.getMessage());
 		}
+	}
+
+	/**
+	 * Sets the content headers — {@code content.contentType} (falling back to
+	 * the resolver's declared type), optional inline disposition and filename —
+	 * and streams the resolved content.
+	 */
+	private static void sendContent(Context ctx, ACell contentMeta,
+			covia.venue.storage.ContentProvider.Resolved resolved) throws IOException {
+		ACell contentType=(contentMeta==null)?null:RT.getIn(contentMeta,Fields.CONTENT_TYPE);
+		if (contentType instanceof AString ct) {
+			ctx.contentType(ct.toString());
+		} else if (resolved.contentType()!=null) {
+			ctx.contentType(resolved.contentType());
+		}
+		if (ctx.queryParam("inline")!=null) {
+			ctx.header("Content-Disposition","inline");
+		}
+		ACell fileName=(contentMeta==null)?null:RT.getIn(contentMeta,Fields.FILE_NAME);
+		if (fileName instanceof AString fn) {
+			ctx.header("filename",fn.toString());
+		}
+		ctx.result(resolved.content().getInputStream());
+		ctx.status(200);
 	}
 	
 	@OpenApi(path = ROUTE + "assets/{id}/content", 

--- a/venue/src/test/java/covia/venue/CoviaAssetRefTest.java
+++ b/venue/src/test/java/covia/venue/CoviaAssetRefTest.java
@@ -173,4 +173,87 @@ public class CoviaAssetRefTest {
 		assertNotNull(byBareHash, "client must resolve a bare hash");
 		assertEquals(h, byBareHash.getID());
 	}
+
+	// ---------------------------------------------------------------- #368
+	// Content by any reference: assets/content/<ref> puts the selector BEFORE
+	// the ref, so the variable-length ref is always the tail wildcard and a ref
+	// whose own final segment is "content" stays unambiguous.
+
+	private static final String CONTENT_META =
+		"{\"name\":\"Ref Content Asset\",\"content\":{\"inline\":\"ref content bytes\",\"contentType\":\"text/plain\"}}";
+
+	/** Registers CONTENT_META and writes its canonical (as-served) metadata to
+	 *  the given workspace path, so the path resolves to the pinned asset. */
+	private Hash pinContentAssetAt(String wsPath) throws Exception {
+		Hash h = client.addAsset(CONTENT_META).join();
+		ACell canonicalMeta = JSON.parse(get("/api/v1/assets/" + h.toHexString()).body());
+		client.invokeAndWait(Strings.create("v/ops/covia/write"), Maps.of(
+			Strings.create("path"), Strings.create(wsPath),
+			Strings.create("value"), canonicalMeta));
+		return h;
+	}
+
+	@Test
+	public void canonicalContentRouteAcceptsHashForms() throws Exception {
+		Hash h = client.addAsset(CONTENT_META).join();
+		String legacy = get("/api/v1/assets/" + h.toHexString() + "/content").body();
+		assertEquals("ref content bytes", legacy, "legacy hash route must keep working");
+
+		HttpResponse<String> bare = get("/api/v1/assets/content/" + h.toHexString());
+		assertEquals(200, bare.statusCode());
+		assertEquals(legacy, bare.body(), "canonical route must serve identical bytes for a bare hash");
+
+		HttpResponse<String> aForm = get("/api/v1/assets/content/a/" + h.toHexString());
+		assertEquals(200, aForm.statusCode());
+		assertEquals(legacy, aForm.body(), "canonical route must serve identical bytes for a/<hash>");
+	}
+
+	@Test
+	public void canonicalContentRouteResolvesWorkspacePath() throws Exception {
+		pinContentAssetAt("w/asset-ref-test/inline-src");
+		HttpResponse<String> r = get("/api/v1/assets/content/w/asset-ref-test/inline-src");
+		assertEquals(200, r.statusCode());
+		assertEquals("ref content bytes", r.body());
+		assertTrue(r.headers().firstValue("Content-Type").orElse("").startsWith("text/plain"),
+			"content.contentType must drive the media type");
+	}
+
+	@Test
+	public void refEndingInContentServesMetadata() throws Exception {
+		// /assets/w/content lands on the legacy {id}/content route with id="w";
+		// a non-hash id there is really a metadata read for w/content (#368).
+		Hash h = pinContentAssetAt("w/content");
+		HttpResponse<String> meta = get("/api/v1/assets/w/content");
+		assertEquals(200, meta.statusCode());
+		assertTrue(meta.body().contains("Ref Content Asset"),
+			"a ref whose final segment is 'content' must read as metadata, got: " + meta.body());
+		assertTrue(etagHash(meta).contains(h.toHexString()));
+
+		// The same ref's CONTENT is reachable only via the canonical route.
+		HttpResponse<String> content = get("/api/v1/assets/content/w/content");
+		assertEquals(200, content.statusCode());
+		assertEquals("ref content bytes", content.body());
+	}
+
+	@Test
+	public void deepRefEndingInContentServesMetadata() throws Exception {
+		// A >=3-segment ref ending in "content" reaches the <id> metadata
+		// wildcard directly — the canonical content route must not shadow it.
+		Hash h = pinContentAssetAt("w/asset-ref-test/content");
+		HttpResponse<String> meta = get("/api/v1/assets/w/asset-ref-test/content");
+		assertEquals(200, meta.statusCode());
+		assertTrue(meta.body().contains("Ref Content Asset"));
+		assertTrue(etagHash(meta).contains(h.toHexString()));
+
+		HttpResponse<String> content = get("/api/v1/assets/content/w/asset-ref-test/content");
+		assertEquals(200, content.statusCode());
+		assertEquals("ref content bytes", content.body());
+	}
+
+	@Test
+	public void canonicalContentRouteUnknownRefIs404() throws Exception {
+		HttpResponse<String> r = get("/api/v1/assets/content/w/does/not/exist");
+		assertEquals(404, r.statusCode());
+		assertTrue(r.body().contains("not found"), "unknown ref must be a clean 404, got: " + r.body());
+	}
 }


### PR DESCRIPTION
Implements #368: asset content retrieval accepts every reference form the metadata endpoint accepts.

- New canonical route `GET /api/v1/assets/content/<ref>` — the projection selector precedes the variable-length ref, so it can never collide with a ref (`content` is not a namespace prefix). Accepts bare hashes, `a/<hash>`, workspace/operation paths, and DID URLs; serves inline, CAS, and provider/DLFS-backed content with sha256 pin verification via the existing `Engine.resolveContent` seam.
- Legacy `GET /assets/{id}/content` keeps its hash contract byte-identically and now disambiguates a non-hash `{id}` as the metadata read it always mis-ate (`/assets/w/content` = metadata of `w/content`). Marked deprecated in OpenAPI.
- 5 new regression tests in `CoviaAssetRefTest`; full venue suite green (2136 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)