### PR TITLE
fix(client): share one HttpClient across VenueHTTP instances

### DIFF
--- a/covia-core/src/main/java/covia/grid/client/VenueHTTP.java
+++ b/covia-core/src/main/java/covia/grid/client/VenueHTTP.java
@@ -50,6 +50,26 @@ public class VenueHTTP extends Venue {
 
 	public static Logger log=LoggerFactory.getLogger(VenueHTTP.class);
 
+	/**
+	 * The HTTP client shared by every {@code VenueHTTP}.
+	 *
+	 * <p>A JDK {@link HttpClient} is a thread-safe, heavyweight object: it owns
+	 * a selector thread, an executor and a connection pool, and releases them
+	 * only on close. One per {@code VenueHTTP} therefore cost ~3 platform
+	 * threads and a private pool per instance, and — since callers legitimately
+	 * build a client per remote venue, per user, or per request — that cost was
+	 * unbounded. It also defeated keep-alive: every instance opened its own TCP
+	 * connections to a venue another instance was already talking to.</p>
+	 *
+	 * <p>Sharing is safe because nothing identifying a caller lives on the
+	 * client — auth, UCAN proofs, the per-request deadline and the base URI are
+	 * all applied per request. One pool serves every caller, reusing
+	 * connections instead of accumulating them.</p>
+	 */
+	private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+		.connectTimeout(Duration.ofSeconds(10))
+		.build();
+
 	private static final double BACKOFF_FACTOR = 1.5;
 	/**
 	 * Initial poll delay in ms. Kept low so short operations finish in
@@ -148,9 +168,7 @@ public class VenueHTTP extends Venue {
 
 	public VenueHTTP(URI host, VenueAuth auth) {
 		this.baseURI = host.resolve("/api/v1/");
-		this.httpClient = HttpClient.newBuilder()
-			.connectTimeout(Duration.ofSeconds(10))
-			.build();
+		this.httpClient = HTTP_CLIENT;
 		this.auth = auth;
 
 		// Auto-set user identity from auth if available

--- a/venue/src/test/java/covia/venue/NamedUserAuthTest.java
+++ b/venue/src/test/java/covia/venue/NamedUserAuthTest.java
@@ -1,11 +1,13 @@
 package covia.venue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -28,6 +30,7 @@ import convex.core.data.prim.CVMLong;
 import convex.core.lang.RT;
 import covia.api.Fields;
 import covia.exception.AuthException;
+import covia.exception.ResponseException;
 import covia.grid.Job;
 import covia.grid.auth.VenueAuth;
 import covia.grid.client.VenueHTTP;
@@ -216,14 +219,17 @@ public class NamedUserAuthTest {
 		assertNotNull(job);
 	}
 
+	/**
+	 * Asserts the venue refused the token. The refusal is a {@link
+	 * ResponseException} — the type the client already raises for any non-2xx
+	 * answer — so that is what we assert. Matching text in the cause chain
+	 * instead would accept any failure whose message happened to contain the
+	 * digits, including a transport error that never reached the venue.
+	 */
 	private void assertRejected(String token) {
-		Throwable failure = assertThrows(Throwable.class,
-			() -> client(token).invokeAndWait(OP_ECHO, Maps.of(Fields.VALUE, "denied")));
-		StringBuilder chain = new StringBuilder();
-		for (Throwable c = failure; c != null; c = c.getCause()) {
-			chain.append(c.getMessage()).append(" | ");
-		}
-		assertTrue(chain.toString().contains("401"), "expected 401, got " + chain);
+		CompletionException failure = assertThrows(CompletionException.class,
+			() -> client(token).startJobAsync(OP_ECHO, Maps.of(Fields.VALUE, "denied")).join());
+		assertInstanceOf(ResponseException.class, failure.getCause());
 	}
 
 	private VenueHTTP client(String token) {

--- a/venue/src/test/java/covia/venue/grid/CrossVenueTest.java
+++ b/venue/src/test/java/covia/venue/grid/CrossVenueTest.java
@@ -1,12 +1,14 @@
 package covia.venue.grid;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
+import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +21,7 @@ import convex.core.data.Strings;
 import convex.core.data.Vectors;
 import convex.core.lang.RT;
 import covia.api.Fields;
+import covia.exception.ResponseException;
 import covia.grid.Job;
 import covia.grid.Status;
 import covia.grid.auth.VenueAuth;
@@ -220,13 +223,14 @@ public class CrossVenueTest {
 			VenueAuth.bearer(jwt));
 		bobOnB.setUser(bobDID.toString());
 
-		Throwable t = assertThrows(Throwable.class, () ->
-			bobOnB.invokeAndWait(Strings.create("v/ops/covia/read"),
-				Maps.of(Fields.PATH, bobDID + "/w/somewhere")));
-		StringBuilder chain = new StringBuilder();
-		for (Throwable c = t; c != null; c = c.getCause()) chain.append(c.getMessage()).append(" | ");
-		assertTrue(chain.toString().contains("audience") || chain.toString().contains("401"),
-			"A token not audienced to venue B must be rejected at the transport boundary, got: " + chain);
+		// Venue B refuses the token, which the client raises as a typed
+		// ResponseException. Asserting the type — not text in the cause chain —
+		// is what makes this a test of venue B's answer: a transport failure
+		// arrives as a different type and now fails the test as itself.
+		CompletionException failure = assertThrows(CompletionException.class, () ->
+			bobOnB.startJobAsync(Strings.create("v/ops/covia/read"),
+				Maps.of(Fields.PATH, bobDID + "/w/somewhere")).join());
+		assertInstanceOf(ResponseException.class, failure.getCause());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Two independent fixes found while investigating an intermittent test failure. **Neither fixes that flake** — see below.

### 1. `VenueHTTP` built an `HttpClient` per instance (`50999fb4`)

A JDK `HttpClient` owns a selector thread, an executor and a connection pool, released only on close. `VenueHTTP` built one per instance and exposed no way to release it.

That cost was unbounded rather than incidental: `Grid.connect()` builds a client per connection string, and `GridAdapter` calls it **once per federated invocation** — so every cross-venue call leaked ~3 platform threads and a private pool for the life of the JVM.

Measured with 1000 clients:

| | HttpClient threads |
|---|---|
| before | 3080 |
| after | 11 |

Sharing is safe because nothing identifying a caller lives on the client — auth, UCAN proofs, the per-request deadline and the base URI are all applied per request.

### 2. Two tests asserted on error text, not type (`ea2bde54`)

`NamedUserAuthTest.assertRejected` and `CrossVenueTest.venueAIssuedUCANRejectedByVenueB` concatenated every `getMessage()` in the failure's cause chain and searched it for `"401"` / `"audience"`. That accepts any failure whose text happens to contain the token — so a transport error that never reached the venue was reported as a *successful auth rejection*.

The client already raises `ResponseException` for any non-2xx, and the repo already asserts on that type (`UserAdmissionTest`). These now do the same, so a transport failure fails as itself.

## Known issue this does NOT fix

The venue suite has a pre-existing intermittent failure, roughly 1 run in 4–6, always with the same signature on an **auth-rejection path**:

```
IOException: HTTP/1.1 header parser received no bytes
  <- SocketException: An established connection was aborted...
```

Seen in four distinct tests (`CrossVenueTest`, `NamedUserAuthTest`, `UCANBearerTransportTest`, `AudiencePolicyTest`). Ruled out by direct test: stale pooled connections, the client leak above, large bodies vs. early response, response-before-body-write ordering, and GC reclaim of the client. One occurrence used a raw JDK `HttpClient`, so it is server-side, not the client library.

The victims are always the *fastest* responses in the suite — rejected in `AuthMiddleware` before any handler, job creation or lattice I/O. Running the auth classes alone for 12 iterations produces zero aborts, so it needs full-suite concurrency plus a sub-millisecond response. Next step would be Jetty `HttpConnection` debug logging during a full run to see whether the 401 bytes are ever written.

## Test plan

- Full `mvn clean install` green (2399 tests).
- Six consecutive venue-suite runs after the shared-client change: 5 clean, 1 hit the pre-existing flake above.
- Leak fix verified by direct thread-count measurement (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)