### PR TITLE
Connection skills: Notion, HubSpot, Slack over the http ops (bearerSecret)

### DIFF
--- a/venue/src/main/java/covia/adapter/HTTPAdapter.java
+++ b/venue/src/main/java/covia/adapter/HTTPAdapter.java
@@ -156,6 +156,11 @@ public class HTTPAdapter extends AAdapter {
 	protected void installAssets() {
 		// The adapter's own skill: v/skills/http lives and dies with this adapter.
 		installSkill("ops-tools/http", "/skills/http.json");
+		// Connection skills: third-party services reachable with a user-supplied token
+		// via bearerSecret. Pure instruction bundles over the http ops above.
+		installSkill("connections/notion", "/skills/notion.json");
+		installSkill("connections/hubspot", "/skills/hubspot.json");
+		installSkill("connections/slack", "/skills/slack.json");
 		String BASE = "/asset-examples/";
 
 		// HTTP primitives — registered in /v/ops/.

--- a/venue/src/main/resources/skills/hubspot.json
+++ b/venue/src/main/resources/skills/hubspot.json
@@ -1,0 +1,15 @@
+{
+	"name": "hubspot",
+	"description": "Work with HubSpot CRM contacts, companies, deals, and tickets using a private-app token. Load for CRM lookups, searches, and updates.",
+	"content": {
+		"contentType": "text/markdown",
+		"inline": "## HubSpot\nCalls go through `v/ops/http/get` / `v/ops/http/post` against `https://api.hubapi.com` with `bearerSecret: \"s/HUBSPOT_TOKEN\"` (a private-app access token: Settings → Integrations → Private Apps; scoped, non-expiring). Only the secret reference goes in the request; never the token itself.\n\nCRM v3 patterns (`{object}` is `contacts`, `companies`, `deals`, or `tickets`):\n- List: `GET /crm/v3/objects/{object}?limit=100&properties=firstname,lastname,email` (paginate with `after` from `paging.next.after`)\n- Get one: `GET /crm/v3/objects/{object}/{id}?properties=...`\n- Search: `POST /crm/v3/objects/{object}/search` body `{filterGroups: [{filters: [{propertyName, operator: \"EQ\"|\"CONTAINS_TOKEN\"|..., value}]}], properties: [...], limit}`\n- Create: `POST /crm/v3/objects/{object}` body `{properties: {...}}`\n- Update: `POST /crm/v3/objects/{object}/{id}` with `method: \"PATCH\"` and body `{properties: {...}}`\n- Associations: `GET /crm/v4/objects/{object}/{id}/associations/{toObject}`\n\nRules:\n- Check `status`; HubSpot errors carry `{status: \"error\", message, category}`. `MISSING_SCOPES` means the private app lacks the scope: say which scope, do not retry.\n- Property names are internal names (`firstname`, `hs_object_id`), not display labels; `GET /crm/v3/properties/{object}` lists them.\n- Respect rate limits (HTTP 429 with `Retry-After`); batch endpoints (`/batch/read`, `/batch/create`) for more than a handful of records.\n- Email addresses identify contacts; search before creating to avoid duplicates.\n"
+	},
+	"skill": {
+		"tools": [
+			"v/ops/http/get",
+			"v/ops/http/post",
+			"v/ops/jvm/url-encode"
+		]
+	}
+}

--- a/venue/src/main/resources/skills/notion.json
+++ b/venue/src/main/resources/skills/notion.json
@@ -1,0 +1,15 @@
+{
+	"name": "notion",
+	"description": "Read and write Notion pages and databases with the user's own Notion token. Load for Notion search, page reads, database queries, and page updates.",
+	"content": {
+		"contentType": "text/markdown",
+		"inline": "## Notion\nAll calls go through `v/ops/http/get` / `v/ops/http/post` against `https://api.notion.com/v1` with `bearerSecret: \"s/NOTION_TOKEN\"` and the header `Notion-Version: 2022-06-28`. The token is the user's Notion personal access token (Settings → Developer Mode; uses their own permissions) or an internal connection token (pages must be shared with the connection). Never place the token in `headers`; only the secret reference.\n\nCommon calls (POST unless noted):\n- Search: `POST /search` body `{query, filter?: {property: \"object\", value: \"page\"|\"database\"}}`\n- Read a page: `GET /pages/{page_id}`; page body blocks: `GET /blocks/{page_id}/children?page_size=100` (paginate with `start_cursor`)\n- Query a database: `POST /databases/{database_id}/query` body `{filter?, sorts?, page_size?}`\n- Create a page: `POST /pages` body `{parent: {database_id} | {page_id}, properties, children?}`\n- Update properties: `POST /pages/{page_id}` with `method: \"PATCH\"` and body `{properties}`\n- Append blocks: `POST /blocks/{block_id}/children` with `method: \"PATCH\"` and body `{children: [...]}`\n\nRules:\n- Check `status` before trusting `body`; Notion returns `{object: \"error\", code, message}` on failure. `unauthorized` means the token is missing or the page is not shared with the connection; `rate_limited` means back off (about 3 requests per second).\n- Database property values are typed (`title`, `rich_text`, `select`, `date`, ...); read the schema from `GET /databases/{id}` before writing.\n- Page and database ids may be pasted as URLs; the id is the 32-hex segment (dashes optional).\n- Large pages: fetch blocks page by page and extract what the task needs; do not load whole workspaces into context.\n"
+	},
+	"skill": {
+		"tools": [
+			"v/ops/http/get",
+			"v/ops/http/post",
+			"v/ops/jvm/url-encode"
+		]
+	}
+}

--- a/venue/src/main/resources/skills/slack.json
+++ b/venue/src/main/resources/skills/slack.json
@@ -1,0 +1,15 @@
+{
+	"name": "slack",
+	"description": "Read and post in Slack with the user's workspace bot or user token. Load when a task involves Slack messages, channels, or users.",
+	"content": {
+		"contentType": "text/markdown",
+		"inline": "## Slack\nCalls go through `v/ops/http/get` / `v/ops/http/post` against `https://slack.com/api/<method>` with `bearerSecret: \"s/SLACK_BOT_TOKEN\"` (an `xoxb-` bot token, or `s/SLACK_USER_TOKEN` for an `xoxp-` user token when the task needs the user's own view, such as search). The token comes from a Slack app the user created and installed in their workspace (api.slack.com/apps, optionally from a manifest). Only the secret reference goes in the request.\n\nCommon methods:\n- Post a message: `POST chat.postMessage` headers `{\"Content-Type\": \"application/json; charset=utf-8\"}` body `{channel, text, thread_ts?, blocks?}`\n- List channels: `GET conversations.list?types=public_channel,private_channel&limit=200` (paginate with `cursor`)\n- Read history: `GET conversations.history?channel=C123&limit=50` (the bot must be a member; `conversations.join` for public channels)\n- Users: `GET users.list`, `GET users.info?user=U123`\n- Search (user token only): `GET search.messages?query=...`\n- Files: `GET files.list`; uploading needs `files.getUploadURLExternal` then `files.completeUploadExternal`\n\nRules:\n- Every response has `ok`; when `ok` is false, `error` names the cause (`missing_scope`, `not_in_channel`, `channel_not_found`). Report the scope or membership needed rather than retrying.\n- Channel ids (`C...`) and user ids (`U...`) are stable; names change. Resolve names to ids once, then use ids.\n- Mentions are `<@U123>`; links are `<https://url|text>`; keep messages short and thread replies with `thread_ts`.\n- Rate limits are per method tier; on HTTP 429 honour `Retry-After`.\n- Posting is visible to real people: confirm channel and content before `chat.postMessage` unless the task explicitly authorises posting.\n"
+	},
+	"skill": {
+		"tools": [
+			"v/ops/http/get",
+			"v/ops/http/post",
+			"v/ops/jvm/url-encode"
+		]
+	}
+}


### PR DESCRIPTION
## Summary

First slice of the "Connections sprint": three skills that let agents use third-party services with a **user-supplied token** and **no new adapter or auth machinery**: `v/skills/connections/notion`, `connections/hubspot`, `connections/slack`, installed by `HTTPAdapter` next to `ops-tools/http`.

Each skill: the API base and the `bearerSecret: "s/<NAME>"` rule (token never inline), the common calls with method/body shapes (`method: "PATCH"` via http:post where needed), the service's error envelope (`unauthorized`/`rate_limited`, `MISSING_SCOPES`, `ok:false` + `error`), pagination, rate limits, and one safety rule each (e.g. confirm before `chat.postMessage`).

Chosen because all three are **Bearer-clean**, so `bearerSecret` covers them today. Atlassian (API tokens use Basic auth) is deliberately left out; follow-up ask filed separately for a `basicSecret`/header-secret option on the http ops.

## Verification

- `SkillsLibraryTest` (17) and `SkillsAdapterTest` (17) pass with the new skills in the shipped set: description budget respected (129–147 chars), every declared tool resolves.
- `mvn -pl venue -am compile` clean.

Naming (`connections/*` group) is a proposal; rename freely if you prefer `ops-tools/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)