### PR TITLE
Add hash-to-catalog-path reverse index (v/info/catalog/<hash>)

### DIFF
--- a/venue/src/main/java/covia/venue/VenueBootstrapMaterializer.java
+++ b/venue/src/main/java/covia/venue/VenueBootstrapMaterializer.java
@@ -106,6 +106,16 @@ final class VenueBootstrapMaterializer {
 		}
 
 		writeAndValidateVenuePath(path, metadata);
+
+		// Reverse index: the catalog store (venueState.assets(), what GET
+		// /api/v1/assets iterates) is keyed purely by content hash, with no
+		// path recorded — so once a caller resolves one of these assets by
+		// hash alone, its catalog name is otherwise unrecoverable. This is an
+		// independent write of the same (path, hash) pair already computed
+		// above, not derived from the hashed metadata itself — the metadata
+		// body must stay exactly what its hash certifies, so this lives
+		// outside it, the same way ETag does.
+		writeAndValidateVenuePath("v/info/catalog/" + assetHash.toHexString(), Strings.create(path));
 	}
 
 	private static void validateCatalogPath(String path) {

--- a/venue/src/test/java/covia/venue/VenueBootstrapMaterializerTest.java
+++ b/venue/src/test/java/covia/venue/VenueBootstrapMaterializerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import convex.core.data.ACell;
 import convex.core.data.AMap;
 import convex.core.data.AString;
+import convex.core.data.Cells;
 import convex.core.data.Strings;
 import covia.adapter.AAdapter;
 
@@ -33,6 +34,26 @@ public class VenueBootstrapMaterializerTest {
 				Strings.create("v/ops/covia/write"), engine.venueContext()));
 			assertEquals(engine.getDIDString(), engine.resolvePath(
 				Strings.create("v/info/did"), engine.venueContext()));
+		} finally {
+			engine.close();
+		}
+	}
+
+	@Test
+	public void catalogHashReverseIndexResolvesBackToItsPath() {
+		Engine engine = Engine.createTemp(null);
+		try {
+			Engine.addDemoAssets(engine);
+
+			String path = "v/ops/covia/write";
+			ACell metadata = engine.resolvePath(Strings.create(path), engine.venueContext());
+			assertNotNull(metadata, "sanity: the operation itself must resolve");
+			String hash = Cells.getHash(metadata).toHexString();
+
+			ACell reversed = engine.resolvePath(
+				Strings.create("v/info/catalog/" + hash), engine.venueContext());
+			assertEquals(Strings.create(path), reversed,
+				"the reverse index must map the operation's own metadata hash back to its catalog path");
 		} finally {
 			engine.close();
 		}


### PR DESCRIPTION
Closes #390

## Summary

Every venue-catalog item (operation, agent template, skill) is written to two independent places at bootstrap: the hash-keyed `AssetStore` (what `GET /api/v1/assets` iterates) and its named lattice path (`v/ops/...`, `v/agents/templates/...`, `v/skills/...`). Neither write references the other — confirmed no `hash → path` reverse index exists anywhere (`AssetStore`'s per-hash record has no path field). So once a caller resolves one of these items by hash alone, its catalog name becomes unrecoverable — a real gap, surfaced by the frontend showing a misleading `/a/<hash>` (implying a caller's own pinned namespace) for content that's actually venue-catalog owned.

## Fix

Add one more write in `VenueBootstrapMaterializer.writeCatalogDeclaration()`, right where the `(path, hash)` pair is already computed for the primary write: `v/info/catalog/<hash> → path`. Deliberately **not** a field added to the served asset metadata body — that body is content-hashed (CAD3), so injecting serve-time context into it would make identical content hash differently depending on how it was fetched. It lives outside the hashed content, the way `ETag` already does for the resolved hash.

Readable today via the existing job-free values API — no new REST surface, no new resolver, no new capability/auth code:
```
GET /api/v1/values/read?path=v/info/catalog/<hash>
```

Confirmed via `VenueGlobalsResolver`: `v/<rest>` is a fully generic, path-agnostic rewrite to the venue's own namespace (no allowlist to update), reads are already universally allowed with no capability check, and writes are already gated to `callerDID == venueDID` — exactly the identity `VenueBootstrapMaterializer` already writes under.

## Test plan

- [x] `mvn test -pl venue` — full module suite (2144/2144), including a new test proving the round trip: resolve a known operation, hash its own metadata, look that hash up in the reverse index, confirm it maps back to the operation's catalog path.
- [x] Manually rebuilt and ran the venue locally; confirmed via `curl` that real seeded catalog hashes resolve correctly through the new index, including the exact hash from the original bug report (`00ea572ed3...` → `v/skills/assets`).

## Related

A frontend follow-up (`covia-ai/frontend`) consumes this reverse index to upgrade `AssetHeader`'s displayed address from `/a/<hash>` to the real `/v/<path>` for venue-catalog content. Harmless without this PR — the lookup just misses and falls back to today's `/a/<hash>` behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
