### PR TITLE
Fix OpenAI gpt-5.x + tools failing with reasoning_effort on /v1/chat/completions

### DIFF
--- a/venue/src/main/java/covia/adapter/LangChainAdapter.java
+++ b/venue/src/main/java/covia/adapter/LangChainAdapter.java
@@ -54,6 +54,7 @@ import dev.langchain4j.model.ollama.OllamaChatModel;
 import dev.langchain4j.model.ollama.OllamaModelCard;
 import dev.langchain4j.model.ollama.OllamaModels;
 import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 
 /**
  * LLM adapter providing level 3 (single LLM call) operations.
@@ -218,6 +219,12 @@ public class LangChainAdapter extends AAdapter {
 		final AString effectiveUrl = (ollamaUrl != null) ? Strings.create(ollamaUrl) : urlParam;
 
 		// Build the ChatModel
+		// buildProviderModel() applies its own defaultModelFor(provider) fallback
+		// internally when finalModelName is null (e.g. the frontend's "Venue
+		// default" option omits "model" entirely) — that resolved name is local
+		// to that method, so it's recomputed here for callers downstream (like
+		// callModel's reasoning-model check) that need the model actually in use.
+		final String resolvedModelName = (finalModelName != null) ? finalModelName : defaultModelFor(provider);
 		final ChatModel chatModel = buildProviderModel(provider, finalModelName, apiKey, effectiveUrl, tuning);
 		if (chatModel == null) {
 			return CompletableFuture.completedFuture(
@@ -277,7 +284,7 @@ public class LangChainAdapter extends AAdapter {
 				AVector<ACell> resolvedMessages = resolveImageRefs(providerMessages, rctx);
 				ACell result;
 				try {
-					result = callModel(provider, chatModel, resolvedMessages, tools, responseFormatCell);
+					result = callModel(provider, resolvedModelName, chatModel, resolvedMessages, tools, responseFormatCell);
 				} catch (RuntimeException e) {
 					// A connect failure against Ollama is almost always topology
 					// (Docker vs host) — turn the bare ConnectException into a
@@ -730,7 +737,7 @@ public class LangChainAdapter extends AAdapter {
 	 * @param responseFormatCell Response format: null (default text), "json" or "text" string,
 	 *        or a map {@code {name: "...", schema: {type: "object", ...}}} for strict schema mode
 	 */
-	private static ACell callModel(String provider, ChatModel model, AVector<ACell> messages,
+	private static ACell callModel(String provider, String modelName, ChatModel model, AVector<ACell> messages,
 			AVector<ACell> tools, ACell responseFormatCell) {
 		List<ChatMessage> chatMessages = toChatMessages(messages);
 		ResponseFormat responseFormat = toResponseFormat(responseFormatCell);
@@ -751,15 +758,35 @@ public class LangChainAdapter extends AAdapter {
 			log.debug("  msg[{}]: {}", i, chatMessages.get(i));
 		}
 
-		boolean needsRequest = (tools != null && tools.count() > 0) || responseFormat != null;
+		boolean hasTools = tools != null && tools.count() > 0;
+		boolean needsRequest = hasTools || responseFormat != null;
 		ChatResponse response;
 		if (needsRequest) {
 			ChatRequest.Builder builder = ChatRequest.builder().messages(chatMessages);
-			if (tools != null && tools.count() > 0) {
-				builder.toolSpecifications(toToolSpecifications(tools));
-			}
-			if (responseFormat != null) {
-				builder.responseFormat(responseFormat);
+			if (hasTools && "openai".equals(provider) && isOpenAiReasoningModel(modelName)) {
+				// OpenAI rejects function tools together with a reasoning
+				// effort on /v1/chat/completions for the gpt-5.x family
+				// ("Function tools with reasoning_effort are not supported
+				// for <model> in /v1/chat/completions. To use function
+				// tools, use /v1/responses or set reasoning_effort to
+				// 'none'.") langchain4j's OpenAiChatModel never sets
+				// reasoning_effort itself, but the API defaults it to a
+				// non-'none' value server-side whenever it's omitted — so an
+				// explicit 'none' here is required, not just a fallback.
+				// Scoped to hasTools: a tool-free turn keeps the provider's
+				// default reasoning effort.
+				OpenAiChatRequestParameters.Builder paramsBuilder = OpenAiChatRequestParameters.builder()
+					.toolSpecifications(toToolSpecifications(tools))
+					.reasoningEffort("none");
+				if (responseFormat != null) paramsBuilder.responseFormat(responseFormat);
+				builder.parameters(paramsBuilder.build());
+			} else {
+				if (hasTools) {
+					builder.toolSpecifications(toToolSpecifications(tools));
+				}
+				if (responseFormat != null) {
+					builder.responseFormat(responseFormat);
+				}
 			}
 			response = model.chat(builder.build());
 		} else {
@@ -784,6 +811,22 @@ public class LangChainAdapter extends AAdapter {
 	 */
 	static boolean lacksSchemaResponseFormat(String provider) {
 		return "anthropic".equals(provider);
+	}
+
+	/**
+	 * OpenAI's gpt-5.x family are reasoning models: {@code /v1/chat/completions}
+	 * defaults their reasoning effort to a non-'none' value whenever the
+	 * request omits it, which OpenAI rejects together with function tools
+	 * (see the {@code reasoningEffort("none")} call site in {@link #callModel}).
+	 * Every model this adapter's catalog recommends for {@code provider:
+	 * "openai"} is gpt-5.x (openai.json / HostedProvider "openai"); this check
+	 * is deliberately scoped to that prefix rather than applied to every
+	 * openai-compatible provider, since {@code reasoning_effort} is an
+	 * OpenAI-specific field an arbitrary compatible endpoint (or an older,
+	 * non-reasoning model a caller names explicitly) may reject outright.
+	 */
+	static boolean isOpenAiReasoningModel(String modelName) {
+		return modelName != null && modelName.toLowerCase(java.util.Locale.ROOT).startsWith("gpt-5");
 	}
 
 	/**

--- a/venue/src/test/java/covia/adapter/LangChainAdapterTest.java
+++ b/venue/src/test/java/covia/adapter/LangChainAdapterTest.java
@@ -1306,6 +1306,31 @@ public class LangChainAdapterTest {
 	}
 
 	@Test
+	public void testIsOpenAiReasoningModel() {
+		for (String m : new String[] {"gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.4-mini", "gpt-5.4-nano", "GPT-5.6-Terra"}) {
+			assertTrue(LangChainAdapter.isOpenAiReasoningModel(m), m + " is a gpt-5.x reasoning model");
+		}
+		for (String m : new String[] {"gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo", "o1", "o3-mini", null}) {
+			assertFalse(LangChainAdapter.isOpenAiReasoningModel(m), m + " is not gpt-5.x");
+		}
+	}
+
+	/**
+	 * Regression for the actual root cause behind the reasoning_effort fix:
+	 * a caller that omits "model" (e.g. the frontend's "Venue default" option)
+	 * relies on {@code defaultModelFor} to resolve it — that resolved name,
+	 * not the raw null input, is what must reach the reasoning-model check,
+	 * or the whole fix silently never fires for the default configuration.
+	 */
+	@Test
+	public void testDefaultOpenAiModelIsARecognisedReasoningModel() {
+		String resolved = LangChainAdapter.defaultModelFor("openai");
+		assertTrue(LangChainAdapter.isOpenAiReasoningModel(resolved),
+			"openai's default model (" + resolved + ") must be recognised as a reasoning model, "
+			+ "since every catalogued openai model is gpt-5.x");
+	}
+
+	@Test
 	public void testSyntheticOutputToolCarriesSchema() {
 		AMap<AString, ACell> tool = LangChainAdapter.syntheticOutputTool(
 			"agent_output", RF_SCHEMA);


### PR DESCRIPTION
## Summary

OpenAI's `/v1/chat/completions` defaults `reasoning_effort` to a non-`'none'` value server-side whenever the request omits it, and rejects that combined with function tools for the gpt-5.x family:

```
Function tools with reasoning_effort are not supported for gpt-5.6-terra in /v1/chat/completions.
To use function tools, use /v1/responses or set reasoning_effort to 'none'.
```

`LangChainAdapter` never set `reasoning_effort`, so every `openai`-provider agent with a tool attached hit this — including the **default template**, since `openai.json`'s entire curated catalog (`gpt-5.6-terra`/`sol`/`luna`, `gpt-5.4-mini`/`nano`) is gpt-5.x.

## Fix

When `provider == "openai"`, tools are present, and the model is gpt-5.x, the request now explicitly sets `reasoning_effort: "none"` via `OpenAiChatRequestParameters`. Scoped narrowly — openai only, gpt-5.x only, tools-present only — so it doesn't affect other providers (Anthropic, Gemini, xAI, DeepSeek, Mistral, OpenRouter), tool-free turns, or a caller-named non-reasoning model.

**A second, non-obvious fix was required for the first one to actually fire**: the model name reaching the reasoning-model check was the raw, often-`null` caller input (`finalModelName`), not the resolved name actually in use. `buildProviderModel()` applies its own `defaultModelFor()` fallback *internally* when the caller omits `"model"` (exactly what the frontend's "Venue default" option does), and that resolution never left the method. Since every `openai`-provider agent that doesn't pin an explicit model relies on this fallback, the reasoning-effort fix would have silently never fired for the default configuration — I caught this by live-testing against a real venue and inspecting the actual outgoing request body, not by inspection alone. Recomputing the resolved name at the call site (`resolvedModelName`) is what makes the fix actually take effect.

Closes #388

## Test plan

- [x] `mvn test -pl venue -Dtest=LangChainAdapterTest` — 89/89 passing, including two new unit tests: `testIsOpenAiReasoningModel` (gpt-5.x detection) and `testDefaultOpenAiModelIsARecognisedReasoningModel` (regression for the model-name-resolution root cause)
- [x] `mvn test -pl venue` — full module suite, 2231/2231 passing, 0 failures
- [x] Manually verified against a real `OPENAI_API_KEY` on a local venue: created an agent with the default OpenAI provider/model and an attached tool, chatted with it.
  - **Before the fix**: job failed with the exact reported `reasoning_effort` error.
  - **After the fix**: the model called the attached tool and the job completed successfully.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>